### PR TITLE
[v0] PostgreSQL Event Store und normalisierte Read Models implementieren

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/risqyy/visualise-ai/backend/internal/health"
 	"github.com/risqyy/visualise-ai/backend/internal/httpapi"
 	"github.com/risqyy/visualise-ai/backend/internal/logging"
+	"github.com/risqyy/visualise-ai/backend/internal/store"
 )
 
 // version is overridden at build time via -ldflags.
@@ -79,8 +80,10 @@ func run() error {
 		serverErr <- nil
 	}()
 
-	// Startup work is complete: only now may the instance report readiness.
-	bootstrap(db, checker, logger)
+	// Startup work must succeed before the instance may report readiness.
+	if err := bootstrap(db, checker, logger); err != nil {
+		return err
+	}
 
 	select {
 	case err := <-serverErr:
@@ -101,8 +104,20 @@ func run() error {
 }
 
 // bootstrap performs the startup work that must succeed before the backend is
-// routed to. Schema migration is added together with the event store.
-func bootstrap(_ *gorm.DB, checker *health.Checker, logger zerolog.Logger) {
+// routed to.
+//
+// The schema is owned by the backend: GORM AutoMigrate is the only migration
+// mechanism in v0. A failing migration returns an error, so the instance never
+// marks itself bootstrapped, /readyz keeps answering 503 and the process exits
+// non-zero instead of serving against an unknown schema.
+func bootstrap(db *gorm.DB, checker *health.Checker, logger zerolog.Logger) error {
+	if err := store.Migrate(db); err != nil {
+		logger.Error().Err(err).Msg("schema migration failed")
+		return err
+	}
+	logger.Info().Msg("schema migrated")
+
 	checker.MarkBootstrapped()
 	logger.Info().Msg("backend is ready")
+	return nil
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gin-gonic/gin v1.12.0
+	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.35.1
 	gorm.io/driver/postgres v1.6.2
 	gorm.io/gorm v1.31.2

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -30,6 +30,8 @@ github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7Lk
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/backend/internal/store/canonical.go
+++ b/backend/internal/store/canonical.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// canonicalJSON re-encodes a JSON document into its canonical form: object keys
+// sorted recursively, no insignificant whitespace, numbers kept verbatim.
+//
+// This is what makes the idempotency check content based rather than byte
+// based. Two retries that serialise the same event with a different key order —
+// which JSON libraries are free to do — must produce the same hash, otherwise a
+// harmless retry would be answered with a spurious conflict.
+//
+// Sorting comes for free: encoding/json marshals map[string]any with sorted
+// keys, and decoding into `any` turns every object into such a map. UseNumber
+// keeps numeric literals as written instead of routing them through float64.
+func canonicalJSON(raw []byte) ([]byte, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, fmt.Errorf("payload is empty")
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+
+	var document any
+	if err := decoder.Decode(&document); err != nil {
+		return nil, err
+	}
+	if decoder.More() {
+		return nil, fmt.Errorf("payload carries trailing JSON data")
+	}
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(document); err != nil {
+		return nil, err
+	}
+	// Encode appends a newline that carries no meaning here.
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// payloadHash is the SHA-256 of the canonical payload, hex encoded.
+func payloadHash(canonical []byte) string {
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/store/canonical_test.go
+++ b/backend/internal/store/canonical_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The idempotency check must survive a retry that serialises the same event
+// with a different object key order, otherwise a harmless retry would be
+// answered with a spurious conflict.
+func TestPayloadHashIsIndependentOfObjectKeyOrder(t *testing.T) {
+	first := []byte(`{
+		"changeId": "change-2026-08-04-0007",
+		"operation": "add",
+		"component": {
+			"componentId": "shop-platform.orders.domain.tax",
+			"name": "Tax Calculation",
+			"kind": "module",
+			"parentComponentId": "shop-platform.orders.domain",
+			"technology": {"language": "Go", "runtime": "Go", "version": "1.24"},
+			"tags": ["pricing", "tax"]
+		}
+	}`)
+	second := []byte(`{"component":{"tags":["pricing","tax"],` +
+		`"technology":{"version":"1.24","runtime":"Go","language":"Go"},` +
+		`"parentComponentId":"shop-platform.orders.domain","kind":"module",` +
+		`"name":"Tax Calculation","componentId":"shop-platform.orders.domain.tax"},` +
+		`"operation":"add","changeId":"change-2026-08-04-0007"}`)
+
+	firstCanonical, err := canonicalJSON(first)
+	if err != nil {
+		t.Fatalf("canonicalising the first document: %v", err)
+	}
+	secondCanonical, err := canonicalJSON(second)
+	if err != nil {
+		t.Fatalf("canonicalising the second document: %v", err)
+	}
+
+	if string(firstCanonical) != string(secondCanonical) {
+		t.Fatalf("canonical forms differ:\n%s\n%s", firstCanonical, secondCanonical)
+	}
+	if payloadHash(firstCanonical) != payloadHash(secondCanonical) {
+		t.Fatal("payload hashes differ although the documents are equal")
+	}
+}
+
+// Array order, in contrast, is content: reordering a list is a different event.
+func TestPayloadHashKeepsArrayOrderSignificant(t *testing.T) {
+	first, err := canonicalJSON([]byte(`{"componentIds":["a","b"]}`))
+	if err != nil {
+		t.Fatalf("canonicalising: %v", err)
+	}
+	second, err := canonicalJSON([]byte(`{"componentIds":["b","a"]}`))
+	if err != nil {
+		t.Fatalf("canonicalising: %v", err)
+	}
+	if payloadHash(first) == payloadHash(second) {
+		t.Fatal("reordering an array must change the payload hash")
+	}
+}
+
+func TestCanonicalJSONStripsWhitespaceAndKeepsNumbers(t *testing.T) {
+	canonical, err := canonicalJSON([]byte("{\n  \"percent\" : 40,\n  \"basis\":\"completed_steps\"\n}"))
+	if err != nil {
+		t.Fatalf("canonicalising: %v", err)
+	}
+	const want = `{"basis":"completed_steps","percent":40}`
+	if string(canonical) != want {
+		t.Fatalf("canonical form = %s, want %s", canonical, want)
+	}
+	if !json.Valid(canonical) {
+		t.Fatal("canonical form is not valid JSON")
+	}
+}
+
+func TestCanonicalJSONRejectsBrokenDocuments(t *testing.T) {
+	cases := map[string]string{
+		"empty":    "",
+		"trailing": `{"a":1} {"b":2}`,
+		"broken":   `{"a":`,
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := canonicalJSON([]byte(payload)); err == nil {
+				t.Fatalf("expected an error for the %s payload", name)
+			}
+		})
+	}
+}

--- a/backend/internal/store/components.go
+++ b/backend/internal/store/components.go
@@ -1,0 +1,139 @@
+package store
+
+import (
+	"sort"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// linkEventComponents writes one event_components row per component the event
+// touches, so component history is served by an index instead of a JSONB scan.
+func linkEventComponents(tx *gorm.DB, ev *Event) error {
+	ids, err := eventComponentIDs(ev.Type, ev.Payload)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		link := &EventComponent{ProjectID: ev.ProjectID, Position: ev.Position, ComponentID: id}
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(link).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// eventComponentIDs collects every component an event refers to, either through
+// a componentIds array or through a reported component or relationship
+// descriptor. Relationships contribute both of their endpoints.
+func eventComponentIDs(evType string, payload []byte) ([]string, error) {
+	switch evType {
+	case TypeWorkStepStarted:
+		var p workStepStartedPayload
+		if err := decodePayload(payload, &p); err != nil {
+			return nil, err
+		}
+		return normaliseIDs(p.ComponentIDs), nil
+
+	case TypeFeedbackPublished:
+		var p feedbackPublishedPayload
+		if err := decodePayload(payload, &p); err != nil {
+			return nil, err
+		}
+		return normaliseIDs(p.ComponentIDs), nil
+
+	case TypeDiffReported:
+		var p diffReportedPayload
+		if err := decodePayload(payload, &p); err != nil {
+			return nil, err
+		}
+		return normaliseIDs(p.ComponentIDs), nil
+
+	case TypeRiskReported:
+		var p riskReportedPayload
+		if err := decodePayload(payload, &p); err != nil {
+			return nil, err
+		}
+		return normaliseIDs(p.ComponentIDs), nil
+
+	case TypeProblemReported:
+		var p problemReportedPayload
+		if err := decodePayload(payload, &p); err != nil {
+			return nil, err
+		}
+		return normaliseIDs(p.ComponentIDs), nil
+
+	case TypePlanPublished:
+		var p planPublishedPayload
+		if err := decodePayload(payload, &p); err != nil {
+			return nil, err
+		}
+		var ids []string
+		for _, step := range p.Steps {
+			ids = append(ids, step.ComponentIDs...)
+		}
+		return normaliseIDs(ids), nil
+
+	case TypeComponentChangePlanned, TypeComponentChangeApplied:
+		component, _, err := decodeComponentChange(payload)
+		if err != nil {
+			return nil, err
+		}
+		return normaliseIDs([]string{component.ComponentID}), nil
+
+	case TypeRelationshipChangePlanned, TypeRelationshipChangeApplied:
+		relationship, _, err := decodeRelationshipChange(payload)
+		if err != nil {
+			return nil, err
+		}
+		return normaliseIDs([]string{relationship.SourceComponentID, relationship.TargetComponentID}), nil
+
+	case TypeArchitectureSnapshotPublished:
+		var p architectureSnapshotPayload
+		if err := decodePayload(payload, &p); err != nil {
+			return nil, err
+		}
+		var ids []string
+		for _, component := range p.Components {
+			ids = append(ids, component.ComponentID)
+		}
+		for _, relationship := range p.Relationships {
+			ids = append(ids, relationship.SourceComponentID, relationship.TargetComponentID)
+		}
+		return normaliseIDs(ids), nil
+
+	case TypeCorrectionIssued:
+		// A correction carries the corrected content, so it touches the same
+		// components as the event it replaces.
+		var p correctionIssuedPayload
+		if err := decodePayload(payload, &p); err != nil {
+			return nil, err
+		}
+		if p.CorrectedType == TypeCorrectionIssued || p.CorrectedType == TypeRetractionIssued {
+			return nil, nil
+		}
+		return eventComponentIDs(p.CorrectedType, p.CorrectedPayload)
+
+	default:
+		return nil, nil
+	}
+}
+
+// normaliseIDs drops empty entries and duplicates and sorts the rest, so the
+// generated rows do not depend on the order the agent reported them in.
+func normaliseIDs(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend/internal/store/jsonb.go
+++ b/backend/internal/store/jsonb.go
@@ -1,0 +1,55 @@
+package store
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// JSON is a `jsonb` column holding one raw JSON document.
+//
+// The store keeps payloads and reported descriptors as JSON instead of
+// exploding them into columns: the contract already fixes their shape, and the
+// cockpit hands them back to the UI unchanged.
+type JSON []byte
+
+// emptyObject and emptyArray are the placeholders for optional JSON documents
+// the agent did not report, so the columns stay NOT NULL.
+var (
+	emptyObject = JSON(`{}`)
+	emptyArray  = JSON(`[]`)
+)
+
+// GormDataType makes GORM create the column as `jsonb`.
+func (JSON) GormDataType() string { return "jsonb" }
+
+// Value implements driver.Valuer.
+func (j JSON) Value() (driver.Value, error) {
+	if len(j) == 0 {
+		return nil, nil
+	}
+	return string(j), nil
+}
+
+// Scan implements sql.Scanner.
+func (j *JSON) Scan(src any) error {
+	switch v := src.(type) {
+	case nil:
+		*j = nil
+	case []byte:
+		*j = append(JSON(nil), v...)
+	case string:
+		*j = JSON(v)
+	default:
+		return fmt.Errorf("store: cannot scan %T into a jsonb column", src)
+	}
+	return nil
+}
+
+// orEmpty returns fallback when raw carries no document, so optional reported
+// objects and arrays never become SQL NULL.
+func orEmpty(raw []byte, fallback JSON) JSON {
+	if len(raw) == 0 {
+		return fallback
+	}
+	return JSON(raw)
+}

--- a/backend/internal/store/migrate.go
+++ b/backend/internal/store/migrate.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// Models lists every table the store owns.
+//
+// The order is the order AutoMigrate creates them in; the schema declares no
+// foreign keys, so read models can be rebuilt or truncated independently of the
+// log without fighting reference constraints.
+func Models() []any {
+	return []any{
+		&Project{},
+		&Run{},
+		&Agent{},
+		&Event{},
+		&EventCorrection{},
+		&EventComponent{},
+		&Plan{},
+		&PlanRevision{},
+		&PlanStep{},
+		&WorkStep{},
+		&WorkStepComponent{},
+		&Component{},
+		&Relationship{},
+		&ActiveChange{},
+		&FeedbackEntry{},
+		&FeedbackComponent{},
+		&Diff{},
+		&DiffComponent{},
+		&Risk{},
+		&RiskComponent{},
+		&Problem{},
+		&ProblemComponent{},
+	}
+}
+
+// Migrate brings the schema in line with the models, including the composite
+// primary keys, the two unique constraints of the event log and every index.
+//
+// v0 deliberately has no SQL migration engine and no rebuild command: GORM
+// AutoMigrate on startup is the single schema authority. A failure here must
+// keep the backend from reporting readiness.
+func Migrate(db *gorm.DB) error {
+	if err := db.AutoMigrate(Models()...); err != nil {
+		return fmt.Errorf("store: automigrate: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/store/models.go
+++ b/backend/internal/store/models.go
@@ -1,0 +1,394 @@
+package store
+
+import (
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// ErrEventLogImmutable is reported when something tries to rewrite the log.
+var ErrEventLogImmutable = errors.New("store: the event log is append-only")
+
+// ---------------------------------------------------------------------------
+// Event log
+// ---------------------------------------------------------------------------
+
+// Event is one entry of a project event log.
+//
+// The two unique indexes carry the invariants of the log: a project position is
+// handed out exactly once, and a clientEventId is accepted exactly once per
+// project. The remaining indexes serve the four reads the cockpit performs —
+// replay, run history, agent history and type history. Component history does
+// not scan the payload; it is served by the EventComponent join table.
+type Event struct {
+	ID            string    `gorm:"column:id;type:uuid;primaryKey"`
+	ProjectID     string    `gorm:"column:project_id;type:text;not null;uniqueIndex:uq_events_project_position,priority:1;uniqueIndex:uq_events_project_client_event_id,priority:1;index:idx_events_project_run_position,priority:1;index:idx_events_project_agent_position,priority:1;index:idx_events_project_type_position,priority:1"`
+	Position      int64     `gorm:"column:position;type:bigint;not null;uniqueIndex:uq_events_project_position,priority:2;index:idx_events_project_run_position,priority:3;index:idx_events_project_agent_position,priority:3;index:idx_events_project_type_position,priority:3"`
+	ClientEventID string    `gorm:"column:client_event_id;type:uuid;not null;uniqueIndex:uq_events_project_client_event_id,priority:2"`
+	RunID         string    `gorm:"column:run_id;type:text;not null;index:idx_events_project_run_position,priority:2"`
+	AgentID       string    `gorm:"column:agent_id;type:text;not null;index:idx_events_project_agent_position,priority:2"`
+	ParentAgentID *string   `gorm:"column:parent_agent_id;type:text"`
+	Type          string    `gorm:"column:type;type:text;not null;index:idx_events_project_type_position,priority:2"`
+	SchemaVersion string    `gorm:"column:schema_version;type:text;not null"`
+	OccurredAt    time.Time `gorm:"column:occurred_at;type:timestamptz;not null"`
+	ReceivedAt    time.Time `gorm:"column:received_at;type:timestamptz;not null"`
+	Payload       JSON      `gorm:"column:payload;type:jsonb;not null"`
+	PayloadHash   string    `gorm:"column:payload_hash;type:text;not null"`
+}
+
+// TableName pins the table name so the schema does not depend on GORM's
+// pluralisation rules.
+func (Event) TableName() string { return "events" }
+
+// BeforeUpdate refuses every update of a stored event. Corrections and
+// retractions are new events referencing the original one.
+func (Event) BeforeUpdate(*gorm.DB) error { return ErrEventLogImmutable }
+
+// BeforeDelete refuses every delete of a stored event.
+func (Event) BeforeDelete(*gorm.DB) error { return ErrEventLogImmutable }
+
+// EventCorrection links a correction or retraction event to the event it
+// refers to. The original event itself stays untouched.
+//
+// The position column is the position of the correcting event, so it doubles as
+// this row's applied position; a separate last_applied_project_position would
+// only repeat it.
+type EventCorrection struct {
+	ProjectID           string  `gorm:"column:project_id;type:text;primaryKey;index:idx_event_corrections_target,priority:1"`
+	Position            int64   `gorm:"column:position;type:bigint;primaryKey"`
+	Kind                string  `gorm:"column:kind;type:text;not null;default:''"`
+	TargetClientEventID string  `gorm:"column:target_client_event_id;type:uuid;not null;index:idx_event_corrections_target,priority:2"`
+	Reason              string  `gorm:"column:reason;type:text;not null;default:''"`
+	CorrectedType       *string `gorm:"column:corrected_type;type:text"`
+}
+
+// TableName pins the table name.
+func (EventCorrection) TableName() string { return "event_corrections" }
+
+// EventComponent links an event to every component it touches, so component
+// history is an index lookup instead of a JSONB scan.
+//
+// As for EventCorrection, the position column already is the applied position.
+type EventComponent struct {
+	ProjectID   string `gorm:"column:project_id;type:text;primaryKey;index:idx_event_components_component_position,priority:1"`
+	Position    int64  `gorm:"column:position;type:bigint;primaryKey;index:idx_event_components_component_position,priority:3"`
+	ComponentID string `gorm:"column:component_id;type:text;primaryKey;index:idx_event_components_component_position,priority:2"`
+}
+
+// TableName pins the table name.
+func (EventComponent) TableName() string { return "event_components" }
+
+// ---------------------------------------------------------------------------
+// Read models
+// ---------------------------------------------------------------------------
+
+// Project is the head of one project event log.
+//
+// It is also the serialisation point of position assignment: every append locks
+// this row before it reads LastPosition.
+type Project struct {
+	ProjectID                  string    `gorm:"column:project_id;type:text;primaryKey"`
+	FirstSeenAt                time.Time `gorm:"column:first_seen_at;type:timestamptz;not null"`
+	LastEventAt                time.Time `gorm:"column:last_event_at;type:timestamptz;not null"`
+	LastPosition               int64     `gorm:"column:last_position;type:bigint;not null;default:0"`
+	CurrentRunID               string    `gorm:"column:current_run_id;type:text;not null;default:''"`
+	LastAppliedProjectPosition int64     `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (Project) TableName() string { return "projects" }
+
+// Run is one orchestrated session inside a project.
+//
+// A run stays open until an explicit run.finished event closes it; silence is
+// never interpreted as a terminal state.
+type Run struct {
+	ProjectID                  string     `gorm:"column:project_id;type:text;primaryKey"`
+	RunID                      string     `gorm:"column:run_id;type:text;primaryKey"`
+	RootAgentID                string     `gorm:"column:root_agent_id;type:text;not null;default:''"`
+	StartedAt                  time.Time  `gorm:"column:started_at;type:timestamptz;not null"`
+	FinishedAt                 *time.Time `gorm:"column:finished_at;type:timestamptz"`
+	Outcome                    *string    `gorm:"column:outcome;type:text"`
+	IsOpen                     bool       `gorm:"column:is_open;not null;default:true"`
+	LastAppliedProjectPosition int64      `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (Run) TableName() string { return "runs" }
+
+// Agent is one node of the agent tree of a run. The tree is expressed through
+// ParentAgentID; a root orchestrator has none.
+//
+// Status, progress and the finished outcome are kept apart on purpose: each is
+// written only by the event that explicitly reports it.
+type Agent struct {
+	ProjectID                  string    `gorm:"column:project_id;type:text;primaryKey;index:idx_agents_parent,priority:1"`
+	RunID                      string    `gorm:"column:run_id;type:text;primaryKey;index:idx_agents_parent,priority:2"`
+	AgentID                    string    `gorm:"column:agent_id;type:text;primaryKey"`
+	ParentAgentID              *string   `gorm:"column:parent_agent_id;type:text;index:idx_agents_parent,priority:3"`
+	Role                       string    `gorm:"column:role;type:text;not null;default:''"`
+	DisplayName                string    `gorm:"column:display_name;type:text;not null;default:''"`
+	AssignedTask               string    `gorm:"column:assigned_task;type:text;not null;default:''"`
+	Status                     string    `gorm:"column:status;type:text;not null;default:''"`
+	StatusNote                 string    `gorm:"column:status_note;type:text;not null;default:''"`
+	ProgressPercent            *int      `gorm:"column:progress_percent;type:int"`
+	ProgressScope              *string   `gorm:"column:progress_scope;type:text"`
+	ProgressBasis              *string   `gorm:"column:progress_basis;type:text"`
+	FinishedOutcome            *string   `gorm:"column:finished_outcome;type:text"`
+	StartedAt                  time.Time `gorm:"column:started_at;type:timestamptz;not null"`
+	LastEventAt                time.Time `gorm:"column:last_event_at;type:timestamptz;not null"`
+	LastAppliedProjectPosition int64     `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (Agent) TableName() string { return "agents" }
+
+// Plan points at the revision of a plan that is currently displayed.
+type Plan struct {
+	ProjectID                  string `gorm:"column:project_id;type:text;primaryKey"`
+	RunID                      string `gorm:"column:run_id;type:text;primaryKey"`
+	PlanID                     string `gorm:"column:plan_id;type:text;primaryKey"`
+	AgentID                    string `gorm:"column:agent_id;type:text;not null;default:''"`
+	CurrentRevision            int    `gorm:"column:current_revision;type:int;not null;default:0"`
+	LastAppliedProjectPosition int64  `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (Plan) TableName() string { return "plans" }
+
+// PlanRevision is one published revision of a plan. Revisions are append-only:
+// publishing a new revision never rewrites an earlier one.
+type PlanRevision struct {
+	ProjectID                  string    `gorm:"column:project_id;type:text;primaryKey"`
+	PlanID                     string    `gorm:"column:plan_id;type:text;primaryKey"`
+	Revision                   int       `gorm:"column:revision;type:int;primaryKey"`
+	CreatedAt                  time.Time `gorm:"column:created_at;type:timestamptz;not null"`
+	CreatedByAgentID           string    `gorm:"column:created_by_agent_id;type:text;not null;default:''"`
+	LastAppliedProjectPosition int64     `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (PlanRevision) TableName() string { return "plan_revisions" }
+
+// PlanStep is one step of one plan revision. Only its state changes after
+// publication, through plan.step_updated on the current revision.
+type PlanStep struct {
+	ProjectID                  string `gorm:"column:project_id;type:text;primaryKey"`
+	PlanID                     string `gorm:"column:plan_id;type:text;primaryKey"`
+	Revision                   int    `gorm:"column:revision;type:int;primaryKey"`
+	StepID                     string `gorm:"column:step_id;type:text;primaryKey"`
+	StepOrder                  int    `gorm:"column:step_order;type:int;not null;default:0"`
+	Title                      string `gorm:"column:title;type:text;not null;default:''"`
+	State                      string `gorm:"column:state;type:text;not null;default:''"`
+	LastAppliedProjectPosition int64  `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (PlanStep) TableName() string { return "plan_steps" }
+
+// WorkStep is a concrete unit of work an agent reported.
+type WorkStep struct {
+	ProjectID                  string     `gorm:"column:project_id;type:text;primaryKey"`
+	RunID                      string     `gorm:"column:run_id;type:text;primaryKey"`
+	WorkStepID                 string     `gorm:"column:work_step_id;type:text;primaryKey"`
+	AgentID                    string     `gorm:"column:agent_id;type:text;not null;default:''"`
+	PlanStepID                 *string    `gorm:"column:plan_step_id;type:text"`
+	Title                      string     `gorm:"column:title;type:text;not null;default:''"`
+	StartedAt                  time.Time  `gorm:"column:started_at;type:timestamptz;not null"`
+	CompletedAt                *time.Time `gorm:"column:completed_at;type:timestamptz"`
+	Summary                    *string    `gorm:"column:summary;type:text"`
+	LastAppliedProjectPosition int64      `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (WorkStep) TableName() string { return "work_steps" }
+
+// Component is one node of the *applied* architecture model. Planned changes
+// never reach this table.
+type Component struct {
+	ProjectID                  string    `gorm:"column:project_id;type:text;primaryKey;index:idx_components_parent,priority:1"`
+	ComponentID                string    `gorm:"column:component_id;type:text;primaryKey"`
+	Name                       string    `gorm:"column:name;type:text;not null;default:''"`
+	Kind                       string    `gorm:"column:kind;type:text;not null;default:''"`
+	ParentComponentID          *string   `gorm:"column:parent_component_id;type:text;index:idx_components_parent,priority:2"`
+	Description                string    `gorm:"column:description;type:text;not null;default:''"`
+	Technology                 JSON      `gorm:"column:technology;type:jsonb;not null"`
+	Tags                       JSON      `gorm:"column:tags;type:jsonb;not null"`
+	AppliedAt                  time.Time `gorm:"column:applied_at;type:timestamptz;not null"`
+	AppliedByAgentID           string    `gorm:"column:applied_by_agent_id;type:text;not null;default:''"`
+	AppliedRunID               string    `gorm:"column:applied_run_id;type:text;not null;default:''"`
+	LastAppliedProjectPosition int64     `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (Component) TableName() string { return "components" }
+
+// Relationship is one typed, directed edge of the applied architecture model.
+// Every message topic keeps its own row; edges are never aggregated.
+type Relationship struct {
+	ProjectID                  string    `gorm:"column:project_id;type:text;primaryKey;index:idx_relationships_source,priority:1;index:idx_relationships_target,priority:1"`
+	RelationshipID             string    `gorm:"column:relationship_id;type:text;primaryKey"`
+	SourceComponentID          string    `gorm:"column:source_component_id;type:text;not null;default:'';index:idx_relationships_source,priority:2"`
+	TargetComponentID          string    `gorm:"column:target_component_id;type:text;not null;default:'';index:idx_relationships_target,priority:2"`
+	Kind                       string    `gorm:"column:kind;type:text;not null;default:''"`
+	Label                      string    `gorm:"column:label;type:text;not null;default:''"`
+	Protocol                   string    `gorm:"column:protocol;type:text;not null;default:''"`
+	Operation                  string    `gorm:"column:operation;type:text;not null;default:''"`
+	Channel                    string    `gorm:"column:channel;type:text;not null;default:''"`
+	AppliedAt                  time.Time `gorm:"column:applied_at;type:timestamptz;not null"`
+	AppliedByAgentID           string    `gorm:"column:applied_by_agent_id;type:text;not null;default:''"`
+	AppliedRunID               string    `gorm:"column:applied_run_id;type:text;not null;default:''"`
+	LastAppliedProjectPosition int64     `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (Relationship) TableName() string { return "relationships" }
+
+// ActiveChange is a reported change to the architecture model together with the
+// state it is in: planned, applied or retracted.
+type ActiveChange struct {
+	ProjectID                  string     `gorm:"column:project_id;type:text;primaryKey;index:idx_active_changes_target,priority:1"`
+	ChangeID                   string     `gorm:"column:change_id;type:text;primaryKey"`
+	TargetKind                 string     `gorm:"column:target_kind;type:text;not null;default:'';index:idx_active_changes_target,priority:2"`
+	TargetID                   string     `gorm:"column:target_id;type:text;not null;default:'';index:idx_active_changes_target,priority:3"`
+	Operation                  string     `gorm:"column:operation;type:text;not null;default:''"`
+	State                      string     `gorm:"column:state;type:text;not null;default:''"`
+	RunID                      string     `gorm:"column:run_id;type:text;not null;default:''"`
+	AgentID                    string     `gorm:"column:agent_id;type:text;not null;default:''"`
+	PlannedAt                  *time.Time `gorm:"column:planned_at;type:timestamptz"`
+	AppliedAt                  *time.Time `gorm:"column:applied_at;type:timestamptz"`
+	RetractedAt                *time.Time `gorm:"column:retracted_at;type:timestamptz"`
+	Snapshot                   JSON       `gorm:"column:snapshot;type:jsonb;not null"`
+	LastAppliedProjectPosition int64      `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (ActiveChange) TableName() string { return "active_changes" }
+
+// FeedbackEntry is one published, component-scoped feedback item.
+type FeedbackEntry struct {
+	ProjectID                  string    `gorm:"column:project_id;type:text;primaryKey"`
+	FeedbackID                 string    `gorm:"column:feedback_id;type:text;primaryKey"`
+	RunID                      string    `gorm:"column:run_id;type:text;not null;default:''"`
+	AgentID                    string    `gorm:"column:agent_id;type:text;not null;default:''"`
+	Format                     string    `gorm:"column:format;type:text;not null;default:''"`
+	Title                      string    `gorm:"column:title;type:text;not null;default:''"`
+	Body                       string    `gorm:"column:body;type:text;not null;default:''"`
+	CreatedAt                  time.Time `gorm:"column:created_at;type:timestamptz;not null"`
+	SourcePosition             int64     `gorm:"column:source_position;type:bigint;not null;default:0"`
+	LastAppliedProjectPosition int64     `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (FeedbackEntry) TableName() string { return "feedback_entries" }
+
+// Diff is one reported unified diff of exactly one repository file.
+type Diff struct {
+	ProjectID                  string    `gorm:"column:project_id;type:text;primaryKey"`
+	DiffID                     string    `gorm:"column:diff_id;type:text;primaryKey"`
+	RunID                      string    `gorm:"column:run_id;type:text;not null;default:''"`
+	AgentID                    string    `gorm:"column:agent_id;type:text;not null;default:''"`
+	ChangeID                   *string   `gorm:"column:change_id;type:text"`
+	FilePath                   string    `gorm:"column:file_path;type:text;not null;default:''"`
+	UnifiedDiff                string    `gorm:"column:unified_diff;type:text;not null;default:''"`
+	CreatedAt                  time.Time `gorm:"column:created_at;type:timestamptz;not null"`
+	SourcePosition             int64     `gorm:"column:source_position;type:bigint;not null;default:0"`
+	LastAppliedProjectPosition int64     `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (Diff) TableName() string { return "diffs" }
+
+// Risk is a risk as stated by the reporting agent. The system never derives,
+// scores or aggregates risks on its own.
+type Risk struct {
+	ProjectID                  string    `gorm:"column:project_id;type:text;primaryKey"`
+	RiskID                     string    `gorm:"column:risk_id;type:text;primaryKey"`
+	RunID                      string    `gorm:"column:run_id;type:text;not null;default:''"`
+	AgentID                    string    `gorm:"column:agent_id;type:text;not null;default:''"`
+	Title                      string    `gorm:"column:title;type:text;not null;default:''"`
+	Detail                     string    `gorm:"column:detail;type:text;not null;default:''"`
+	Severity                   string    `gorm:"column:severity;type:text;not null;default:''"`
+	CreatedAt                  time.Time `gorm:"column:created_at;type:timestamptz;not null"`
+	SourcePosition             int64     `gorm:"column:source_position;type:bigint;not null;default:0"`
+	LastAppliedProjectPosition int64     `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (Risk) TableName() string { return "risks" }
+
+// Problem is a problem as stated by the reporting agent.
+type Problem struct {
+	ProjectID                  string    `gorm:"column:project_id;type:text;primaryKey"`
+	ProblemID                  string    `gorm:"column:problem_id;type:text;primaryKey"`
+	RunID                      string    `gorm:"column:run_id;type:text;not null;default:''"`
+	AgentID                    string    `gorm:"column:agent_id;type:text;not null;default:''"`
+	Title                      string    `gorm:"column:title;type:text;not null;default:''"`
+	Detail                     string    `gorm:"column:detail;type:text;not null;default:''"`
+	CreatedAt                  time.Time `gorm:"column:created_at;type:timestamptz;not null"`
+	SourcePosition             int64     `gorm:"column:source_position;type:bigint;not null;default:0"`
+	LastAppliedProjectPosition int64     `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (Problem) TableName() string { return "problems" }
+
+// ---------------------------------------------------------------------------
+// Component join tables
+// ---------------------------------------------------------------------------
+
+// FeedbackComponent links a feedback entry to one component.
+type FeedbackComponent struct {
+	ProjectID                  string `gorm:"column:project_id;type:text;primaryKey;index:idx_feedback_components_component,priority:1"`
+	FeedbackID                 string `gorm:"column:feedback_id;type:text;primaryKey"`
+	ComponentID                string `gorm:"column:component_id;type:text;primaryKey;index:idx_feedback_components_component,priority:2"`
+	LastAppliedProjectPosition int64  `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (FeedbackComponent) TableName() string { return "feedback_components" }
+
+// DiffComponent links a diff to one component.
+type DiffComponent struct {
+	ProjectID                  string `gorm:"column:project_id;type:text;primaryKey;index:idx_diff_components_component,priority:1"`
+	DiffID                     string `gorm:"column:diff_id;type:text;primaryKey"`
+	ComponentID                string `gorm:"column:component_id;type:text;primaryKey;index:idx_diff_components_component,priority:2"`
+	LastAppliedProjectPosition int64  `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (DiffComponent) TableName() string { return "diff_components" }
+
+// RiskComponent links a risk to one component.
+type RiskComponent struct {
+	ProjectID                  string `gorm:"column:project_id;type:text;primaryKey;index:idx_risk_components_component,priority:1"`
+	RiskID                     string `gorm:"column:risk_id;type:text;primaryKey"`
+	ComponentID                string `gorm:"column:component_id;type:text;primaryKey;index:idx_risk_components_component,priority:2"`
+	LastAppliedProjectPosition int64  `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (RiskComponent) TableName() string { return "risk_components" }
+
+// ProblemComponent links a problem to one component.
+type ProblemComponent struct {
+	ProjectID                  string `gorm:"column:project_id;type:text;primaryKey;index:idx_problem_components_component,priority:1"`
+	ProblemID                  string `gorm:"column:problem_id;type:text;primaryKey"`
+	ComponentID                string `gorm:"column:component_id;type:text;primaryKey;index:idx_problem_components_component,priority:2"`
+	LastAppliedProjectPosition int64  `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (ProblemComponent) TableName() string { return "problem_components" }
+
+// WorkStepComponent links a work step to one component.
+type WorkStepComponent struct {
+	ProjectID                  string `gorm:"column:project_id;type:text;primaryKey;index:idx_work_step_components_component,priority:1"`
+	WorkStepID                 string `gorm:"column:work_step_id;type:text;primaryKey"`
+	ComponentID                string `gorm:"column:component_id;type:text;primaryKey;index:idx_work_step_components_component,priority:2"`
+	LastAppliedProjectPosition int64  `gorm:"column:last_applied_project_position;type:bigint;not null;default:0"`
+}
+
+// TableName pins the table name.
+func (WorkStepComponent) TableName() string { return "work_step_components" }

--- a/backend/internal/store/payloads.go
+++ b/backend/internal/store/payloads.go
@@ -1,0 +1,248 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// The closed v0 event catalogue. The contract in api/openapi.yaml is the
+// authority; the store must be able to project every one of these types.
+const (
+	TypeAgentStarted                  = "agent.started"
+	TypeAgentStatusReported           = "agent.status_reported"
+	TypeAgentProgressReported         = "agent.progress_reported"
+	TypeAgentFinished                 = "agent.finished"
+	TypePlanPublished                 = "plan.published"
+	TypePlanStepUpdated               = "plan.step_updated"
+	TypeWorkStepStarted               = "work.step_started"
+	TypeWorkStepCompleted             = "work.step_completed"
+	TypeFeedbackPublished             = "feedback.published"
+	TypeArchitectureSnapshotPublished = "architecture.snapshot_published"
+	TypeComponentChangePlanned        = "component.change_planned"
+	TypeComponentChangeApplied        = "component.change_applied"
+	TypeRelationshipChangePlanned     = "relationship.change_planned"
+	TypeRelationshipChangeApplied     = "relationship.change_applied"
+	TypeDiffReported                  = "diff.reported"
+	TypeRiskReported                  = "risk.reported"
+	TypeProblemReported               = "problem.reported"
+	TypeCorrectionIssued              = "correction.issued"
+	TypeRetractionIssued              = "retraction.issued"
+	TypeRunFinished                   = "run.finished"
+)
+
+// Values of the change lifecycle kept in ActiveChange.
+const (
+	ChangeStatePlanned   = "planned"
+	ChangeStateApplied   = "applied"
+	ChangeStateRetracted = "retracted"
+
+	ChangeTargetComponent    = "component"
+	ChangeTargetRelationship = "relationship"
+
+	OperationAdd    = "add"
+	OperationModify = "modify"
+	OperationRemove = "remove"
+)
+
+// Kinds stored in EventCorrection.
+const (
+	CorrectionKindCorrection = "correction"
+	CorrectionKindRetraction = "retraction"
+)
+
+// roleOrchestrator marks the agent that owns a run.
+const roleOrchestrator = "orchestrator"
+
+// EventTypes lists the closed v0 catalogue in contract order.
+func EventTypes() []string {
+	return []string{
+		TypeAgentStarted,
+		TypeAgentStatusReported,
+		TypeAgentProgressReported,
+		TypeAgentFinished,
+		TypePlanPublished,
+		TypePlanStepUpdated,
+		TypeWorkStepStarted,
+		TypeWorkStepCompleted,
+		TypeFeedbackPublished,
+		TypeArchitectureSnapshotPublished,
+		TypeComponentChangePlanned,
+		TypeComponentChangeApplied,
+		TypeRelationshipChangePlanned,
+		TypeRelationshipChangeApplied,
+		TypeDiffReported,
+		TypeRiskReported,
+		TypeProblemReported,
+		TypeCorrectionIssued,
+		TypeRetractionIssued,
+		TypeRunFinished,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Payload shapes
+//
+// These mirror the payload schemas of the contract. Validating them is the job
+// of the ingestion layer; the store only needs to read the fields it projects.
+// ---------------------------------------------------------------------------
+
+type componentDescriptor struct {
+	ComponentID       string          `json:"componentId"`
+	Name              string          `json:"name"`
+	Kind              string          `json:"kind"`
+	ParentComponentID *string         `json:"parentComponentId"`
+	Description       string          `json:"description"`
+	Technology        json.RawMessage `json:"technology"`
+	Tags              json.RawMessage `json:"tags"`
+}
+
+type relationshipDescriptor struct {
+	RelationshipID    string `json:"relationshipId"`
+	SourceComponentID string `json:"sourceComponentId"`
+	TargetComponentID string `json:"targetComponentId"`
+	Kind              string `json:"kind"`
+	Label             string `json:"label"`
+	Protocol          string `json:"protocol"`
+	Operation         string `json:"operation"`
+	Channel           string `json:"channel"`
+}
+
+type planStepDescriptor struct {
+	StepID       string   `json:"stepId"`
+	Order        int      `json:"order"`
+	Title        string   `json:"title"`
+	State        string   `json:"state"`
+	ComponentIDs []string `json:"componentIds"`
+}
+
+type agentStartedPayload struct {
+	Role         string   `json:"role"`
+	DisplayName  string   `json:"displayName"`
+	AssignedTask string   `json:"assignedTask"`
+	Capabilities []string `json:"capabilities"`
+}
+
+type agentStatusReportedPayload struct {
+	Status string `json:"status"`
+	Note   string `json:"note"`
+}
+
+type agentProgressReportedPayload struct {
+	Percent int    `json:"percent"`
+	Scope   string `json:"scope"`
+	Basis   string `json:"basis"`
+	Note    string `json:"note"`
+}
+
+type agentFinishedPayload struct {
+	Outcome string `json:"outcome"`
+	Summary string `json:"summary"`
+}
+
+type planPublishedPayload struct {
+	PlanID   string               `json:"planId"`
+	Revision int                  `json:"revision"`
+	Steps    []planStepDescriptor `json:"steps"`
+}
+
+type planStepUpdatedPayload struct {
+	PlanID string `json:"planId"`
+	StepID string `json:"stepId"`
+	State  string `json:"state"`
+	Note   string `json:"note"`
+}
+
+type workStepStartedPayload struct {
+	WorkStepID   string   `json:"workStepId"`
+	Title        string   `json:"title"`
+	ComponentIDs []string `json:"componentIds"`
+	PlanStepID   *string  `json:"planStepId"`
+}
+
+type workStepCompletedPayload struct {
+	WorkStepID string `json:"workStepId"`
+	Summary    string `json:"summary"`
+}
+
+type feedbackPublishedPayload struct {
+	FeedbackID   string   `json:"feedbackId"`
+	ComponentIDs []string `json:"componentIds"`
+	Format       string   `json:"format"`
+	Body         string   `json:"body"`
+	Title        string   `json:"title"`
+}
+
+type architectureSnapshotPayload struct {
+	SnapshotID    string                   `json:"snapshotId"`
+	Components    []componentDescriptor    `json:"components"`
+	Relationships []relationshipDescriptor `json:"relationships"`
+}
+
+// componentChangePayload covers both component.change_planned and
+// component.change_applied: only the planned variant carries a rationale, and
+// only the applied variant may omit changeId. The descriptor stays raw so the
+// reported document can be stored verbatim in active_changes.snapshot.
+type componentChangePayload struct {
+	ChangeID  *string         `json:"changeId"`
+	Operation string          `json:"operation"`
+	Component json.RawMessage `json:"component"`
+	Rationale string          `json:"rationale"`
+}
+
+type relationshipChangePayload struct {
+	ChangeID     *string         `json:"changeId"`
+	Operation    string          `json:"operation"`
+	Relationship json.RawMessage `json:"relationship"`
+	Rationale    string          `json:"rationale"`
+}
+
+type diffReportedPayload struct {
+	DiffID       string   `json:"diffId"`
+	ChangeID     *string  `json:"changeId"`
+	ComponentIDs []string `json:"componentIds"`
+	FilePath     string   `json:"filePath"`
+	UnifiedDiff  string   `json:"unifiedDiff"`
+}
+
+type riskReportedPayload struct {
+	RiskID       string   `json:"riskId"`
+	ComponentIDs []string `json:"componentIds"`
+	Title        string   `json:"title"`
+	Detail       string   `json:"detail"`
+	Severity     string   `json:"severity"`
+}
+
+type problemReportedPayload struct {
+	ProblemID    string   `json:"problemId"`
+	ComponentIDs []string `json:"componentIds"`
+	Title        string   `json:"title"`
+	Detail       string   `json:"detail"`
+}
+
+type correctionIssuedPayload struct {
+	CorrectsClientEventID string          `json:"correctsClientEventId"`
+	Reason                string          `json:"reason"`
+	CorrectedType         string          `json:"correctedType"`
+	CorrectedPayload      json.RawMessage `json:"correctedPayload"`
+}
+
+type retractionIssuedPayload struct {
+	RetractsClientEventID string `json:"retractsClientEventId"`
+	Reason                string `json:"reason"`
+}
+
+type runFinishedPayload struct {
+	Outcome string `json:"outcome"`
+	Summary string `json:"summary"`
+}
+
+// decodePayload reads one payload document into target.
+func decodePayload(raw []byte, target any) error {
+	if len(raw) == 0 {
+		return fmt.Errorf("store: empty payload for %T", target)
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return fmt.Errorf("store: decoding payload into %T: %w", target, err)
+	}
+	return nil
+}

--- a/backend/internal/store/projector.go
+++ b/backend/internal/store/projector.go
@@ -1,0 +1,936 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Projector advances the normalised read models for one appended event.
+//
+// It is deliberately total over the closed v0 catalogue: an unknown type is an
+// error rather than a silent no-op, so a catalogue extension cannot slip
+// through unprojected.
+type Projector struct{}
+
+// NewProjector returns the projector used by a Store.
+func NewProjector() *Projector { return &Projector{} }
+
+// maxCorrectionDepth bounds correction handling. A correction restates the
+// content of one earlier event; a correction of a correction is not projected
+// further, it is only recorded in event_corrections.
+const maxCorrectionDepth = 1
+
+// Apply projects one event. It runs inside the append transaction, so any error
+// rolls back the event together with every projection it had already written.
+func (p *Projector) Apply(tx *gorm.DB, ev *Event) error {
+	if err := advanceProject(tx, ev); err != nil {
+		return err
+	}
+	if err := ensureRun(tx, ev); err != nil {
+		return err
+	}
+	if err := touchAgent(tx, ev); err != nil {
+		return err
+	}
+	return p.applyPayload(tx, ev, ev.Type, ev.Payload, 0)
+}
+
+func (p *Projector) applyPayload(tx *gorm.DB, ev *Event, evType string, payload []byte, depth int) error {
+	switch evType {
+	case TypeAgentStarted:
+		return applyAgentStarted(tx, ev, payload)
+	case TypeAgentStatusReported:
+		return applyAgentStatusReported(tx, ev, payload)
+	case TypeAgentProgressReported:
+		return applyAgentProgressReported(tx, ev, payload)
+	case TypeAgentFinished:
+		return applyAgentFinished(tx, ev, payload)
+	case TypePlanPublished:
+		return applyPlanPublished(tx, ev, payload)
+	case TypePlanStepUpdated:
+		return applyPlanStepUpdated(tx, ev, payload)
+	case TypeWorkStepStarted:
+		return applyWorkStepStarted(tx, ev, payload)
+	case TypeWorkStepCompleted:
+		return applyWorkStepCompleted(tx, ev, payload)
+	case TypeFeedbackPublished:
+		return applyFeedbackPublished(tx, ev, payload)
+	case TypeArchitectureSnapshotPublished:
+		return applyArchitectureSnapshot(tx, ev, payload)
+	case TypeComponentChangePlanned:
+		return applyComponentChangePlanned(tx, ev, payload)
+	case TypeComponentChangeApplied:
+		return applyComponentChangeApplied(tx, ev, payload)
+	case TypeRelationshipChangePlanned:
+		return applyRelationshipChangePlanned(tx, ev, payload)
+	case TypeRelationshipChangeApplied:
+		return applyRelationshipChangeApplied(tx, ev, payload)
+	case TypeDiffReported:
+		return applyDiffReported(tx, ev, payload)
+	case TypeRiskReported:
+		return applyRiskReported(tx, ev, payload)
+	case TypeProblemReported:
+		return applyProblemReported(tx, ev, payload)
+	case TypeCorrectionIssued:
+		return p.applyCorrectionIssued(tx, ev, payload, depth)
+	case TypeRetractionIssued:
+		return applyRetractionIssued(tx, ev, payload, depth)
+	case TypeRunFinished:
+		return applyRunFinished(tx, ev, payload)
+	default:
+		return fmt.Errorf("store: no projection for event type %q", evType)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared projections
+// ---------------------------------------------------------------------------
+
+// advanceProject moves the project head to the committed event.
+func advanceProject(tx *gorm.DB, ev *Event) error {
+	return tx.Model(&Project{}).
+		Where("project_id = ?", ev.ProjectID).
+		Updates(map[string]any{
+			"last_event_at":                 ev.OccurredAt,
+			"last_position":                 ev.Position,
+			"last_applied_project_position": ev.Position,
+		}).Error
+}
+
+// ensureRun records that the run exists. A run is open from the moment it is
+// first seen and stays open until an explicit run.finished closes it — silence
+// never produces a terminal state.
+func ensureRun(tx *gorm.DB, ev *Event) error {
+	run := &Run{
+		ProjectID:                  ev.ProjectID,
+		RunID:                      ev.RunID,
+		StartedAt:                  ev.OccurredAt,
+		IsOpen:                     true,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	return upsert(tx, run, runKey, []string{"last_applied_project_position"})
+}
+
+// touchAgent records activity of the reporting agent, but never invents a row:
+// an agent exists once it has reported agent.started.
+func touchAgent(tx *gorm.DB, ev *Event) error {
+	return tx.Model(&Agent{}).
+		Where("project_id = ? AND run_id = ? AND agent_id = ?", ev.ProjectID, ev.RunID, ev.AgentID).
+		Updates(map[string]any{
+			"last_event_at":                 ev.OccurredAt,
+			"last_applied_project_position": ev.Position,
+		}).Error
+}
+
+// ---------------------------------------------------------------------------
+// Agent projections
+// ---------------------------------------------------------------------------
+
+func applyAgentStarted(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p agentStartedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	agent := &Agent{
+		ProjectID:                  ev.ProjectID,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		ParentAgentID:              ev.ParentAgentID,
+		Role:                       p.Role,
+		DisplayName:                p.DisplayName,
+		AssignedTask:               p.AssignedTask,
+		StartedAt:                  ev.OccurredAt,
+		LastEventAt:                ev.OccurredAt,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	// status, progress and outcome are left untouched: they are only ever
+	// written by the event that explicitly reports them.
+	if err := upsert(tx, agent, agentKey, []string{
+		"parent_agent_id", "role", "display_name", "assigned_task",
+		"started_at", "last_event_at", "last_applied_project_position",
+	}); err != nil {
+		return err
+	}
+
+	if p.Role != roleOrchestrator || ev.ParentAgentID != nil {
+		return nil
+	}
+	// A root orchestrator opens the run and becomes the project's current run.
+	if err := tx.Model(&Run{}).
+		Where("project_id = ? AND run_id = ?", ev.ProjectID, ev.RunID).
+		Updates(map[string]any{
+			"root_agent_id":                 ev.AgentID,
+			"started_at":                    ev.OccurredAt,
+			"last_applied_project_position": ev.Position,
+		}).Error; err != nil {
+		return err
+	}
+	return tx.Model(&Project{}).
+		Where("project_id = ?", ev.ProjectID).
+		Update("current_run_id", ev.RunID).Error
+}
+
+func applyAgentStatusReported(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p agentStatusReportedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+	agent := &Agent{
+		ProjectID:                  ev.ProjectID,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		ParentAgentID:              ev.ParentAgentID,
+		Status:                     p.Status,
+		StatusNote:                 p.Note,
+		StartedAt:                  ev.OccurredAt,
+		LastEventAt:                ev.OccurredAt,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	return upsert(tx, agent, agentKey, []string{
+		"status", "status_note", "last_event_at", "last_applied_project_position",
+	})
+}
+
+func applyAgentProgressReported(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p agentProgressReportedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+	percent := p.Percent
+	agent := &Agent{
+		ProjectID:                  ev.ProjectID,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		ParentAgentID:              ev.ParentAgentID,
+		ProgressPercent:            &percent,
+		ProgressScope:              nonEmpty(p.Scope),
+		ProgressBasis:              nonEmpty(p.Basis),
+		StartedAt:                  ev.OccurredAt,
+		LastEventAt:                ev.OccurredAt,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	return upsert(tx, agent, agentKey, []string{
+		"progress_percent", "progress_scope", "progress_basis",
+		"last_event_at", "last_applied_project_position",
+	})
+}
+
+func applyAgentFinished(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p agentFinishedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+	agent := &Agent{
+		ProjectID:                  ev.ProjectID,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		ParentAgentID:              ev.ParentAgentID,
+		FinishedOutcome:            nonEmpty(p.Outcome),
+		StartedAt:                  ev.OccurredAt,
+		LastEventAt:                ev.OccurredAt,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	// An agent finishing does not finish its run, and it does not overwrite the
+	// last explicitly reported status either.
+	return upsert(tx, agent, agentKey, []string{
+		"finished_outcome", "last_event_at", "last_applied_project_position",
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Plan projections
+// ---------------------------------------------------------------------------
+
+func applyPlanPublished(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p planPublishedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	plan := &Plan{
+		ProjectID:                  ev.ProjectID,
+		RunID:                      ev.RunID,
+		PlanID:                     p.PlanID,
+		AgentID:                    ev.AgentID,
+		CurrentRevision:            p.Revision,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	if err := upsert(tx, plan, planKey, []string{
+		"agent_id", "current_revision", "last_applied_project_position",
+	}); err != nil {
+		return err
+	}
+
+	// Revisions are append-only: an already published revision and its steps
+	// are never rewritten, they stay inspectable exactly as reported.
+	revision := &PlanRevision{
+		ProjectID:                  ev.ProjectID,
+		PlanID:                     p.PlanID,
+		Revision:                   p.Revision,
+		CreatedAt:                  ev.OccurredAt,
+		CreatedByAgentID:           ev.AgentID,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(revision).Error; err != nil {
+		return err
+	}
+
+	for _, step := range p.Steps {
+		row := &PlanStep{
+			ProjectID:                  ev.ProjectID,
+			PlanID:                     p.PlanID,
+			Revision:                   p.Revision,
+			StepID:                     step.StepID,
+			StepOrder:                  step.Order,
+			Title:                      step.Title,
+			State:                      step.State,
+			LastAppliedProjectPosition: ev.Position,
+		}
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(row).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyPlanStepUpdated(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p planStepUpdatedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	var plan Plan
+	err := tx.Where("project_id = ? AND run_id = ? AND plan_id = ?", ev.ProjectID, ev.RunID, p.PlanID).
+		Take(&plan).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		// No revision has been published yet, so there is no step to update.
+		// The ingestion layer rejects this case; the store stays a no-op.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// The update targets the currently published revision only — earlier
+	// revisions keep the state they were published with.
+	if err := tx.Model(&PlanStep{}).
+		Where("project_id = ? AND plan_id = ? AND revision = ? AND step_id = ?",
+			ev.ProjectID, p.PlanID, plan.CurrentRevision, p.StepID).
+		Updates(map[string]any{
+			"state":                         p.State,
+			"last_applied_project_position": ev.Position,
+		}).Error; err != nil {
+		return err
+	}
+
+	return tx.Model(&Plan{}).
+		Where("project_id = ? AND run_id = ? AND plan_id = ?", ev.ProjectID, ev.RunID, p.PlanID).
+		Update("last_applied_project_position", ev.Position).Error
+}
+
+// ---------------------------------------------------------------------------
+// Work step projections
+// ---------------------------------------------------------------------------
+
+func applyWorkStepStarted(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p workStepStartedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	step := &WorkStep{
+		ProjectID:                  ev.ProjectID,
+		RunID:                      ev.RunID,
+		WorkStepID:                 p.WorkStepID,
+		AgentID:                    ev.AgentID,
+		PlanStepID:                 p.PlanStepID,
+		Title:                      p.Title,
+		StartedAt:                  ev.OccurredAt,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	if err := upsert(tx, step, workStepKey, []string{
+		"agent_id", "plan_step_id", "title", "started_at", "last_applied_project_position",
+	}); err != nil {
+		return err
+	}
+
+	for _, id := range normaliseIDs(p.ComponentIDs) {
+		link := &WorkStepComponent{
+			ProjectID:                  ev.ProjectID,
+			WorkStepID:                 p.WorkStepID,
+			ComponentID:                id,
+			LastAppliedProjectPosition: ev.Position,
+		}
+		if err := upsert(tx, link, workStepComponentKey, []string{"last_applied_project_position"}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyWorkStepCompleted(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p workStepCompletedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+	completedAt := ev.OccurredAt
+	step := &WorkStep{
+		ProjectID:                  ev.ProjectID,
+		RunID:                      ev.RunID,
+		WorkStepID:                 p.WorkStepID,
+		AgentID:                    ev.AgentID,
+		StartedAt:                  ev.OccurredAt,
+		CompletedAt:                &completedAt,
+		Summary:                    nonEmpty(p.Summary),
+		LastAppliedProjectPosition: ev.Position,
+	}
+	return upsert(tx, step, workStepKey, []string{
+		"completed_at", "summary", "last_applied_project_position",
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Feedback, diff, risk and problem projections
+// ---------------------------------------------------------------------------
+
+func applyFeedbackPublished(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p feedbackPublishedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	entry := &FeedbackEntry{
+		ProjectID:                  ev.ProjectID,
+		FeedbackID:                 p.FeedbackID,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		Format:                     p.Format,
+		Title:                      p.Title,
+		Body:                       p.Body,
+		CreatedAt:                  ev.OccurredAt,
+		SourcePosition:             ev.Position,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	if err := upsert(tx, entry, feedbackKey, []string{
+		"run_id", "agent_id", "format", "title", "body",
+		"created_at", "source_position", "last_applied_project_position",
+	}); err != nil {
+		return err
+	}
+
+	for _, id := range normaliseIDs(p.ComponentIDs) {
+		link := &FeedbackComponent{
+			ProjectID:                  ev.ProjectID,
+			FeedbackID:                 p.FeedbackID,
+			ComponentID:                id,
+			LastAppliedProjectPosition: ev.Position,
+		}
+		if err := upsert(tx, link, feedbackComponentKey, []string{"last_applied_project_position"}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyDiffReported(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p diffReportedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	diff := &Diff{
+		ProjectID:                  ev.ProjectID,
+		DiffID:                     p.DiffID,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		ChangeID:                   p.ChangeID,
+		FilePath:                   p.FilePath,
+		UnifiedDiff:                p.UnifiedDiff,
+		CreatedAt:                  ev.OccurredAt,
+		SourcePosition:             ev.Position,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	if err := upsert(tx, diff, diffKey, []string{
+		"run_id", "agent_id", "change_id", "file_path", "unified_diff",
+		"created_at", "source_position", "last_applied_project_position",
+	}); err != nil {
+		return err
+	}
+
+	for _, id := range normaliseIDs(p.ComponentIDs) {
+		link := &DiffComponent{
+			ProjectID:                  ev.ProjectID,
+			DiffID:                     p.DiffID,
+			ComponentID:                id,
+			LastAppliedProjectPosition: ev.Position,
+		}
+		if err := upsert(tx, link, diffComponentKey, []string{"last_applied_project_position"}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyRiskReported(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p riskReportedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	risk := &Risk{
+		ProjectID:                  ev.ProjectID,
+		RiskID:                     p.RiskID,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		Title:                      p.Title,
+		Detail:                     p.Detail,
+		Severity:                   p.Severity,
+		CreatedAt:                  ev.OccurredAt,
+		SourcePosition:             ev.Position,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	if err := upsert(tx, risk, riskKey, []string{
+		"run_id", "agent_id", "title", "detail", "severity",
+		"created_at", "source_position", "last_applied_project_position",
+	}); err != nil {
+		return err
+	}
+
+	for _, id := range normaliseIDs(p.ComponentIDs) {
+		link := &RiskComponent{
+			ProjectID:                  ev.ProjectID,
+			RiskID:                     p.RiskID,
+			ComponentID:                id,
+			LastAppliedProjectPosition: ev.Position,
+		}
+		if err := upsert(tx, link, riskComponentKey, []string{"last_applied_project_position"}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyProblemReported(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p problemReportedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	problem := &Problem{
+		ProjectID:                  ev.ProjectID,
+		ProblemID:                  p.ProblemID,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		Title:                      p.Title,
+		Detail:                     p.Detail,
+		CreatedAt:                  ev.OccurredAt,
+		SourcePosition:             ev.Position,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	if err := upsert(tx, problem, problemKey, []string{
+		"run_id", "agent_id", "title", "detail",
+		"created_at", "source_position", "last_applied_project_position",
+	}); err != nil {
+		return err
+	}
+
+	for _, id := range normaliseIDs(p.ComponentIDs) {
+		link := &ProblemComponent{
+			ProjectID:                  ev.ProjectID,
+			ProblemID:                  p.ProblemID,
+			ComponentID:                id,
+			LastAppliedProjectPosition: ev.Position,
+		}
+		if err := upsert(tx, link, problemComponentKey, []string{"last_applied_project_position"}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Architecture projections
+// ---------------------------------------------------------------------------
+
+// applyArchitectureSnapshot replaces the applied model wholesale.
+//
+// The contract defines a snapshot as authoritative: components and
+// relationships missing from it no longer exist. Deleting and re-inserting
+// inside the append transaction is what makes that atomic — readers never see
+// a half-replaced model.
+func applyArchitectureSnapshot(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p architectureSnapshotPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	if err := tx.Where("project_id = ?", ev.ProjectID).Delete(&Component{}).Error; err != nil {
+		return err
+	}
+	if err := tx.Where("project_id = ?", ev.ProjectID).Delete(&Relationship{}).Error; err != nil {
+		return err
+	}
+
+	for _, component := range p.Components {
+		if err := writeComponent(tx, ev, component); err != nil {
+			return err
+		}
+	}
+	for _, relationship := range p.Relationships {
+		if err := writeRelationship(tx, ev, relationship); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyComponentChangePlanned(tx *gorm.DB, ev *Event, payload []byte) error {
+	component, change, err := decodeComponentChange(payload)
+	if err != nil {
+		return err
+	}
+	// A planned change is a proposal: it must not touch the applied model.
+	return recordPlannedChange(tx, ev, changeIDOrEventID(change.ChangeID, ev),
+		ChangeTargetComponent, component.ComponentID, change.Operation, change.Component)
+}
+
+func applyComponentChangeApplied(tx *gorm.DB, ev *Event, payload []byte) error {
+	component, change, err := decodeComponentChange(payload)
+	if err != nil {
+		return err
+	}
+
+	switch change.Operation {
+	case OperationRemove:
+		if err := tx.Where("project_id = ? AND component_id = ?", ev.ProjectID, component.ComponentID).
+			Delete(&Component{}).Error; err != nil {
+			return err
+		}
+	default: // add and modify both merge the reported descriptor
+		if err := writeComponent(tx, ev, component); err != nil {
+			return err
+		}
+	}
+
+	return recordAppliedChange(tx, ev, changeIDOrEventID(change.ChangeID, ev),
+		ChangeTargetComponent, component.ComponentID, change.Operation, change.Component)
+}
+
+func applyRelationshipChangePlanned(tx *gorm.DB, ev *Event, payload []byte) error {
+	relationship, change, err := decodeRelationshipChange(payload)
+	if err != nil {
+		return err
+	}
+	return recordPlannedChange(tx, ev, changeIDOrEventID(change.ChangeID, ev),
+		ChangeTargetRelationship, relationship.RelationshipID, change.Operation, change.Relationship)
+}
+
+func applyRelationshipChangeApplied(tx *gorm.DB, ev *Event, payload []byte) error {
+	relationship, change, err := decodeRelationshipChange(payload)
+	if err != nil {
+		return err
+	}
+
+	switch change.Operation {
+	case OperationRemove:
+		if err := tx.Where("project_id = ? AND relationship_id = ?", ev.ProjectID, relationship.RelationshipID).
+			Delete(&Relationship{}).Error; err != nil {
+			return err
+		}
+	default:
+		if err := writeRelationship(tx, ev, relationship); err != nil {
+			return err
+		}
+	}
+
+	return recordAppliedChange(tx, ev, changeIDOrEventID(change.ChangeID, ev),
+		ChangeTargetRelationship, relationship.RelationshipID, change.Operation, change.Relationship)
+}
+
+// ---------------------------------------------------------------------------
+// Correction, retraction and run projections
+// ---------------------------------------------------------------------------
+
+func (p *Projector) applyCorrectionIssued(tx *gorm.DB, ev *Event, payload []byte, depth int) error {
+	var corrected correctionIssuedPayload
+	if err := decodePayload(payload, &corrected); err != nil {
+		return err
+	}
+
+	correctedType := corrected.CorrectedType
+	record := &EventCorrection{
+		ProjectID:           ev.ProjectID,
+		Position:            ev.Position,
+		Kind:                CorrectionKindCorrection,
+		TargetClientEventID: corrected.CorrectsClientEventID,
+		Reason:              corrected.Reason,
+		CorrectedType:       nonEmpty(correctedType),
+	}
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(record).Error; err != nil {
+		return err
+	}
+
+	if depth >= maxCorrectionDepth {
+		return nil
+	}
+	// The original event stays in the log untouched; the read models show the
+	// corrected content instead.
+	return p.applyPayload(tx, ev, correctedType, corrected.CorrectedPayload, depth+1)
+}
+
+// applyRetractionIssued withdraws a previously announced change. It deletes
+// nothing from the log and rewrites no history: it only marks the change the
+// retracted event had announced.
+func applyRetractionIssued(tx *gorm.DB, ev *Event, payload []byte, depth int) error {
+	var p retractionIssuedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+
+	record := &EventCorrection{
+		ProjectID:           ev.ProjectID,
+		Position:            ev.Position,
+		Kind:                CorrectionKindRetraction,
+		TargetClientEventID: p.RetractsClientEventID,
+		Reason:              p.Reason,
+	}
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(record).Error; err != nil {
+		return err
+	}
+	if depth >= maxCorrectionDepth {
+		return nil
+	}
+
+	target, err := findByClientEventID(tx, ev.ProjectID, p.RetractsClientEventID)
+	if err != nil || target == nil {
+		return err
+	}
+	changeID, err := changeIDOf(target)
+	if err != nil || changeID == "" {
+		return err
+	}
+
+	retractedAt := ev.OccurredAt
+	return tx.Model(&ActiveChange{}).
+		Where("project_id = ? AND change_id = ?", ev.ProjectID, changeID).
+		Updates(map[string]any{
+			"state":                         ChangeStateRetracted,
+			"retracted_at":                  retractedAt,
+			"last_applied_project_position": ev.Position,
+		}).Error
+}
+
+func applyRunFinished(tx *gorm.DB, ev *Event, payload []byte) error {
+	var p runFinishedPayload
+	if err := decodePayload(payload, &p); err != nil {
+		return err
+	}
+	finishedAt := ev.OccurredAt
+	return tx.Model(&Run{}).
+		Where("project_id = ? AND run_id = ?", ev.ProjectID, ev.RunID).
+		Updates(map[string]any{
+			"is_open":                       false,
+			"finished_at":                   finishedAt,
+			"outcome":                       p.Outcome,
+			"last_applied_project_position": ev.Position,
+		}).Error
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func writeComponent(tx *gorm.DB, ev *Event, c componentDescriptor) error {
+	row := &Component{
+		ProjectID:                  ev.ProjectID,
+		ComponentID:                c.ComponentID,
+		Name:                       c.Name,
+		Kind:                       c.Kind,
+		ParentComponentID:          c.ParentComponentID,
+		Description:                c.Description,
+		Technology:                 orEmpty(c.Technology, emptyObject),
+		Tags:                       orEmpty(c.Tags, emptyArray),
+		AppliedAt:                  ev.OccurredAt,
+		AppliedByAgentID:           ev.AgentID,
+		AppliedRunID:               ev.RunID,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	return upsert(tx, row, componentKey, []string{
+		"name", "kind", "parent_component_id", "description", "technology", "tags",
+		"applied_at", "applied_by_agent_id", "applied_run_id", "last_applied_project_position",
+	})
+}
+
+func writeRelationship(tx *gorm.DB, ev *Event, r relationshipDescriptor) error {
+	row := &Relationship{
+		ProjectID:                  ev.ProjectID,
+		RelationshipID:             r.RelationshipID,
+		SourceComponentID:          r.SourceComponentID,
+		TargetComponentID:          r.TargetComponentID,
+		Kind:                       r.Kind,
+		Label:                      r.Label,
+		Protocol:                   r.Protocol,
+		Operation:                  r.Operation,
+		Channel:                    r.Channel,
+		AppliedAt:                  ev.OccurredAt,
+		AppliedByAgentID:           ev.AgentID,
+		AppliedRunID:               ev.RunID,
+		LastAppliedProjectPosition: ev.Position,
+	}
+	return upsert(tx, row, relationshipKey, []string{
+		"source_component_id", "target_component_id", "kind", "label",
+		"protocol", "operation", "channel",
+		"applied_at", "applied_by_agent_id", "applied_run_id", "last_applied_project_position",
+	})
+}
+
+// recordPlannedChange stores a proposal. state, applied_at and retracted_at are
+// left out of the update set, so a planned event arriving after the applied one
+// cannot reopen a change that is already closed.
+func recordPlannedChange(tx *gorm.DB, ev *Event, changeID, targetKind, targetID, operation string, snapshot []byte) error {
+	plannedAt := ev.OccurredAt
+	row := &ActiveChange{
+		ProjectID:                  ev.ProjectID,
+		ChangeID:                   changeID,
+		TargetKind:                 targetKind,
+		TargetID:                   targetID,
+		Operation:                  operation,
+		State:                      ChangeStatePlanned,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		PlannedAt:                  &plannedAt,
+		Snapshot:                   orEmpty(snapshot, emptyObject),
+		LastAppliedProjectPosition: ev.Position,
+	}
+	return upsert(tx, row, changeKey, []string{
+		"target_kind", "target_id", "operation", "run_id", "agent_id",
+		"planned_at", "snapshot", "last_applied_project_position",
+	})
+}
+
+// recordAppliedChange closes a change. It creates the row when the change was
+// never planned or its changeId is unknown.
+func recordAppliedChange(tx *gorm.DB, ev *Event, changeID, targetKind, targetID, operation string, snapshot []byte) error {
+	appliedAt := ev.OccurredAt
+	row := &ActiveChange{
+		ProjectID:                  ev.ProjectID,
+		ChangeID:                   changeID,
+		TargetKind:                 targetKind,
+		TargetID:                   targetID,
+		Operation:                  operation,
+		State:                      ChangeStateApplied,
+		RunID:                      ev.RunID,
+		AgentID:                    ev.AgentID,
+		AppliedAt:                  &appliedAt,
+		Snapshot:                   orEmpty(snapshot, emptyObject),
+		LastAppliedProjectPosition: ev.Position,
+	}
+	return upsert(tx, row, changeKey, []string{
+		"target_kind", "target_id", "operation", "state", "run_id", "agent_id",
+		"applied_at", "snapshot", "last_applied_project_position",
+	})
+}
+
+func decodeComponentChange(payload []byte) (componentDescriptor, componentChangePayload, error) {
+	var change componentChangePayload
+	if err := decodePayload(payload, &change); err != nil {
+		return componentDescriptor{}, change, err
+	}
+	var component componentDescriptor
+	if err := decodePayload(change.Component, &component); err != nil {
+		return componentDescriptor{}, change, err
+	}
+	return component, change, nil
+}
+
+func decodeRelationshipChange(payload []byte) (relationshipDescriptor, relationshipChangePayload, error) {
+	var change relationshipChangePayload
+	if err := decodePayload(payload, &change); err != nil {
+		return relationshipDescriptor{}, change, err
+	}
+	var relationship relationshipDescriptor
+	if err := decodePayload(change.Relationship, &relationship); err != nil {
+		return relationshipDescriptor{}, change, err
+	}
+	return relationship, change, nil
+}
+
+// changeIDOrEventID falls back to the server event id for an unplanned change,
+// which the contract allows to omit changeId. The event id is stable, so the
+// change keeps one identity across replays.
+func changeIDOrEventID(changeID *string, ev *Event) string {
+	if changeID != nil && *changeID != "" {
+		return *changeID
+	}
+	return ev.ID
+}
+
+// changeIDOf reports which change a stored event announced, or "" when the
+// event announced none.
+func changeIDOf(ev *Event) (string, error) {
+	switch ev.Type {
+	case TypeComponentChangePlanned, TypeComponentChangeApplied:
+		var change componentChangePayload
+		if err := decodePayload(ev.Payload, &change); err != nil {
+			return "", err
+		}
+		return changeIDOrEventID(change.ChangeID, ev), nil
+	case TypeRelationshipChangePlanned, TypeRelationshipChangeApplied:
+		var change relationshipChangePayload
+		if err := decodePayload(ev.Payload, &change); err != nil {
+			return "", err
+		}
+		return changeIDOrEventID(change.ChangeID, ev), nil
+	default:
+		return "", nil
+	}
+}
+
+// nonEmpty maps the empty string to a NULL column value.
+func nonEmpty(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+// upsert writes value and, on a primary key collision, updates exactly the
+// listed columns. Everything left out keeps the value an earlier event wrote.
+func upsert(tx *gorm.DB, value any, conflict []clause.Column, assign []string) error {
+	return tx.Clauses(clause.OnConflict{
+		Columns:   conflict,
+		DoUpdates: clause.AssignmentColumns(assign),
+	}).Create(value).Error
+}
+
+func cols(names ...string) []clause.Column {
+	out := make([]clause.Column, 0, len(names))
+	for _, name := range names {
+		out = append(out, clause.Column{Name: name})
+	}
+	return out
+}
+
+// Primary keys used by the upserts above.
+var (
+	runKey               = cols("project_id", "run_id")
+	agentKey             = cols("project_id", "run_id", "agent_id")
+	planKey              = cols("project_id", "run_id", "plan_id")
+	workStepKey          = cols("project_id", "run_id", "work_step_id")
+	componentKey         = cols("project_id", "component_id")
+	relationshipKey      = cols("project_id", "relationship_id")
+	changeKey            = cols("project_id", "change_id")
+	feedbackKey          = cols("project_id", "feedback_id")
+	diffKey              = cols("project_id", "diff_id")
+	riskKey              = cols("project_id", "risk_id")
+	problemKey           = cols("project_id", "problem_id")
+	feedbackComponentKey = cols("project_id", "feedback_id", "component_id")
+	diffComponentKey     = cols("project_id", "diff_id", "component_id")
+	riskComponentKey     = cols("project_id", "risk_id", "component_id")
+	problemComponentKey  = cols("project_id", "problem_id", "component_id")
+	workStepComponentKey = cols("project_id", "work_step_id", "component_id")
+)

--- a/backend/internal/store/projector_test.go
+++ b/backend/internal/store/projector_test.go
@@ -1,0 +1,536 @@
+package store
+
+import (
+	"testing"
+)
+
+// A snapshot is authoritative: everything missing from it stops existing.
+func TestArchitectureSnapshotReplacesTheAppliedModel(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	s.append(s.loadExample("architecture-snapshot.json"))
+
+	if got := s.mustCount(&Component{}, "project_id = ?", s.projectID); got != 15 {
+		t.Fatalf("components after the first snapshot = %d, want 15", got)
+	}
+	if got := s.mustCount(&Relationship{}, "project_id = ?", s.projectID); got != 8 {
+		t.Fatalf("relationships after the first snapshot = %d, want 8", got)
+	}
+
+	// The hierarchy is carried by parentComponentId, four levels deep.
+	pricing := s.component("shop-platform.orders.domain.pricing")
+	if pricing.ParentComponentID == nil || *pricing.ParentComponentID != "shop-platform.orders.domain" {
+		t.Errorf("pricing.parent_component_id = %v, want shop-platform.orders.domain", pricing.ParentComponentID)
+	}
+	root := s.component("shop-platform")
+	if root.ParentComponentID != nil {
+		t.Errorf("the root component has parent %v, want NULL", *root.ParentComponentID)
+	}
+	storefront := s.component("shop-platform.storefront")
+	if string(storefront.Tags) == "" || string(storefront.Technology) == "" {
+		t.Errorf("technology/tags were not stored: %q / %q", storefront.Technology, storefront.Tags)
+	}
+	// Every NATS topic keeps its own edge; nothing is merged.
+	if got := s.mustCount(&Relationship{}, "project_id = ? AND kind = ?", s.projectID, "nats_topic"); got != 3 {
+		t.Errorf("nats_topic relationships = %d, want 3", got)
+	}
+
+	s.emit("subagent-architecture-mapper", ptr("orchestrator-root"), TypeArchitectureSnapshotPublished, `{
+		"snapshotId": "snapshot-2026-08-04-0002",
+		"components": [
+			{"componentId": "shop-platform", "name": "Shop Platform", "kind": "system", "parentComponentId": null}
+		],
+		"relationships": []
+	}`)
+
+	if got := s.mustCount(&Component{}, "project_id = ?", s.projectID); got != 1 {
+		t.Errorf("components after the replacing snapshot = %d, want 1", got)
+	}
+	if got := s.mustCount(&Relationship{}, "project_id = ?", s.projectID); got != 0 {
+		t.Errorf("relationships after the replacing snapshot = %d, want 0", got)
+	}
+}
+
+// A planned change is a proposal. It must be visible as such and must not touch
+// the applied model.
+func TestComponentChangePlannedDoesNotTouchTheAppliedModel(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	s.append(s.loadExample("component-change-planned.json"))
+
+	const componentID = "shop-platform.orders.domain.tax"
+	if got := s.mustCount(&Component{}, "project_id = ? AND component_id = ?", s.projectID, componentID); got != 0 {
+		t.Fatalf("the planned change created %d component rows, want 0", got)
+	}
+
+	change := s.activeChange("change-2026-08-04-0007")
+	if change.State != ChangeStatePlanned {
+		t.Errorf("change state = %q, want %q", change.State, ChangeStatePlanned)
+	}
+	if change.TargetKind != ChangeTargetComponent || change.TargetID != componentID {
+		t.Errorf("change target = %s/%s, want component/%s", change.TargetKind, change.TargetID, componentID)
+	}
+	if change.Operation != OperationAdd {
+		t.Errorf("change operation = %q, want %q", change.Operation, OperationAdd)
+	}
+	if change.PlannedAt == nil {
+		t.Error("planned_at was not written")
+	}
+	if change.AppliedAt != nil || change.RetractedAt != nil {
+		t.Error("a planned change must not carry applied_at or retracted_at")
+	}
+	if len(change.Snapshot) == 0 {
+		t.Error("the reported descriptor was not stored in snapshot")
+	}
+}
+
+// Applying a change merges it into the model and closes the planned change.
+func TestComponentChangeAppliedUpdatesTheModelAndClosesThePlannedChange(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+	s.append(s.loadExample("component-change-planned.json"))
+	planned := s.activeChange("change-2026-08-04-0007")
+
+	s.append(s.loadExample("component-change-applied.json"))
+
+	const componentID = "shop-platform.orders.domain.tax"
+	component := s.component(componentID)
+	if component.Name != "Tax Calculation" || component.Kind != "module" {
+		t.Errorf("applied component = %+v, want the reported descriptor", component)
+	}
+	if component.ParentComponentID == nil || *component.ParentComponentID != "shop-platform.orders.domain" {
+		t.Errorf("applied component parent = %v", component.ParentComponentID)
+	}
+	if component.AppliedByAgentID != "subagent-architecture-mapper" || component.AppliedRunID != s.runID {
+		t.Errorf("applied metadata = %s/%s", component.AppliedByAgentID, component.AppliedRunID)
+	}
+
+	change := s.activeChange("change-2026-08-04-0007")
+	if change.State != ChangeStateApplied {
+		t.Errorf("change state = %q, want %q", change.State, ChangeStateApplied)
+	}
+	if change.AppliedAt == nil {
+		t.Error("applied_at was not written")
+	}
+	if change.PlannedAt == nil || !change.PlannedAt.Equal(*planned.PlannedAt) {
+		t.Error("applying a change must keep the moment it was planned")
+	}
+
+	// Removing it again drops the row from the applied model.
+	s.emit("subagent-architecture-mapper", ptr("orchestrator-root"), TypeComponentChangeApplied, `{
+		"changeId": "change-2026-08-04-0008",
+		"operation": "remove",
+		"component": {
+			"componentId": "shop-platform.orders.domain.tax",
+			"name": "Tax Calculation",
+			"kind": "module",
+			"parentComponentId": "shop-platform.orders.domain"
+		}
+	}`)
+	if got := s.mustCount(&Component{}, "project_id = ? AND component_id = ?", s.projectID, componentID); got != 0 {
+		t.Errorf("component rows after the remove = %d, want 0", got)
+	}
+}
+
+// run.finished is optional. A run stays open until it arrives; the backend
+// never infers a terminal state from silence.
+func TestRunStaysOpenUntilRunFinishedArrives(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+	s.emit("orchestrator-root", nil, TypeAgentFinished, `{"outcome":"completed","summary":"done"}`)
+
+	if run := s.run(); !run.IsOpen || run.FinishedAt != nil || run.Outcome != nil {
+		t.Fatalf("the run closed without run.finished: %+v", run)
+	}
+
+	s.append(s.loadExample("run-finished.json"))
+
+	run := s.run()
+	if run.IsOpen {
+		t.Error("run.finished did not close the run")
+	}
+	if run.FinishedAt == nil {
+		t.Error("finished_at was not written")
+	}
+	if run.Outcome == nil || *run.Outcome != "completed" {
+		t.Errorf("run outcome = %v, want completed", run.Outcome)
+	}
+	if run.RootAgentID != "orchestrator-root" {
+		t.Errorf("root_agent_id = %q, want orchestrator-root", run.RootAgentID)
+	}
+}
+
+// The agent tree is expressed through parentAgentId and may nest arbitrarily.
+func TestNestedAgentTreeIsProjected(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	s.emit("subagent-contract", ptr("orchestrator-root"), TypeAgentStarted, `{
+		"role": "subagent", "displayName": "Contract Agent", "assignedTask": "Define the event contract."
+	}`)
+	s.emit("subagent-store", ptr("orchestrator-root"), TypeAgentStarted, `{
+		"role": "subagent", "displayName": "Store Agent", "assignedTask": "Implement the event store."
+	}`)
+	s.emit("subagent-projections", ptr("subagent-store"), TypeAgentStarted, `{
+		"role": "subagent", "displayName": "Projection Agent", "assignedTask": "Implement the read models."
+	}`)
+	s.emit("subagent-migrations", ptr("subagent-projections"), TypeAgentStarted, `{
+		"role": "subagent", "displayName": "Migration Agent", "assignedTask": "Wire AutoMigrate into the bootstrap."
+	}`)
+
+	if got := s.mustCount(&Agent{}, "project_id = ? AND run_id = ?", s.projectID, s.runID); got != 5 {
+		t.Fatalf("agents = %d, want 5", got)
+	}
+
+	root := s.agent("orchestrator-root")
+	if root.ParentAgentID != nil {
+		t.Errorf("the root orchestrator has parent %v, want NULL", *root.ParentAgentID)
+	}
+	if root.Role != roleOrchestrator {
+		t.Errorf("root role = %q, want %q", root.Role, roleOrchestrator)
+	}
+
+	for child, wantParent := range map[string]string{
+		"subagent-contract":    "orchestrator-root",
+		"subagent-store":       "orchestrator-root",
+		"subagent-projections": "subagent-store",
+		"subagent-migrations":  "subagent-projections",
+	} {
+		agent := s.agent(child)
+		if agent.ParentAgentID == nil || *agent.ParentAgentID != wantParent {
+			t.Errorf("%s.parent_agent_id = %v, want %s", child, agent.ParentAgentID, wantParent)
+		}
+		if agent.Role != "subagent" {
+			t.Errorf("%s.role = %q, want subagent", child, agent.Role)
+		}
+	}
+
+	// Only the root orchestrator owns the run and the project's current run.
+	if run := s.run(); run.RootAgentID != "orchestrator-root" {
+		t.Errorf("root_agent_id = %q, want orchestrator-root", run.RootAgentID)
+	}
+	if project := s.project(); project.CurrentRunID != s.runID {
+		t.Errorf("projects.current_run_id = %q, want %q", project.CurrentRunID, s.runID)
+	}
+}
+
+// Every projection an event touches records the position it was written at.
+func TestLastAppliedProjectPositionAdvancesOnTouchedProjections(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+	s.emit("subagent-reviewer", ptr("orchestrator-root"), TypeAgentStarted, `{
+		"role": "subagent", "displayName": "Reviewer", "assignedTask": "Review the extraction."
+	}`)
+
+	feedback := s.append(s.loadExample("feedback-published.json"))
+
+	if project := s.project(); project.LastAppliedProjectPosition != feedback.Position {
+		t.Errorf("projects.last_applied_project_position = %d, want %d",
+			project.LastAppliedProjectPosition, feedback.Position)
+	}
+	if run := s.run(); run.LastAppliedProjectPosition != feedback.Position {
+		t.Errorf("runs.last_applied_project_position = %d, want %d",
+			run.LastAppliedProjectPosition, feedback.Position)
+	}
+	if agent := s.agent("subagent-reviewer"); agent.LastAppliedProjectPosition != feedback.Position {
+		t.Errorf("agents.last_applied_project_position = %d, want %d",
+			agent.LastAppliedProjectPosition, feedback.Position)
+	}
+
+	var entry FeedbackEntry
+	if err := s.db.Where("project_id = ? AND feedback_id = ?", s.projectID, "feedback-2026-08-04-0003").
+		Take(&entry).Error; err != nil {
+		t.Fatalf("loading the feedback entry: %v", err)
+	}
+	if entry.LastAppliedProjectPosition != feedback.Position || entry.SourcePosition != feedback.Position {
+		t.Errorf("feedback positions = %d/%d, want %d",
+			entry.SourcePosition, entry.LastAppliedProjectPosition, feedback.Position)
+	}
+
+	// An untouched projection keeps the position it was last written at.
+	orchestrator := s.agent("orchestrator-root")
+	if orchestrator.LastAppliedProjectPosition >= feedback.Position {
+		t.Errorf("the orchestrator row advanced to %d although it reported nothing",
+			orchestrator.LastAppliedProjectPosition)
+	}
+}
+
+// Component history is served by the join table, in position order, without
+// scanning payloads.
+func TestComponentHistoryIsOrderedByPosition(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+	s.emit("subagent-implementer", ptr("orchestrator-root"), TypeAgentStarted, `{
+		"role": "subagent", "displayName": "Implementer", "assignedTask": "Extract VAT handling."
+	}`)
+
+	const pricing = "shop-platform.orders.domain.pricing"
+	const tax = "shop-platform.orders.domain.tax"
+
+	snapshot := s.append(s.loadExample("architecture-snapshot.json"))
+	work := s.emit("subagent-implementer", ptr("orchestrator-root"), TypeWorkStepStarted, `{
+		"workStepId": "work-2026-08-04-0004",
+		"title": "Extract VAT handling into its own module",
+		"componentIds": ["shop-platform.orders.domain.pricing"]
+	}`)
+	diff := s.append(s.loadExample("diff-reported.json"))
+	planned := s.append(s.loadExample("component-change-planned.json"))
+
+	type row struct {
+		Position int64
+		Type     string
+	}
+	var history []row
+	err := s.db.Table("event_components AS ec").
+		Select("ec.position, e.type").
+		Joins("JOIN events AS e ON e.project_id = ec.project_id AND e.position = ec.position").
+		Where("ec.project_id = ? AND ec.component_id = ?", s.projectID, pricing).
+		Order("ec.position").
+		Scan(&history).Error
+	if err != nil {
+		t.Fatalf("reading the component history: %v", err)
+	}
+
+	want := []row{
+		{snapshot.Position, TypeArchitectureSnapshotPublished},
+		{work.Position, TypeWorkStepStarted},
+		{diff.Position, TypeDiffReported},
+	}
+	if len(history) != len(want) {
+		t.Fatalf("history for %s = %+v, want %+v", pricing, history, want)
+	}
+	for i, entry := range want {
+		if history[i] != entry {
+			t.Errorf("history[%d] = %+v, want %+v", i, history[i], entry)
+		}
+	}
+
+	// The planned change is linked to the component it proposes, even though it
+	// does not exist in the applied model yet.
+	var taxPositions []int64
+	if err := s.db.Model(&EventComponent{}).
+		Where("project_id = ? AND component_id = ?", s.projectID, tax).
+		Order("position").Pluck("position", &taxPositions).Error; err != nil {
+		t.Fatalf("reading the history of %s: %v", tax, err)
+	}
+	if len(taxPositions) != 1 || taxPositions[0] != planned.Position {
+		t.Errorf("history for %s = %v, want [%d]", tax, taxPositions, planned.Position)
+	}
+}
+
+// A correction is a new event. The original stays in the log untouched and the
+// read models show the corrected content.
+func TestCorrectionProjectsTheCorrectedPayloadAndKeepsTheOriginal(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	original := s.loadExample("diff-reported.json")
+	// The correction example references this exact idempotency key.
+	original.ClientEventID = "5d41402a-bc4b-4a76-b971-9d911017c592"
+	originalResult := s.append(original)
+
+	correction := s.append(s.loadExample("correction-issued.json"))
+
+	// The corrected payload adds the tax module to the diff's components.
+	if got := s.mustCount(&DiffComponent{}, "project_id = ? AND diff_id = ?", s.projectID, "diff-2026-08-04-0011"); got != 2 {
+		t.Errorf("diff component links = %d, want 2", got)
+	}
+
+	var record EventCorrection
+	if err := s.db.Where("project_id = ? AND position = ?", s.projectID, correction.Position).
+		Take(&record).Error; err != nil {
+		t.Fatalf("loading the correction record: %v", err)
+	}
+	if record.Kind != CorrectionKindCorrection {
+		t.Errorf("correction kind = %q, want %q", record.Kind, CorrectionKindCorrection)
+	}
+	if record.TargetClientEventID != original.ClientEventID {
+		t.Errorf("correction target = %q, want %q", record.TargetClientEventID, original.ClientEventID)
+	}
+	if record.CorrectedType == nil || *record.CorrectedType != TypeDiffReported {
+		t.Errorf("corrected_type = %v, want %s", record.CorrectedType, TypeDiffReported)
+	}
+
+	var stored Event
+	if err := s.db.Where("project_id = ? AND position = ?", s.projectID, originalResult.Position).
+		Take(&stored).Error; err != nil {
+		t.Fatalf("loading the corrected event: %v", err)
+	}
+	if stored.Type != TypeDiffReported || stored.ClientEventID != original.ClientEventID {
+		t.Errorf("the original event was rewritten: %+v", stored)
+	}
+}
+
+// A retraction withdraws an announced change without deleting anything.
+func TestRetractionMarksTheChangeAndKeepsTheLog(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	planned := s.loadExample("component-change-planned.json")
+	plannedResult := s.append(planned)
+
+	s.emit("subagent-architecture-mapper", ptr("orchestrator-root"), TypeRetractionIssued, `{
+		"retractsClientEventId": "`+planned.ClientEventID+`",
+		"reason": "The tax rules stay inside the pricing module for now."
+	}`)
+
+	change := s.activeChange("change-2026-08-04-0007")
+	if change.State != ChangeStateRetracted {
+		t.Errorf("change state = %q, want %q", change.State, ChangeStateRetracted)
+	}
+	if change.RetractedAt == nil {
+		t.Error("retracted_at was not written")
+	}
+	if change.PlannedAt == nil {
+		t.Error("the retraction dropped the moment the change was planned")
+	}
+
+	if got := s.mustCount(&Event{}, "project_id = ?", s.projectID); got != 3 {
+		t.Errorf("stored events = %d, want 3 — a retraction never removes an event", got)
+	}
+	if got := s.mustCount(&Event{}, "project_id = ? AND position = ?", s.projectID, plannedResult.Position); got != 1 {
+		t.Error("the retracted event is gone from the log")
+	}
+	if got := s.mustCount(&EventCorrection{}, "project_id = ? AND kind = ?", s.projectID, CorrectionKindRetraction); got != 1 {
+		t.Errorf("retraction records = %d, want 1", got)
+	}
+}
+
+// The catalogue is closed and the projector must be total over it: an event
+// type without a projection branch fails the append.
+func TestEveryCatalogueTypeIsProjected(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	const parent = "orchestrator-root"
+	subagent := ptr(parent)
+
+	s.emit("subagent-implementer", subagent, TypeAgentStarted, `{
+		"role": "subagent", "displayName": "Implementer", "assignedTask": "Extract VAT handling."
+	}`)
+	s.emit("subagent-implementer", subagent, TypeAgentStatusReported, `{"status":"working","note":"Writing the module."}`)
+	s.emit("subagent-implementer", subagent, TypeAgentProgressReported, `{"percent":40,"scope":"own_task","basis":"completed_steps"}`)
+	s.emit(parent, nil, TypePlanPublished, `{
+		"planId": "plan-2026-08-04-0001",
+		"revision": 1,
+		"steps": [
+			{"stepId": "step-1", "order": 0, "title": "Map the architecture", "state": "done", "componentIds": ["shop-platform"]},
+			{"stepId": "step-2", "order": 1, "title": "Extract the tax module", "state": "pending"}
+		]
+	}`)
+	s.emit(parent, nil, TypePlanStepUpdated, `{
+		"planId": "plan-2026-08-04-0001", "stepId": "step-2", "state": "in_progress"
+	}`)
+	s.emit("subagent-implementer", subagent, TypeWorkStepStarted, `{
+		"workStepId": "work-1", "title": "Create the tax module",
+		"componentIds": ["shop-platform.orders.domain.pricing"], "planStepId": "step-2"
+	}`)
+	s.emit("subagent-implementer", subagent, TypeWorkStepCompleted, `{
+		"workStepId": "work-1", "summary": "Tax rules live in their own module now."
+	}`)
+	s.append(s.loadExample("architecture-snapshot.json"))
+	s.append(s.loadExample("component-change-planned.json"))
+	s.append(s.loadExample("component-change-applied.json"))
+	relationshipPlanned := s.event("subagent-implementer", subagent, TypeRelationshipChangePlanned, `{
+		"changeId": "change-2026-08-04-0009",
+		"operation": "add",
+		"relationship": {
+			"relationshipId": "rel-pricing-tax-dependency",
+			"sourceComponentId": "shop-platform.orders.domain.pricing",
+			"targetComponentId": "shop-platform.orders.domain.tax",
+			"kind": "dependency", "label": "Tax rules"
+		},
+		"rationale": "Pricing delegates VAT handling to the new module."
+	}`)
+	s.append(relationshipPlanned)
+	s.emit("subagent-implementer", subagent, TypeRelationshipChangeApplied, `{
+		"changeId": "change-2026-08-04-0009",
+		"operation": "add",
+		"relationship": {
+			"relationshipId": "rel-pricing-tax-dependency",
+			"sourceComponentId": "shop-platform.orders.domain.pricing",
+			"targetComponentId": "shop-platform.orders.domain.tax",
+			"kind": "dependency", "label": "Tax rules"
+		}
+	}`)
+	s.append(s.loadExample("feedback-published.json"))
+	diff := s.loadExample("diff-reported.json")
+	diff.ClientEventID = "5d41402a-bc4b-4a76-b971-9d911017c592"
+	s.append(diff)
+	s.emit("subagent-implementer", subagent, TypeRiskReported, `{
+		"riskId": "risk-1", "componentIds": ["shop-platform.orders.domain.pricing"],
+		"title": "Discount and tax order changed", "detail": "Percentage discounts now apply before VAT.",
+		"severity": "medium"
+	}`)
+	s.emit("subagent-implementer", subagent, TypeProblemReported, `{
+		"problemId": "problem-1", "componentIds": ["shop-platform.orders.domain.tax"],
+		"title": "No rounding rule stated"
+	}`)
+	s.append(s.loadExample("correction-issued.json"))
+	s.emit("subagent-implementer", subagent, TypeRetractionIssued, `{
+		"retractsClientEventId": "`+relationshipPlanned.ClientEventID+`",
+		"reason": "Superseded by the applied change."
+	}`)
+	s.emit("subagent-implementer", subagent, TypeAgentFinished, `{"outcome":"completed","summary":"VAT extracted."}`)
+	s.append(s.loadExample("run-finished.json"))
+
+	var storedTypes []string
+	if err := s.db.Model(&Event{}).
+		Where("project_id = ?", s.projectID).
+		Distinct().Pluck("type", &storedTypes).Error; err != nil {
+		t.Fatalf("reading the stored event types: %v", err)
+	}
+	stored := make(map[string]bool, len(storedTypes))
+	for _, evType := range storedTypes {
+		stored[evType] = true
+	}
+
+	catalogue := EventTypes()
+	if len(catalogue) != 20 {
+		t.Fatalf("the catalogue has %d types, want 20", len(catalogue))
+	}
+	for _, evType := range catalogue {
+		if !stored[evType] {
+			t.Errorf("event type %q was never exercised", evType)
+		}
+	}
+
+	// The plan step update reached the published revision only.
+	var step PlanStep
+	if err := s.db.Where("project_id = ? AND plan_id = ? AND revision = ? AND step_id = ?",
+		s.projectID, "plan-2026-08-04-0001", 1, "step-2").Take(&step).Error; err != nil {
+		t.Fatalf("loading the plan step: %v", err)
+	}
+	if step.State != "in_progress" {
+		t.Errorf("plan step state = %q, want in_progress", step.State)
+	}
+	if step.StepOrder != 1 {
+		t.Errorf("plan step order = %d, want 1", step.StepOrder)
+	}
+
+	// The work step was started and completed.
+	var work WorkStep
+	if err := s.db.Where("project_id = ? AND run_id = ? AND work_step_id = ?", s.projectID, s.runID, "work-1").
+		Take(&work).Error; err != nil {
+		t.Fatalf("loading the work step: %v", err)
+	}
+	if work.CompletedAt == nil || work.Summary == nil {
+		t.Errorf("work step was not completed: %+v", work)
+	}
+	if work.PlanStepID == nil || *work.PlanStepID != "step-2" {
+		t.Errorf("work step plan link = %v, want step-2", work.PlanStepID)
+	}
+
+	// The retracted relationship change is marked, the applied one is not.
+	if change := s.activeChange("change-2026-08-04-0009"); change.State != ChangeStateRetracted {
+		t.Errorf("relationship change state = %q, want %q", change.State, ChangeStateRetracted)
+	}
+	if change := s.activeChange("change-2026-08-04-0007"); change.State != ChangeStateApplied {
+		t.Errorf("component change state = %q, want %q", change.State, ChangeStateApplied)
+	}
+	if run := s.run(); run.IsOpen {
+		t.Error("the run is still open after run.finished")
+	}
+}

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -1,0 +1,227 @@
+// Package store implements the immutable project event log and the normalised
+// read models the cockpit renders.
+//
+// An accepted event is appended once and, in the very same transaction,
+// projected onto every read model it touches. The log is append-only: nothing
+// ever updates or deletes a stored event, and corrections and retractions are
+// new events that reference the original one.
+//
+// Validating an event against the contract, the lifecycle rules and the HTTP
+// status codes are not this package's concern; the ingestion layer owns them.
+// The store owns position assignment, idempotency, conflict detection,
+// atomicity and the projections.
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Envelope is one validated event handed to the store for appending.
+type Envelope struct {
+	ProjectID     string
+	ClientEventID string
+	RunID         string
+	AgentID       string
+	ParentAgentID *string
+	Type          string
+	SchemaVersion string
+	OccurredAt    time.Time
+	Payload       json.RawMessage
+}
+
+// Result reports how an Append was resolved. Duplicate is true when the event
+// had already been accepted under the same clientEventId with identical
+// content; the originally assigned position is repeated unchanged.
+type Result struct {
+	ProjectID     string
+	Position      int64
+	ServerEventID string
+	ClientEventID string
+	Duplicate     bool
+	ReceivedAt    time.Time
+}
+
+// ErrClientEventIDConflict marks a reused idempotency key whose content differs
+// from the stored event. Use errors.As with ClientEventIDConflictError to read
+// the position the original event occupies.
+var ErrClientEventIDConflict = errors.New("store: client event id reused with different content")
+
+// ClientEventIDConflictError carries the details of a conflicting retry.
+type ClientEventIDConflictError struct {
+	ProjectID        string
+	ClientEventID    string
+	ExistingPosition int64
+}
+
+// Error implements error.
+func (e *ClientEventIDConflictError) Error() string {
+	return fmt.Sprintf(
+		"store: clientEventId %q was already accepted at position %d for project %q with different content",
+		e.ClientEventID, e.ExistingPosition, e.ProjectID,
+	)
+}
+
+// Unwrap makes errors.Is(err, ErrClientEventIDConflict) succeed.
+func (e *ClientEventIDConflictError) Unwrap() error { return ErrClientEventIDConflict }
+
+// Store appends events and keeps the read models in sync.
+type Store struct {
+	db *gorm.DB
+	// apply advances the read models. It is a field so tests can inject a
+	// failing projection and observe that the whole append rolls back.
+	apply func(tx *gorm.DB, ev *Event) error
+	now   func() time.Time
+	newID func() string
+}
+
+// New returns a Store backed by db.
+func New(db *gorm.DB) *Store {
+	return &Store{
+		db:    db,
+		apply: NewProjector().Apply,
+		now:   func() time.Time { return time.Now().UTC() },
+		newID: uuid.NewString,
+	}
+}
+
+// Append stores one event and advances every affected read model inside a
+// single transaction. Any failure rolls the whole append back, including the
+// position, which is therefore never consumed by a rejected event.
+//
+// Idempotency is resolved on (projectId, clientEventId):
+//
+//   - unknown key                    -> appended, Duplicate false
+//   - known key, identical content   -> nothing written, Duplicate true
+//   - known key, different content   -> ClientEventIDConflictError
+func (s *Store) Append(ctx context.Context, env Envelope) (Result, error) {
+	canonical, err := canonicalJSON(env.Payload)
+	if err != nil {
+		return Result{}, fmt.Errorf("store: canonicalising payload: %w", err)
+	}
+	hash := payloadHash(canonical)
+
+	var result Result
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// The project row is the serialisation point of the whole append. Every
+		// concurrent request for this project queues up here, so reading
+		// last_position and writing position + 1 cannot interleave. A plain
+		// max(position) + 1 would let two transactions read the same value.
+		project, err := lockProject(tx, env.ProjectID, env.OccurredAt)
+		if err != nil {
+			return err
+		}
+
+		existing, err := findByClientEventID(tx, env.ProjectID, env.ClientEventID)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			if existing.PayloadHash == hash &&
+				existing.Type == env.Type &&
+				existing.SchemaVersion == env.SchemaVersion {
+				result = Result{
+					ProjectID:     existing.ProjectID,
+					Position:      existing.Position,
+					ServerEventID: existing.ID,
+					ClientEventID: existing.ClientEventID,
+					Duplicate:     true,
+					ReceivedAt:    existing.ReceivedAt,
+				}
+				return nil
+			}
+			return &ClientEventIDConflictError{
+				ProjectID:        env.ProjectID,
+				ClientEventID:    env.ClientEventID,
+				ExistingPosition: existing.Position,
+			}
+		}
+
+		event := &Event{
+			ID:            s.newID(),
+			ProjectID:     env.ProjectID,
+			Position:      project.LastPosition + 1,
+			ClientEventID: env.ClientEventID,
+			RunID:         env.RunID,
+			AgentID:       env.AgentID,
+			ParentAgentID: env.ParentAgentID,
+			Type:          env.Type,
+			SchemaVersion: env.SchemaVersion,
+			OccurredAt:    env.OccurredAt.UTC(),
+			ReceivedAt:    s.now(),
+			// The canonical form is stored rather than the received bytes:
+			// jsonb normalises the document anyway, and this keeps the column
+			// and the hash describing exactly the same content.
+			Payload:     JSON(canonical),
+			PayloadHash: hash,
+		}
+		if err := tx.Create(event).Error; err != nil {
+			return err
+		}
+		if err := s.apply(tx, event); err != nil {
+			return err
+		}
+		if err := linkEventComponents(tx, event); err != nil {
+			return err
+		}
+
+		result = Result{
+			ProjectID:     event.ProjectID,
+			Position:      event.Position,
+			ServerEventID: event.ID,
+			ClientEventID: event.ClientEventID,
+			Duplicate:     false,
+			ReceivedAt:    event.ReceivedAt,
+		}
+		return nil
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return result, nil
+}
+
+// lockProject makes sure the project row exists and holds its row lock until
+// the transaction ends.
+func lockProject(tx *gorm.DB, projectID string, seenAt time.Time) (Project, error) {
+	// A brand new project has no row to lock yet. Inserting it first is safe
+	// under concurrency: the loser of the race does nothing and then blocks on
+	// the winner's row lock below, which is exactly the intended queueing.
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&Project{
+		ProjectID:   projectID,
+		FirstSeenAt: seenAt.UTC(),
+		LastEventAt: seenAt.UTC(),
+	}).Error; err != nil {
+		return Project{}, err
+	}
+
+	var project Project
+	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("project_id = ?", projectID).
+		Take(&project).Error; err != nil {
+		return Project{}, err
+	}
+	return project, nil
+}
+
+// findByClientEventID returns the stored event for an idempotency key, or nil.
+func findByClientEventID(tx *gorm.DB, projectID, clientEventID string) (*Event, error) {
+	var event Event
+	err := tx.Where("project_id = ? AND client_event_id = ?", projectID, clientEventID).
+		Take(&event).Error
+	switch {
+	case err == nil:
+		return &event, nil
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return nil, nil
+	default:
+		return nil, err
+	}
+}

--- a/backend/internal/store/store_test.go
+++ b/backend/internal/store/store_test.go
@@ -1,0 +1,245 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Concurrent appends against one project must produce a single, gap-free
+// ordering. This is the property the FOR UPDATE lock on the project row buys;
+// a max(position) + 1 without a lock would hand the same value to two
+// transactions.
+func TestAppendAssignsGaplessPositionsUnderConcurrency(t *testing.T) {
+	s := newScenario(t)
+	s.startRun() // occupies position 1
+
+	const goroutines = 8
+	const perGoroutine = 25
+
+	positions := make([][]int64, goroutines)
+	failures := make([]error, goroutines)
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			agentID := fmt.Sprintf("subagent-%02d", g)
+			<-start
+
+			for i := range perGoroutine {
+				env := Envelope{
+					ProjectID:     s.projectID,
+					ClientEventID: uuid.NewString(),
+					RunID:         s.runID,
+					AgentID:       agentID,
+					ParentAgentID: ptr("orchestrator-root"),
+					Type:          TypeAgentStatusReported,
+					SchemaVersion: "1.0",
+					OccurredAt:    baseTime.Add(time.Duration(g*perGoroutine+i) * time.Millisecond),
+					Payload:       json.RawMessage(fmt.Sprintf(`{"status":"working","note":"step %d"}`, i)),
+				}
+				result, err := s.store.Append(context.Background(), env)
+				if err != nil {
+					failures[g] = err
+					return
+				}
+				positions[g] = append(positions[g], result.Position)
+			}
+		}(g)
+	}
+	close(start)
+	wg.Wait()
+
+	for g, err := range failures {
+		if err != nil {
+			t.Fatalf("goroutine %d failed: %v", g, err)
+		}
+	}
+
+	all := make([]int64, 0, goroutines*perGoroutine)
+	for g := range goroutines {
+		// Every single writer must see its own positions strictly increasing.
+		for i := 1; i < len(positions[g]); i++ {
+			if positions[g][i] <= positions[g][i-1] {
+				t.Fatalf("goroutine %d saw a non-monotonic position sequence: %v", g, positions[g])
+			}
+		}
+		all = append(all, positions[g]...)
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i] < all[j] })
+	for i, position := range all {
+		want := int64(i + 2) // position 1 belongs to the root agent.started
+		if position != want {
+			t.Fatalf("position %d of the sorted sequence is %d, want %d (duplicate or gap)", i, position, want)
+		}
+	}
+
+	total := int64(goroutines*perGoroutine) + 1
+	if stored := s.mustCount(&Event{}, "project_id = ?", s.projectID); stored != total {
+		t.Errorf("stored events = %d, want %d", stored, total)
+	}
+	if last := s.project().LastPosition; last != total {
+		t.Errorf("projects.last_position = %d, want %d", last, total)
+	}
+}
+
+// A failing projection must undo the whole append: no event row, no projection
+// change and, above all, no consumed position.
+func TestAppendRollsBackEventAndProjectionsOnProjectionFailure(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	before := s.project()
+	agentBefore := s.agent("orchestrator-root")
+
+	broken := New(s.db)
+	sentinel := errors.New("projection blew up")
+	broken.apply = func(tx *gorm.DB, ev *Event) error {
+		// Write a projection first, so the rollback has to undo more than the
+		// event row itself.
+		if err := advanceProject(tx, ev); err != nil {
+			return err
+		}
+		return sentinel
+	}
+
+	env := s.event("orchestrator-root", nil, TypeAgentStatusReported, `{"status":"blocked","note":"waiting"}`)
+	if _, err := broken.Append(context.Background(), env); !errors.Is(err, sentinel) {
+		t.Fatalf("Append error = %v, want %v", err, sentinel)
+	}
+
+	if stored := s.mustCount(&Event{}, "project_id = ? AND client_event_id = ?", s.projectID, env.ClientEventID); stored != 0 {
+		t.Errorf("the rejected event left %d rows in the log", stored)
+	}
+	after := s.project()
+	if after.LastPosition != before.LastPosition || after.LastAppliedProjectPosition != before.LastAppliedProjectPosition {
+		t.Errorf("project head moved: %+v -> %+v", before, after)
+	}
+	if agentAfter := s.agent("orchestrator-root"); agentAfter.Status != agentBefore.Status {
+		t.Errorf("agent status changed to %q although the append failed", agentAfter.Status)
+	}
+
+	// The position must still be free for the next accepted event.
+	next := s.emit("orchestrator-root", nil, TypeAgentStatusReported, `{"status":"working"}`)
+	if next.Position != before.LastPosition+1 {
+		t.Errorf("next position = %d, want %d — the failed append consumed one", next.Position, before.LastPosition+1)
+	}
+}
+
+// A retry of an accepted event answers with the original position and writes
+// nothing. Key order must not matter, so the retry below reorders the payload.
+func TestAppendIsIdempotentForAnIdenticalRetry(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	env := s.event("subagent-reviewer", ptr("orchestrator-root"), TypeAgentProgressReported,
+		`{"percent":40,"scope":"own_task","basis":"completed_steps"}`)
+	first := s.append(env)
+	if first.Duplicate {
+		t.Fatal("the first delivery must not be reported as a duplicate")
+	}
+
+	retry := env
+	retry.OccurredAt = env.OccurredAt.Add(time.Minute) // the agent re-stamped its retry
+	retry.Payload = json.RawMessage(`{"basis":"completed_steps","scope":"own_task","percent":40}`)
+
+	second := s.append(retry)
+	if !second.Duplicate {
+		t.Error("the retry must be reported as a duplicate")
+	}
+	if second.Position != first.Position {
+		t.Errorf("retry position = %d, want the original %d", second.Position, first.Position)
+	}
+	if second.ServerEventID != first.ServerEventID {
+		t.Errorf("retry serverEventId = %q, want the original %q", second.ServerEventID, first.ServerEventID)
+	}
+	if stored := s.mustCount(&Event{}, "project_id = ? AND client_event_id = ?", s.projectID, env.ClientEventID); stored != 1 {
+		t.Errorf("stored events for the idempotency key = %d, want 1", stored)
+	}
+	if last := s.project().LastPosition; last != first.Position {
+		t.Errorf("projects.last_position = %d, want %d — the retry consumed a position", last, first.Position)
+	}
+}
+
+// Reusing an idempotency key for different content is a conflict, and the
+// caller must be able to report the position the original event occupies.
+func TestAppendRejectsAReusedClientEventIDWithDifferentContent(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	env := s.event("subagent-reviewer", ptr("orchestrator-root"), TypeAgentProgressReported,
+		`{"percent":40,"scope":"own_task","basis":"completed_steps"}`)
+	first := s.append(env)
+
+	diverging := env
+	diverging.Payload = json.RawMessage(`{"percent":80,"scope":"own_task","basis":"completed_steps"}`)
+
+	_, err := s.store.Append(context.Background(), diverging)
+	if !errors.Is(err, ErrClientEventIDConflict) {
+		t.Fatalf("Append error = %v, want a client event id conflict", err)
+	}
+
+	var conflict *ClientEventIDConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error %v does not carry the conflict details", err)
+	}
+	if conflict.ExistingPosition != first.Position {
+		t.Errorf("conflict position = %d, want %d", conflict.ExistingPosition, first.Position)
+	}
+	if conflict.ClientEventID != env.ClientEventID || conflict.ProjectID != s.projectID {
+		t.Errorf("conflict identifies %q/%q, want %q/%q",
+			conflict.ProjectID, conflict.ClientEventID, s.projectID, env.ClientEventID)
+	}
+
+	if stored := s.mustCount(&Event{}, "project_id = ?", s.projectID); stored != 2 {
+		t.Errorf("stored events = %d, want 2 — the conflict must not append", stored)
+	}
+}
+
+// A change of type or schema version under the same key is a conflict too: the
+// hash alone does not identify an event.
+func TestAppendRejectsAReusedClientEventIDWithADifferentType(t *testing.T) {
+	s := newScenario(t)
+	s.startRun()
+
+	env := s.event("orchestrator-root", nil, TypeAgentStatusReported, `{"status":"working"}`)
+	s.append(env)
+
+	diverging := env
+	diverging.Type = TypeAgentFinished
+	diverging.Payload = json.RawMessage(`{"status":"working"}`)
+
+	if _, err := s.store.Append(context.Background(), diverging); !errors.Is(err, ErrClientEventIDConflict) {
+		t.Fatalf("Append error = %v, want a client event id conflict", err)
+	}
+}
+
+// The log is append-only. Nothing in the backend may rewrite a stored event.
+func TestEventRowsRejectUpdatesAndDeletes(t *testing.T) {
+	s := newScenario(t)
+	result := s.startRun()
+
+	err := s.db.Model(&Event{}).
+		Where("project_id = ? AND position = ?", s.projectID, result.Position).
+		Update("payload_hash", "tampered").Error
+	if !errors.Is(err, ErrEventLogImmutable) {
+		t.Errorf("updating an event returned %v, want %v", err, ErrEventLogImmutable)
+	}
+
+	err = s.db.Where("project_id = ? AND position = ?", s.projectID, result.Position).Delete(&Event{}).Error
+	if !errors.Is(err, ErrEventLogImmutable) {
+		t.Errorf("deleting an event returned %v, want %v", err, ErrEventLogImmutable)
+	}
+}

--- a/backend/internal/store/testsupport_test.go
+++ b/backend/internal/store/testsupport_test.go
@@ -1,0 +1,251 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"gorm.io/gorm"
+
+	"github.com/risqyy/visualise-ai/backend/internal/database"
+)
+
+// The store tests run against a real PostgreSQL instance: row locking, jsonb,
+// composite unique constraints and transaction rollback are exactly the
+// properties under test, and none of them can be demonstrated on a stand-in.
+//
+//	docker run -d --name vai-test-pg -e POSTGRES_PASSWORD=test \
+//	  -e POSTGRES_USER=test -e POSTGRES_DB=test -p 55432:5432 postgres:17-alpine
+//	TEST_DATABASE_URL='postgres://test:test@127.0.0.1:55432/test?sslmode=disable' \
+//	  go test ./internal/store/...
+//
+// Without TEST_DATABASE_URL every test in this package skips, so `go test ./...`
+// stays green on a machine without a database.
+const testDatabaseURLEnv = "TEST_DATABASE_URL"
+
+var (
+	migrateOnce sync.Once
+	migrateErr  error
+)
+
+// baseTime anchors the reported timestamps so assertions stay deterministic.
+var baseTime = time.Date(2026, 8, 4, 9, 0, 0, 0, time.UTC)
+
+func testDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dsn := strings.TrimSpace(os.Getenv(testDatabaseURLEnv))
+	if dsn == "" {
+		t.Skipf("%s is not set: skipping the PostgreSQL backed store tests", testDatabaseURLEnv)
+	}
+
+	db, err := database.Open(context.Background(), dsn, 30*time.Second, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("opening the test database: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := database.Close(db); closeErr != nil {
+			t.Errorf("closing the test database: %v", closeErr)
+		}
+	})
+
+	migrateOnce.Do(func() { migrateErr = Migrate(db) })
+	if migrateErr != nil {
+		t.Fatalf("migrating the test schema: %v", migrateErr)
+	}
+	truncateAll(t, db)
+	return db
+}
+
+// truncateAll empties every table so each test starts from a known state.
+func truncateAll(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	names := make([]string, 0, len(Models()))
+	for _, model := range Models() {
+		named, ok := model.(interface{ TableName() string })
+		if !ok {
+			t.Fatalf("model %T does not pin its table name", model)
+		}
+		names = append(names, `"`+named.TableName()+`"`)
+	}
+	if err := db.Exec("TRUNCATE " + strings.Join(names, ", ") + " RESTART IDENTITY CASCADE").Error; err != nil {
+		t.Fatalf("truncating the test schema: %v", err)
+	}
+}
+
+// scenario appends events for one project and keeps the reported timestamps
+// strictly increasing.
+type scenario struct {
+	t         *testing.T
+	db        *gorm.DB
+	store     *Store
+	projectID string
+	runID     string
+	seq       int
+}
+
+func newScenario(t *testing.T) *scenario {
+	t.Helper()
+	db := testDB(t)
+	return &scenario{
+		t:         t,
+		db:        db,
+		store:     New(db),
+		projectID: "visualise-ai",
+		runID:     "run-2026-08-04-0001",
+	}
+}
+
+func (s *scenario) nextTime() time.Time {
+	s.seq++
+	return baseTime.Add(time.Duration(s.seq) * time.Second)
+}
+
+// event builds an envelope for the scenario's project and run.
+func (s *scenario) event(agentID string, parent *string, evType, payload string) Envelope {
+	return Envelope{
+		ProjectID:     s.projectID,
+		ClientEventID: uuid.NewString(),
+		RunID:         s.runID,
+		AgentID:       agentID,
+		ParentAgentID: parent,
+		Type:          evType,
+		SchemaVersion: "1.0",
+		OccurredAt:    s.nextTime(),
+		Payload:       json.RawMessage(payload),
+	}
+}
+
+// append stores an envelope and fails the test when the store rejects it.
+func (s *scenario) append(env Envelope) Result {
+	s.t.Helper()
+	result, err := s.store.Append(context.Background(), env)
+	if err != nil {
+		s.t.Fatalf("appending %s: %v", env.Type, err)
+	}
+	return result
+}
+
+// emit is the common case: build an envelope and append it in one step.
+func (s *scenario) emit(agentID string, parent *string, evType, payload string) Result {
+	s.t.Helper()
+	return s.append(s.event(agentID, parent, evType, payload))
+}
+
+// startRun appends the root agent.started that opens the scenario's run.
+func (s *scenario) startRun() Result {
+	s.t.Helper()
+	return s.emit("orchestrator-root", nil, TypeAgentStarted, `{
+		"role": "orchestrator",
+		"displayName": "Root Orchestrator",
+		"assignedTask": "Deliver the v0 agent project cockpit."
+	}`)
+}
+
+// exampleEvent mirrors the envelope of the contract examples in api/examples.
+type exampleEvent struct {
+	SchemaVersion string          `json:"schemaVersion"`
+	ClientEventID string          `json:"clientEventId"`
+	ProjectID     string          `json:"projectId"`
+	RunID         string          `json:"runId"`
+	AgentID       string          `json:"agentId"`
+	ParentAgentID *string         `json:"parentAgentId"`
+	OccurredAt    time.Time       `json:"occurredAt"`
+	Type          string          `json:"type"`
+	Payload       json.RawMessage `json:"payload"`
+}
+
+// loadExample reads one of the contract examples and rebinds it to the
+// scenario, so contract and store are exercised against the same documents.
+func (s *scenario) loadExample(name string) Envelope {
+	s.t.Helper()
+
+	path := filepath.Join("..", "..", "..", "api", "examples", name)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		s.t.Fatalf("reading example %s: %v", name, err)
+	}
+	var example exampleEvent
+	if err := json.Unmarshal(raw, &example); err != nil {
+		s.t.Fatalf("decoding example %s: %v", name, err)
+	}
+
+	return Envelope{
+		ProjectID:     s.projectID,
+		ClientEventID: uuid.NewString(),
+		RunID:         s.runID,
+		AgentID:       example.AgentID,
+		ParentAgentID: example.ParentAgentID,
+		Type:          example.Type,
+		SchemaVersion: example.SchemaVersion,
+		OccurredAt:    s.nextTime(),
+		Payload:       example.Payload,
+	}
+}
+
+func (s *scenario) mustCount(model any, query string, args ...any) int64 {
+	s.t.Helper()
+	var count int64
+	if err := s.db.Model(model).Where(query, args...).Count(&count).Error; err != nil {
+		s.t.Fatalf("counting %T: %v", model, err)
+	}
+	return count
+}
+
+func (s *scenario) project() Project {
+	s.t.Helper()
+	var project Project
+	if err := s.db.Where("project_id = ?", s.projectID).Take(&project).Error; err != nil {
+		s.t.Fatalf("loading the project row: %v", err)
+	}
+	return project
+}
+
+func (s *scenario) run() Run {
+	s.t.Helper()
+	var run Run
+	if err := s.db.Where("project_id = ? AND run_id = ?", s.projectID, s.runID).Take(&run).Error; err != nil {
+		s.t.Fatalf("loading the run row: %v", err)
+	}
+	return run
+}
+
+func (s *scenario) agent(agentID string) Agent {
+	s.t.Helper()
+	var agent Agent
+	err := s.db.Where("project_id = ? AND run_id = ? AND agent_id = ?", s.projectID, s.runID, agentID).
+		Take(&agent).Error
+	if err != nil {
+		s.t.Fatalf("loading agent %q: %v", agentID, err)
+	}
+	return agent
+}
+
+func (s *scenario) component(componentID string) Component {
+	s.t.Helper()
+	var component Component
+	err := s.db.Where("project_id = ? AND component_id = ?", s.projectID, componentID).Take(&component).Error
+	if err != nil {
+		s.t.Fatalf("loading component %q: %v", componentID, err)
+	}
+	return component
+}
+
+func (s *scenario) activeChange(changeID string) ActiveChange {
+	s.t.Helper()
+	var change ActiveChange
+	if err := s.db.Where("project_id = ? AND change_id = ?", s.projectID, changeID).Take(&change).Error; err != nil {
+		s.t.Fatalf("loading change %q: %v", changeID, err)
+	}
+	return change
+}
+
+func ptr(value string) *string { return &value }

--- a/docs/decisions/0002-event-log-with-synchronous-projections.md
+++ b/docs/decisions/0002-event-log-with-synchronous-projections.md
@@ -1,0 +1,79 @@
+# 2. Immutable event log with synchronous projections in one transaction
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #4 (part of the v0 epic #1)
+- **Builds on:** [0001 — Compose topology and single entry point](./0001-compose-topology-and-single-entry-point.md)
+
+## Context
+
+The cockpit shows only what agents explicitly reported. The reported events are
+the audit source, but the UI cannot rebuild its whole view from the log on every
+request. v0 also rules out a queue, a broker and a separate worker, and runs
+exactly one backend instance.
+
+Two properties are non-negotiable:
+
+- A reader must never observe a read model that disagrees with the log.
+- A reconnecting SSE client must be able to replay from a position and receive
+  every committed event exactly once, in order.
+
+## Decision
+
+**One immutable log, projected synchronously, in a single transaction.**
+
+`store.Append` performs the entire write inside one `gorm` transaction:
+
+1. lock the project row,
+2. resolve idempotency,
+3. insert the `events` row,
+4. advance every affected projection,
+5. link the event to the components it touches.
+
+Any failure rolls back all five steps. A rejected event therefore leaves no
+trace and — importantly — does not consume a project position.
+
+**The project row is the position allocator.** `SELECT … FOR UPDATE` on
+`projects` serialises concurrent appends for that project; the next position is
+`last_position + 1`. A `max(position) + 1` without a lock would let two
+transactions read the same value and produce a gap or a duplicate. Positions are
+per project, monotonic and gapless, which is exactly what SSE replay needs as a
+cursor.
+
+**Idempotency is content based.** The payload is canonicalised (object keys
+sorted recursively, no insignificant whitespace) and hashed with SHA-256. The
+canonical form is what gets stored, so column and hash always describe the same
+document. A retry with a known `clientEventId` and an identical hash, type and
+schema version returns the original position untouched; a differing one is a
+conflict.
+
+**The log is append-only in the code, not only by convention.** `Event` carries
+`BeforeUpdate` and `BeforeDelete` hooks that fail with `ErrEventLogImmutable`.
+Corrections and retractions are new events referencing the original, never edits.
+
+**Planned changes never touch the applied model.** `*.change_planned` only
+records an `active_changes` row; `*.change_applied` is what mutates `components`
+and `relationships`. `architecture.snapshot_published` replaces both sets
+wholesale inside the same transaction.
+
+**GORM `AutoMigrate` on startup is the only schema authority.** It runs before
+the readiness flag is set, so a failed migration means the backend never reports
+ready and the Compose healthcheck never routes to it. There is no SQL migration
+engine and no rebuild command in v0.
+
+## Consequences
+
+- Ingestion latency includes the projection work. With one backend instance and
+  semantic (not raw) events, the volume is low enough that this is the right
+  trade for consistency.
+- Write throughput per project is serialised by design. Different projects do
+  not contend; parallel agents inside one project queue on the project row and
+  receive one comprehensible ordering, which is the stated requirement.
+- Adding a projection means changing the projector and re-deriving state is not
+  possible from the read models alone — but it is always possible from the log,
+  which is why the log stays immutable and complete.
+- `AutoMigrate` cannot add a `NOT NULL` column to a populated table without a
+  default. Every projection column therefore carries a database default. The
+  failure mode is loud rather than silent: the backend refuses to become ready.
+- Because projections are written in the same transaction, an SSE publisher can
+  safely be triggered *after* commit and never expose an uncommitted event.


### PR DESCRIPTION
Implements #4: the immutable PostgreSQL event log plus the synchronously
materialised read models. Everything lives in the new `backend/internal/store`
package; `cmd/server/main.go` only gains the `AutoMigrate` call.

## Scope

This PR is the persistence layer only. The `POST /api/v1/events` handler,
request validation, lifecycle rules and HTTP status codes belong to #5 and are
deliberately **not** part of this change — no Gin route was added.

## Data model

`store.Migrate` creates 22 tables via GORM `AutoMigrate`.

### Event log

| Table | Key | Notes |
| --- | --- | --- |
| `events` | PK `id` (uuid) | UNIQUE `(project_id, position)`, UNIQUE `(project_id, client_event_id)`; indexes `(project_id, position)`, `(project_id, run_id, position)`, `(project_id, agent_id, position)`, `(project_id, type, position)` |
| `event_corrections` | `(project_id, position)` | `kind` = `correction` or `retraction`, `target_client_event_id`, `reason`, `corrected_type` |
| `event_components` | `(project_id, position, component_id)` | index `(project_id, component_id, position)` — component history without a JSONB scan |

`events` is append-only. `BeforeUpdate` and `BeforeDelete` hooks return
`ErrEventLogImmutable`, so no code path in the backend can rewrite the log.

### Read models

`projects`, `runs`, `agents`, `plans`, `plan_revisions`, `plan_steps`,
`work_steps`, `components`, `relationships`, `active_changes`,
`feedback_entries`, `diffs`, `risks`, `problems`, plus the join tables
`feedback_components`, `diff_components`, `risk_components`,
`problem_components`, `work_step_components`. Every one of them carries
`last_applied_project_position`.

## Behaviour

- **Position assignment.** `Append` locks the `projects` row with
  `SELECT ... FOR UPDATE` (creating it first when the project is new) and
  derives `position = last_position + 1`. That row is the single serialisation
  point per project.
- **Atomicity.** Lock, assign position, insert event, advance every projection,
  fill `event_components` — all in one `gorm` transaction. Any error rolls the
  whole thing back, including the position.
- **Idempotency.** `payload_hash` is the SHA-256 of the canonical payload:
  object keys sorted recursively, no whitespace, numbers verbatim. A retry with
  a different key order still matches. Identical content returns
  `Result{Position: <original>, Duplicate: true}`; diverging content, type or
  schema version returns `ErrClientEventIDConflict` (typed as
  `*ClientEventIDConflictError`, carrying the existing position).
- **Projections.** All 20 catalogue types are handled; an unknown type is an
  error, never a silent no-op.
  - `*.change_planned` records an `active_changes` row in state `planned` and
    **does not** touch `components` or `relationships`.
  - `*.change_applied` merges the descriptor (`add` and `modify` upsert,
    `remove` deletes) and closes the change, creating it when `changeId` is
    absent or unknown.
  - `architecture.snapshot_published` deletes and re-inserts the project's
    components and relationships inside the same transaction.
  - `retraction.issued` sets the affected change to `retracted`; it deletes
    nothing and rewrites no history.
  - `correction.issued` is stored as a new event, linked in `event_corrections`,
    and its `correctedPayload` is projected under `correctedType`. The original
    event stays untouched.
  - `run.finished` closes the run. Without it a run stays open — no state is
    ever derived from silence.
  - Root `agent.started` (`role: orchestrator`, no `parentAgentId`) opens the
    run and sets `projects.current_run_id`.
- **Readiness.** `bootstrap()` runs `store.Migrate` before
  `MarkBootstrapped()`. A failing migration returns an error, so the instance
  never reports ready and the process exits non-zero.

## Tests

The tests need a real PostgreSQL: `FOR UPDATE`, jsonb, composite unique
constraints and transaction rollback cannot be demonstrated on a stand-in. They
read the DSN from `TEST_DATABASE_URL` and `t.Skip` when it is missing, so
`go test ./...` stays green without a database.

```bash
docker run -d --name vai-test-pg -e POSTGRES_PASSWORD=test \
  -e POSTGRES_USER=test -e POSTGRES_DB=test -p 55432:5432 postgres:17-alpine

cd backend
TEST_DATABASE_URL='postgres://test:test@127.0.0.1:55432/test?sslmode=disable' \
  go test ./...

docker rm -f vai-test-pg
```

Actual run against PostgreSQL 17:

```text
--- PASS: TestPayloadHashIsIndependentOfObjectKeyOrder (0.00s)
--- PASS: TestPayloadHashKeepsArrayOrderSignificant (0.00s)
--- PASS: TestCanonicalJSONStripsWhitespaceAndKeepsNumbers (0.00s)
--- PASS: TestCanonicalJSONRejectsBrokenDocuments (0.00s)
--- PASS: TestArchitectureSnapshotReplacesTheAppliedModel (0.46s)
--- PASS: TestComponentChangePlannedDoesNotTouchTheAppliedModel (0.07s)
--- PASS: TestComponentChangeAppliedUpdatesTheModelAndClosesThePlannedChange (0.08s)
--- PASS: TestRunStaysOpenUntilRunFinishedArrives (0.06s)
--- PASS: TestNestedAgentTreeIsProjected (0.08s)
--- PASS: TestLastAppliedProjectPositionAdvancesOnTouchedProjections (0.07s)
--- PASS: TestComponentHistoryIsOrderedByPosition (0.11s)
--- PASS: TestCorrectionProjectsTheCorrectedPayloadAndKeepsTheOriginal (0.09s)
--- PASS: TestRetractionMarksTheChangeAndKeepsTheLog (0.08s)
--- PASS: TestEveryCatalogueTypeIsProjected (0.23s)
--- PASS: TestAppendAssignsGaplessPositionsUnderConcurrency (0.91s)
--- PASS: TestAppendRollsBackEventAndProjectionsOnProjectionFailure (0.06s)
--- PASS: TestAppendIsIdempotentForAnIdenticalRetry (0.06s)
--- PASS: TestAppendRejectsAReusedClientEventIDWithDifferentContent (0.06s)
--- PASS: TestAppendRejectsAReusedClientEventIDWithADifferentType (0.06s)
--- PASS: TestEventRowsRejectUpdatesAndDeletes (0.05s)
PASS
ok  	github.com/risqyy/visualise-ai/backend/internal/store	4.412s
```

Without a database the suite still passes:

```text
?   	github.com/risqyy/visualise-ai/backend/cmd/server	[no test files]
ok  	github.com/risqyy/visualise-ai/backend/internal/config	0.656s
?   	github.com/risqyy/visualise-ai/backend/internal/database	[no test files]
ok  	github.com/risqyy/visualise-ai/backend/internal/health	0.652s
ok  	github.com/risqyy/visualise-ai/backend/internal/httpapi	1.896s
?   	github.com/risqyy/visualise-ai/backend/internal/logging	[no test files]
ok  	github.com/risqyy/visualise-ai/backend/internal/store	2.026s
```

`go build ./...`, `go vet ./...` and `gofmt -l .` are clean.

The concurrency test is not vacuous: removing the `FOR UPDATE` clause makes it
fail immediately.

```text
--- FAIL: TestAppendAssignsGaplessPositionsUnderConcurrency (0.59s)
    store_test.go:66: goroutine 0 failed: ERROR: duplicate key value violates
    unique constraint "uq_events_project_position" (SQLSTATE 23505)
```

The readiness gate was verified by hand as well. Against a fresh database:

```text
INF starting backend addr=:18080 version=dev
INF connected to postgres attempt=1
INF schema migrated
INF backend is ready
```

`GET /readyz` answered `200` and all 22 tables were present. Against a database
whose schema `AutoMigrate` cannot reconcile:

```text
INF starting backend addr=:18082 version=dev
INF connected to postgres attempt=1
ERR schema migration failed error="store: automigrate: ERROR: relation \"projects\" already exists (SQLSTATE 42P07)"
fatal: store: automigrate: ERROR: relation "projects" already exists (SQLSTATE 42P07)
exit status 1
```

Test fixtures reuse `api/examples/*.json` wherever possible, so contract and
store are exercised against the same documents.

## Notes

- New direct dependency `github.com/google/uuid` for the server-side event id.
- `event_components` and `event_corrections` do not carry a separate
  `last_applied_project_position`: their `position` column is part of the
  primary key and already is that value. Every other table has the column.
- Optional reported documents are stored as `{}` or `[]` rather than SQL NULL,
  so `technology`, `tags` and `snapshot` stay NOT NULL.
- An applied change without a `changeId` gets the server event id as its
  `change_id`, which is stable across replays.

Closes #4
