### PR TITLE
[v0] Projektbezogene HTTP Read API implementieren

### DIFF
--- a/api/.redocly.lint-ignore.yaml
+++ b/api/.redocly.lint-ignore.yaml
@@ -4,7 +4,12 @@
 #   /healthz and /readyz are internal container probes on the Go backend. They answer 200 or,
 #   for readiness, 503 — there is no meaningful client error for a probe. The rule stays
 #   enabled for every externally reachable operation.
+#
+#   GET /api/v1/projects takes no path parameter, no query parameter and no request body.
+#   There is nothing a client can get wrong about it, so any declared 4xx would be a lie.
+#   Every other read operation carries its 400 and 404 and the rule stays enforced for them.
 openapi.yaml:
   operation-4xx-response:
     - '#/paths/~1healthz/get/responses'
     - '#/paths/~1readyz/get/responses'
+    - '#/paths/~1api~1v1~1projects/get/responses'

--- a/api/README.md
+++ b/api/README.md
@@ -1,9 +1,9 @@
 # Event contract
 
-`openapi.yaml` is the single, versioned contract between the reporting agents and the
-Visualise AI cockpit. Everything the cockpit shows arrives through it; nothing is inferred.
+`openapi.yaml` is the single, versioned contract between the reporting agents, the Visualise
+AI cockpit and its UI. Everything the cockpit shows arrives through it; nothing is inferred.
 
-* **Document version** — `info.version` (`1.0.0`), OpenAPI 3.1.0.
+* **Document version** — `info.version` (`1.1.0`), OpenAPI 3.1.0.
 * **Payload version** — `schemaVersion` inside every event envelope. v0 accepts `1.0` only.
 
 ## Surface
@@ -12,9 +12,44 @@ Visualise AI cockpit. Everything the cockpit shows arrives through it; nothing i
 | --- | --- |
 | `POST /api/v1/events` | Single-event ingestion, idempotent on `clientEventId`. |
 | `GET /api/v1/projects/{projectId}/stream` | Server-Sent Events: replay from a position, then live. |
+| `GET /api/v1/projects` | Every known project. |
+| `GET /api/v1/projects/{projectId}` | One project with the sizes of its read models. |
+| `GET /api/v1/projects/{projectId}/architecture` | Applied components and relationships plus pending proposals. |
+| `GET /api/v1/projects/{projectId}/runs` | Current and historical runs, paged. |
+| `GET /api/v1/projects/{projectId}/runs/{runId}` | One run; `current` resolves to the current one. |
+| `GET /api/v1/projects/{projectId}/runs/{runId}/agents` | Flat agent tree of one run. |
+| `GET /api/v1/projects/{projectId}/runs/{runId}/plans` | Every plan of one run with all revisions. |
+| `GET /api/v1/projects/{projectId}/components/{componentId}` | Component inspector for exactly one run. |
+| `GET /api/v1/projects/{projectId}/components/{componentId}/history` | Run spanning component history, paged. |
 | `GET /healthz`, `GET /readyz` | Internal probes on the Go backend container. |
 
-The historical read API is specified separately and is not part of this document.
+## Read models
+
+The read endpoints answer from normalised projections the backend advances in the same
+transaction that appends the event. A client never queries the event log; the only place the
+log surfaces is the component history, and there as a paged, component filtered list.
+
+* **`projectPosition` is in every response.** It is the project position at the moment the
+  snapshot was read, so an HTTP snapshot and the SSE stream can be reconciled without guessing
+  which one is ahead. Every row additionally carries the position of the event that last wrote
+  it as `position`. On the project collection, which is not scoped to one project,
+  `projectPosition` is the highest position across the listed projects.
+* **Everything is scoped to one project.** No response ever carries a row of another project,
+  even when two projects reuse the same run, agent or component ids.
+* **Current run and history are separate views.** The inspector shows the evidence of exactly
+  one run — the one in `runId`, or the current one. `…/history` is the run spanning, paged
+  view. Neither mixes into the other.
+* **`activeChanges` means pending.** Only changes in state `planned` are listed: an applied
+  change *is* the model, a retracted one was withdrawn.
+* **Pagination.** `limit` defaults to 50 and maxes out at 200; a value outside that range is a
+  `400`, never a silently clamped page. `cursor` is opaque and echoed back unchanged. Runs, the
+  component history and the inspector's unified diffs (`diffLimit`, `diffCursor`,
+  `nextDiffCursor`) are paged; every other collection is complete.
+* **Errors follow RFC 9457** as on the write path, with the additional codes `run_not_found`,
+  `current_run_not_found`, `component_not_found` and `invalid_query_parameter`. A project whose
+  runs were never opened by a root orchestrator has no current run, and
+  `current_run_not_found` is distinct from `run_not_found` so a client can tell "no run yet"
+  from "wrong run id".
 
 ## How the contract is closed
 
@@ -86,6 +121,8 @@ Low-level tool calls, terminal commands, file reads and token usage are delibera
 | `diff-reported.json` | Single-file unified diff |
 | `correction-issued.json` | Correction of an earlier event |
 | `run-finished.json` | Optional terminal run event |
+| `architecture-read-model.json` | Read model of the applied architecture with two pending proposals |
+| `component-inspector.json` | Read model of one component in one run: feedback, diff, risk, problem, proposal |
 | `retry-idempotent-response.json` | `200` with `duplicate: true` |
 | `conflict-response.json` | `409` problem |
 | `validation-error-response.json` | `400` problem with field errors |
@@ -129,5 +166,6 @@ the simulator and the UI are built against.
 `redocly.yaml` extends the `recommended` ruleset with `struct: error` (the current name of the
 former `spec` rule). Two rules are switched off with a reason in the file: `info-license`
 (the repository declares no license) and `no-server-example.com` (the only entry point really
-is `http://localhost:8080`). `.redocly.lint-ignore.yaml` carries one narrow exception for the
-two internal probes, so `operation-4xx-response` stays enforced everywhere else.
+is `http://localhost:8080`). `.redocly.lint-ignore.yaml` carries narrow, documented exceptions
+for the two internal probes and for `GET /api/v1/projects`, which takes no parameter a client
+could get wrong; `operation-4xx-response` stays enforced everywhere else.

--- a/api/examples/architecture-read-model.json
+++ b/api/examples/architecture-read-model.json
@@ -1,0 +1,412 @@
+{
+  "projectPosition": 17,
+  "components": [
+    {
+      "componentId": "payment-provider",
+      "name": "Payment Provider",
+      "kind": "external",
+      "parentComponentId": null,
+      "description": "Third-party payment system outside the system boundary.",
+      "technology": {},
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform",
+      "name": "Shop Platform",
+      "kind": "system",
+      "parentComponentId": null,
+      "description": "The observed application. Root of the component hierarchy.",
+      "technology": {},
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.api-gateway",
+      "name": "API Gateway",
+      "kind": "service",
+      "parentComponentId": "shop-platform",
+      "description": "Single external entry point, terminates TLS and fans out to services.",
+      "technology": {
+        "runtime": "Go",
+        "version": "1.24",
+        "language": "Go",
+        "framework": "chi"
+      },
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.events",
+      "name": "Event Bus",
+      "kind": "queue",
+      "parentComponentId": "shop-platform",
+      "description": "NATS cluster. Each topic below is modelled as its own component.",
+      "technology": {
+        "runtime": "NATS",
+        "version": "2.10"
+      },
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.events.inventory-reserved",
+      "name": "inventory.item.reserved",
+      "kind": "topic",
+      "parentComponentId": "shop-platform.events",
+      "description": "Published once per successful stock reservation.",
+      "technology": {},
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.events.order-created",
+      "name": "orders.order.created",
+      "kind": "topic",
+      "parentComponentId": "shop-platform.events",
+      "description": "Published once per accepted order.",
+      "technology": {},
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.inventory",
+      "name": "Inventory Service",
+      "kind": "service",
+      "parentComponentId": "shop-platform",
+      "description": "Reserves and releases stock.",
+      "technology": {
+        "runtime": "Go",
+        "version": "1.24",
+        "language": "Go"
+      },
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.orders",
+      "name": "Orders Service",
+      "kind": "service",
+      "parentComponentId": "shop-platform",
+      "description": "Owns the order lifecycle.",
+      "technology": {
+        "runtime": "Go",
+        "version": "1.24",
+        "language": "Go"
+      },
+      "tags": [
+        "core-domain"
+      ],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.orders-db",
+      "name": "Orders Database",
+      "kind": "datastore",
+      "parentComponentId": "shop-platform",
+      "description": "Relational store owned exclusively by the orders service.",
+      "technology": {
+        "runtime": "PostgreSQL",
+        "version": "17"
+      },
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.orders.api",
+      "name": "Orders API Layer",
+      "kind": "module",
+      "parentComponentId": "shop-platform.orders",
+      "description": "gRPC handlers and request mapping.",
+      "technology": {},
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.orders.domain",
+      "name": "Orders Domain Layer",
+      "kind": "module",
+      "parentComponentId": "shop-platform.orders",
+      "description": "Order aggregate, invariants and state machine.",
+      "technology": {},
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.orders.domain.pricing",
+      "name": "Pricing",
+      "kind": "module",
+      "parentComponentId": "shop-platform.orders.domain",
+      "description": "Fourth hierarchy level: discount and tax calculation inside the domain layer.",
+      "technology": {},
+      "tags": [
+        "pricing"
+      ],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.orders.domain.tax",
+      "name": "Tax Calculation",
+      "kind": "module",
+      "parentComponentId": "shop-platform.orders.domain",
+      "description": "VAT rules per delivery country, extracted from the pricing module.",
+      "technology": {
+        "runtime": "Go",
+        "version": "1.24",
+        "language": "Go"
+      },
+      "tags": [
+        "pricing",
+        "tax"
+      ],
+      "appliedAt": "2026-08-04T09:00:12Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 12
+    },
+    {
+      "componentId": "shop-platform.orders.persistence",
+      "name": "Orders Persistence Layer",
+      "kind": "module",
+      "parentComponentId": "shop-platform.orders",
+      "description": "Repository implementations and SQL migrations.",
+      "technology": {},
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.shared-money",
+      "name": "Shared Money Library",
+      "kind": "library",
+      "parentComponentId": "shop-platform",
+      "description": "Currency and amount value objects shared across services.",
+      "technology": {
+        "language": "Go"
+      },
+      "tags": [],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "componentId": "shop-platform.storefront",
+      "name": "Storefront",
+      "kind": "ui",
+      "parentComponentId": "shop-platform",
+      "description": "Customer-facing single page application.",
+      "technology": {
+        "runtime": "Browser",
+        "version": "19",
+        "language": "TypeScript",
+        "framework": "React"
+      },
+      "tags": [
+        "frontend",
+        "public"
+      ],
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    }
+  ],
+  "relationships": [
+    {
+      "relationshipId": "rel-gateway-orders-grpc",
+      "sourceComponentId": "shop-platform.api-gateway",
+      "targetComponentId": "shop-platform.orders.api",
+      "kind": "grpc",
+      "label": "Place order",
+      "protocol": "gRPC/HTTP2",
+      "operation": "orders.v1.OrderService/PlaceOrder",
+      "channel": "",
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "relationshipId": "rel-inventory-consumes-order-created",
+      "sourceComponentId": "shop-platform.events.order-created",
+      "targetComponentId": "shop-platform.inventory",
+      "kind": "nats_topic",
+      "label": "consumes",
+      "protocol": "NATS",
+      "operation": "",
+      "channel": "orders.order.created",
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "relationshipId": "rel-inventory-publishes-inventory-reserved",
+      "sourceComponentId": "shop-platform.inventory",
+      "targetComponentId": "shop-platform.events.inventory-reserved",
+      "kind": "nats_topic",
+      "label": "publishes",
+      "protocol": "NATS",
+      "operation": "",
+      "channel": "inventory.item.reserved",
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "relationshipId": "rel-orders-payment-async",
+      "sourceComponentId": "shop-platform.orders",
+      "targetComponentId": "payment-provider",
+      "kind": "async",
+      "label": "Payment settlement callbacks",
+      "protocol": "webhook",
+      "operation": "POST /callbacks/payment",
+      "channel": "",
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "relationshipId": "rel-orders-persistence-data",
+      "sourceComponentId": "shop-platform.orders.persistence",
+      "targetComponentId": "shop-platform.orders-db",
+      "kind": "data",
+      "label": "Order aggregate storage",
+      "protocol": "postgresql",
+      "operation": "SELECT/INSERT/UPDATE orders",
+      "channel": "",
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "relationshipId": "rel-orders-publishes-order-created",
+      "sourceComponentId": "shop-platform.orders",
+      "targetComponentId": "shop-platform.events.order-created",
+      "kind": "nats_topic",
+      "label": "publishes",
+      "protocol": "NATS",
+      "operation": "",
+      "channel": "orders.order.created",
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "relationshipId": "rel-pricing-shared-money-dependency",
+      "sourceComponentId": "shop-platform.orders.domain.pricing",
+      "targetComponentId": "shop-platform.shared-money",
+      "kind": "dependency",
+      "label": "Money value objects",
+      "protocol": "",
+      "operation": "",
+      "channel": "",
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    },
+    {
+      "relationshipId": "rel-storefront-gateway-http",
+      "sourceComponentId": "shop-platform.storefront",
+      "targetComponentId": "shop-platform.api-gateway",
+      "kind": "http",
+      "label": "Browse and place orders",
+      "protocol": "HTTPS",
+      "operation": "GET /orders",
+      "channel": "",
+      "appliedAt": "2026-08-04T09:00:05Z",
+      "appliedByAgentId": "subagent-architecture-mapper",
+      "appliedRunId": "run-2026-08-04-0001",
+      "position": 5
+    }
+  ],
+  "activeChanges": [
+    {
+      "changeId": "change-2026-08-04-0009",
+      "targetKind": "relationship",
+      "targetId": "rel-pricing-tax",
+      "operation": "add",
+      "state": "planned",
+      "runId": "run-2026-08-04-0001",
+      "agentId": "subagent-architecture-mapper",
+      "plannedAt": "2026-08-04T09:00:17Z",
+      "appliedAt": null,
+      "retractedAt": null,
+      "snapshot": {
+        "kind": "dependency",
+        "label": "Delegates VAT calculation",
+        "relationshipId": "rel-pricing-tax",
+        "sourceComponentId": "shop-platform.orders.domain.pricing",
+        "targetComponentId": "shop-platform.orders.domain.tax"
+      },
+      "position": 17
+    },
+    {
+      "changeId": "change-2026-08-04-0008",
+      "targetKind": "component",
+      "targetId": "shop-platform.orders.domain.pricing",
+      "operation": "modify",
+      "state": "planned",
+      "runId": "run-2026-08-04-0001",
+      "agentId": "subagent-architecture-mapper",
+      "plannedAt": "2026-08-04T09:00:16Z",
+      "appliedAt": null,
+      "retractedAt": null,
+      "snapshot": {
+        "kind": "module",
+        "name": "Pricing",
+        "tags": [
+          "pricing"
+        ],
+        "componentId": "shop-platform.orders.domain.pricing",
+        "description": "Discount calculation only; VAT now lives in the tax module.",
+        "parentComponentId": "shop-platform.orders.domain"
+      },
+      "position": 16
+    }
+  ]
+}

--- a/api/examples/component-inspector.json
+++ b/api/examples/component-inspector.json
@@ -1,0 +1,122 @@
+{
+  "projectPosition": 17,
+  "runId": "run-2026-08-04-0001",
+  "component": {
+    "componentId": "shop-platform.orders.domain.pricing",
+    "name": "Pricing",
+    "kind": "module",
+    "parentComponentId": "shop-platform.orders.domain",
+    "description": "Fourth hierarchy level: discount and tax calculation inside the domain layer.",
+    "technology": {},
+    "tags": [
+      "pricing"
+    ],
+    "appliedAt": "2026-08-04T09:00:05Z",
+    "appliedByAgentId": "subagent-architecture-mapper",
+    "appliedRunId": "run-2026-08-04-0001",
+    "position": 5
+  },
+  "responsibleAgent": {
+    "agentId": "subagent-implementer",
+    "runId": "run-2026-08-04-0001",
+    "parentAgentId": "orchestrator-root",
+    "role": "subagent",
+    "displayName": "Implementer",
+    "assignedTask": "Move VAT handling out of the pricing module.",
+    "status": "working",
+    "statusNote": "Rewriting Total().",
+    "progress": {
+      "percent": 70,
+      "scope": "own_task",
+      "basis": "completed_steps"
+    },
+    "finishedOutcome": null,
+    "startedAt": "2026-08-04T09:00:03Z",
+    "lastEventAt": "2026-08-04T09:00:11Z",
+    "position": 11
+  },
+  "currentWorkStep": {
+    "workStepId": "work-extract-tax",
+    "runId": "run-2026-08-04-0001",
+    "agentId": "subagent-implementer",
+    "planStepId": "step-extract",
+    "title": "Move VAT handling into its own module",
+    "startedAt": "2026-08-04T09:00:08Z",
+    "completedAt": null,
+    "summary": null,
+    "position": 8
+  },
+  "feedback": [
+    {
+      "feedbackId": "feedback-2026-08-04-0003",
+      "runId": "run-2026-08-04-0001",
+      "agentId": "subagent-reviewer",
+      "format": "markdown",
+      "title": "VAT extraction leaves the discount order undefined",
+      "body": "## What I looked at\n\nThe extraction of VAT handling out of `pricing` into the new `tax` module.\n\n## What stands out\n\n1. **Order of operations is now implicit.** `Total` applies tax before the discount, while the\n   old code applied the flat 19 % rate after summing net lines. For percentage discounts this\n   changes the result.\n2. **No rounding rule is stated.** `tax.For(country).Apply(sum)` returns a `money.Amount`, but\n   nothing documents whether it rounds half-up per line or per order.\n\n## Suggestion\n\nMake the sequence explicit and cover it with a table test:\n\n```go\nnet := order.NetTotal()\ndiscounted := net.Sub(p.discountFor(order))\ntotal := discounted.Add(tax.For(order.DeliveryCountry).Apply(discounted))\n```\n\nThis is a reported observation, not a measured defect.\n",
+      "createdAt": "2026-08-04T09:00:13Z",
+      "position": 13
+    }
+  ],
+  "diffs": [
+    {
+      "diffId": "diff-2026-08-04-0011",
+      "runId": "run-2026-08-04-0001",
+      "agentId": "subagent-implementer",
+      "changeId": "change-2026-08-04-0007",
+      "filePath": "internal/orders/domain/pricing/pricing.go",
+      "unifiedDiff": "--- a/internal/orders/domain/pricing/pricing.go\n+++ b/internal/orders/domain/pricing/pricing.go\n@@ -1,6 +1,7 @@\n package pricing\n \n import (\n \t\"shop-platform/internal/shared/money\"\n+\t\"shop-platform/internal/orders/domain/tax\"\n )\n \n@@ -18,11 +19,9 @@ func (p *Pricing) Total(order Order) money.Amount {\n \tsum := money.Zero(order.Currency)\n \tfor _, line := range order.Lines {\n \t\tsum = sum.Add(line.Net)\n \t}\n-\n-\tvat := sum.MultiplyFloat(0.19)\n-\tsum = sum.Add(vat)\n+\tsum = sum.Add(tax.For(order.DeliveryCountry).Apply(sum))\n \n \treturn sum.Sub(p.discountFor(order))\n }\n",
+      "createdAt": "2026-08-04T09:00:11Z",
+      "position": 11
+    }
+  ],
+  "nextDiffCursor": null,
+  "risks": [
+    {
+      "riskId": "risk-2026-08-04-0002",
+      "runId": "run-2026-08-04-0001",
+      "agentId": "subagent-reviewer",
+      "title": "Rounding rule of the extracted VAT calculation is undocumented",
+      "detail": "Neither the diff nor the module doc states whether rounding happens per line or per order.",
+      "severity": "medium",
+      "createdAt": "2026-08-04T09:00:14Z",
+      "position": 14
+    }
+  ],
+  "problems": [
+    {
+      "problemId": "problem-2026-08-04-0001",
+      "runId": "run-2026-08-04-0001",
+      "agentId": "subagent-reviewer",
+      "title": "The pricing table test no longer compiles",
+      "detail": "pricing_test.go still constructs the removed vat field.",
+      "createdAt": "2026-08-04T09:00:15Z",
+      "position": 15
+    }
+  ],
+  "activeChanges": [
+    {
+      "changeId": "change-2026-08-04-0008",
+      "targetKind": "component",
+      "targetId": "shop-platform.orders.domain.pricing",
+      "operation": "modify",
+      "state": "planned",
+      "runId": "run-2026-08-04-0001",
+      "agentId": "subagent-architecture-mapper",
+      "plannedAt": "2026-08-04T09:00:16Z",
+      "appliedAt": null,
+      "retractedAt": null,
+      "snapshot": {
+        "kind": "module",
+        "name": "Pricing",
+        "tags": [
+          "pricing"
+        ],
+        "componentId": "shop-platform.orders.domain.pricing",
+        "description": "Discount calculation only; VAT now lives in the tax module.",
+        "parentComponentId": "shop-platform.orders.domain"
+      },
+      "position": 16
+    }
+  ]
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -961,12 +961,21 @@ components:
       description: |
         The event is well-formed and schema-valid but contradicts the current state of the
         project. Codes: `unknown_agent`, `run_already_finished`, `run_not_started`,
-        `parent_agent_unknown`, `terminal_event_not_allowed`, `correction_target_unknown`.
+        `run_already_started`, `parent_agent_unknown`, `terminal_event_not_allowed`,
+        `correction_target_unknown`.
       content:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/Problem'
           examples:
+            runAlreadyStarted:
+              summary: A second root agent.started for a run that already exists
+              value:
+                type: 'https://visualise-ai.local/problems/run-already-started'
+                title: Run already started
+                status: 422
+                detail: Run "run-2026-08-04-0001" was already opened by a root agent.started in this project.
+                code: run_already_started
             runAlreadyFinished:
               summary: Work event after run.finished
               value:
@@ -2642,7 +2651,7 @@ components:
             `unsupported_event_type`, `unsupported_schema_version`,
             `client_event_id_conflict`, `event_too_large`, `unsupported_media_type`,
             `unknown_agent`, `run_already_finished`, `run_not_started`,
-            `parent_agent_unknown`, `terminal_event_not_allowed`,
+            `run_already_started`, `parent_agent_unknown`, `terminal_event_not_allowed`,
             `correction_target_unknown`, `project_not_found`, `run_not_found`,
             `current_run_not_found`, `component_not_found`, `invalid_query_parameter` or
             `not_ready`.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2,8 +2,8 @@ openapi: 3.1.0
 
 info:
   title: Visualise AI — Agent Cockpit Event Contract
-  version: 1.0.0
-  summary: Versioned contract for agent event ingestion and project event streaming.
+  version: 1.1.0
+  summary: Versioned contract for agent event ingestion, project event streaming and the read models.
   description: |
     The Visualise AI Agent Cockpit is fed exclusively by this contract. An orchestrator and
     its subagents report **semantic work steps**; the cockpit is observing and read-only and
@@ -15,10 +15,26 @@ info:
     | --- | --- |
     | `POST /api/v1/events` | Single-event ingestion, idempotent per `clientEventId`. |
     | `GET /api/v1/projects/{projectId}/stream` | Server-Sent Events: gap-free replay followed by the live stream. |
+    | `GET /api/v1/projects` … `GET /api/v1/projects/{projectId}/components/{componentId}/history` | Project scoped read models: projects, architecture, runs, agents, plans and component evidence. |
     | `GET /healthz`, `GET /readyz` | Internal container probes, not reachable from outside the Compose network. |
 
-    The historical read API (paged history and materialised snapshots over plain HTTP) is
-    specified separately and is deliberately **not** part of this document.
+    ## The read models
+
+    The read endpoints answer from normalised projections the backend advances in the same
+    transaction that appends the event. A client never queries the event log; the only place
+    the log is exposed is the component history, and there as a paged, component filtered list.
+
+    Three rules hold for every read response:
+
+    * **`projectPosition` is always present.** It is the server side project position at the
+      moment the snapshot was read, so an HTTP snapshot and the SSE stream can be reconciled
+      without guessing which one is ahead. Every row additionally carries the position of the
+      event that last wrote it as `position`.
+    * **Everything is scoped to one project.** A response never contains a row of another
+      project, even when two projects reuse the same run, agent or component identifiers.
+    * **Current run and history are separate views.** The component inspector shows the
+      evidence of exactly one run; `…/components/{componentId}/history` is the run spanning,
+      paged view. Neither ever mixes into the other.
 
     ## Versioning
 
@@ -76,6 +92,11 @@ tags:
   - name: Streaming
     description: |
       Read path used by the cockpit UI. Server-Sent Events with replay from a known position.
+  - name: Read models
+    description: |
+      Project scoped HTTP snapshots the cockpit renders from: projects, the applied
+      architecture, runs, agents, plans and component evidence. Answered from the normalised
+      projections, never from the event log.
   - name: Operations
     description: |
       Container probes for the internal Go backend. Not exposed through the Nginx frontend.
@@ -260,6 +281,441 @@ paths:
         '404':
           $ref: '#/components/responses/ProjectNotFound'
 
+  /api/v1/projects:
+    get:
+      tags:
+        - Read models
+      operationId: listProjects
+      summary: List every known project
+      description: |
+        Lists every project the backend has accepted an event for, ordered by `projectId`.
+
+        This is the only read endpoint that is not scoped to a single project, so its
+        `projectPosition` is the highest position across the listed projects. The value a
+        client needs for reconciling one project is repeated on every entry as `lastPosition`.
+      responses:
+        '200':
+          description: |
+            The known projects. Empty, with `projectPosition: 0`, before the first event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectListResponse'
+              examples:
+                projects:
+                  summary: One observed project with an open run
+                  value:
+                    projectPosition: 17
+                    projects:
+                      - projectId: visualise-ai
+                        firstSeenAt: '2026-08-04T09:00:01Z'
+                        lastEventAt: '2026-08-04T09:00:17Z'
+                        lastPosition: 17
+                        currentRunId: run-2026-08-04-0001
+
+  /api/v1/projects/{projectId}:
+    get:
+      tags:
+        - Read models
+      operationId: getProject
+      summary: Get one project with the sizes of its read models
+      description: |
+        Returns the project head row together with the sizes of its read models, so the shell
+        can render its navigation without fetching every collection first.
+
+        `counts.activeChanges` counts pending proposals only — see the architecture endpoint.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+      responses:
+        '200':
+          description: The project.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+              examples:
+                project:
+                  summary: Project with an open run and a mapped architecture
+                  value:
+                    projectPosition: 17
+                    project:
+                      projectId: visualise-ai
+                      firstSeenAt: '2026-08-04T09:00:01Z'
+                      lastEventAt: '2026-08-04T09:00:17Z'
+                      lastPosition: 17
+                      currentRunId: run-2026-08-04-0001
+                      counts:
+                        runs: 1
+                        openRuns: 1
+                        components: 16
+                        relationships: 8
+                        activeChanges: 2
+        '404':
+          $ref: '#/components/responses/ProjectNotFound'
+
+  /api/v1/projects/{projectId}/architecture:
+    get:
+      tags:
+        - Read models
+      operationId: getProjectArchitecture
+      summary: Get the applied architecture model and the pending proposals
+      description: |
+        Returns the **applied** architecture model — every component and every relationship the
+        project currently has — plus the change proposals that are still pending.
+
+        The two are kept strictly apart:
+
+        * `components` and `relationships` are what `architecture.snapshot_published` and the
+          `*.change_applied` events produced. Every NATS topic keeps its own relationship; edges
+          are never aggregated server side.
+        * `activeChanges` holds the changes in state `planned`. An applied change *is* the model
+          and a retracted change was withdrawn, so neither is active any more. A planned change
+          never modifies `components` or `relationships`.
+
+        The component hierarchy is expressed exclusively through `parentComponentId`; the list
+        itself is flat and ordered by `componentId`, which makes the layout deterministic.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+      responses:
+        '200':
+          description: The applied model and the pending proposals.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArchitectureResponse'
+              examples:
+                architecture:
+                  summary: Four hierarchy levels, every relationship kind, three separate NATS topics
+                  externalValue: './examples/architecture-read-model.json'
+        '404':
+          $ref: '#/components/responses/ProjectNotFound'
+
+  /api/v1/projects/{projectId}/runs:
+    get:
+      tags:
+        - Read models
+      operationId: listProjectRuns
+      summary: List current and historical runs
+      description: |
+        Lists the runs of one project, descending by reported start time. Current and
+        historical runs appear in the same list; `isOpen` and `isCurrent` distinguish them.
+
+        A run stays open until an explicit `run.finished` closes it — silence never produces a
+        terminal state, so an abandoned run keeps `isOpen: true` and its last reported values.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/CursorQuery'
+      responses:
+        '200':
+          description: One page of runs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunListResponse'
+              examples:
+                runs:
+                  summary: A single open run
+                  value:
+                    projectPosition: 17
+                    runs:
+                      - runId: run-2026-08-04-0001
+                        rootAgentId: orchestrator-root
+                        startedAt: '2026-08-04T09:00:01Z'
+                        finishedAt: null
+                        outcome: null
+                        isOpen: true
+                        isCurrent: true
+                        position: 17
+                    nextCursor: null
+        '400':
+          $ref: '#/components/responses/InvalidQueryParameter'
+        '404':
+          $ref: '#/components/responses/ProjectNotFound'
+
+  /api/v1/projects/{projectId}/runs/{runId}:
+    get:
+      tags:
+        - Read models
+      operationId: getProjectRun
+      summary: Get one run, or the current one
+      description: |
+        Returns one run together with the sizes of the collections hanging off it.
+
+        The literal `current` resolves to the run a root orchestrator opened last. A project
+        that never saw a root orchestrator has no current run, which is reported as `404` with
+        the distinct code `current_run_not_found` — "no run yet" is not the same failure as
+        "this run id is wrong".
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/RunIdPath'
+      responses:
+        '200':
+          description: The run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunResponse'
+              examples:
+                currentRun:
+                  summary: The current, open run
+                  value:
+                    projectPosition: 17
+                    run:
+                      runId: run-2026-08-04-0001
+                      rootAgentId: orchestrator-root
+                      startedAt: '2026-08-04T09:00:01Z'
+                      finishedAt: null
+                      outcome: null
+                      isOpen: true
+                      isCurrent: true
+                      position: 17
+                      counts:
+                        agents: 4
+                        plans: 1
+                        workSteps: 1
+        '404':
+          $ref: '#/components/responses/RunNotFound'
+
+  /api/v1/projects/{projectId}/runs/{runId}/agents:
+    get:
+      tags:
+        - Read models
+      operationId: listRunAgents
+      summary: Get the agent tree of one run
+      description: |
+        Returns every agent of one run as a **flat list**; the tree is expressed through
+        `parentAgentId`. A flat list keeps arbitrarily deep spawn chains renderable without the
+        server committing to a nesting depth.
+
+        Entries are ordered by start time, so a parent always precedes the subagents it
+        spawned and a consumer can build the tree in a single pass.
+
+        Reported values stay where they were reported: `status` is empty until the agent sent
+        `agent.status_reported`, `progress` is `null` until it reported a number itself, and
+        `finishedOutcome` is `null` until it sent `agent.finished`. Nothing is derived from
+        silence. `progress.scope` separates a subagent's own task from an orchestrator's
+        overall estimate.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/RunIdPath'
+      responses:
+        '200':
+          description: Every agent of the run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentListResponse'
+              examples:
+                agentTree:
+                  summary: Root orchestrator with two subagents and one nested subagent
+                  value:
+                    projectPosition: 17
+                    agents:
+                      - agentId: orchestrator-root
+                        runId: run-2026-08-04-0001
+                        parentAgentId: null
+                        role: orchestrator
+                        displayName: Root Orchestrator
+                        assignedTask: Extract VAT handling out of pricing.
+                        status: ''
+                        statusNote: ''
+                        progress: null
+                        finishedOutcome: null
+                        startedAt: '2026-08-04T09:00:01Z'
+                        lastEventAt: '2026-08-04T09:00:06Z'
+                        position: 6
+                      - agentId: subagent-implementer
+                        runId: run-2026-08-04-0001
+                        parentAgentId: orchestrator-root
+                        role: subagent
+                        displayName: Implementer
+                        assignedTask: Move VAT handling out of the pricing module.
+                        status: working
+                        statusNote: Rewriting Total().
+                        progress:
+                          percent: 70
+                          scope: own_task
+                          basis: completed_steps
+                        finishedOutcome: null
+                        startedAt: '2026-08-04T09:00:03Z'
+                        lastEventAt: '2026-08-04T09:00:11Z'
+                        position: 11
+                      - agentId: subagent-reviewer
+                        runId: run-2026-08-04-0001
+                        parentAgentId: subagent-implementer
+                        role: subagent
+                        displayName: Reviewer
+                        assignedTask: Review the extraction.
+                        status: ''
+                        statusNote: ''
+                        progress: null
+                        finishedOutcome: null
+                        startedAt: '2026-08-04T09:00:04Z'
+                        lastEventAt: '2026-08-04T09:00:15Z'
+                        position: 15
+        '404':
+          $ref: '#/components/responses/RunNotFound'
+
+  /api/v1/projects/{projectId}/runs/{runId}/plans:
+    get:
+      tags:
+        - Read models
+      operationId: listRunPlans
+      summary: Get every plan of one run with all of its revisions
+      description: |
+        Returns every plan of one run together with **all** of its revisions and their steps.
+
+        Revisions are append-only: publishing a new revision never rewrites an earlier one, and
+        a `plan.step_updated` only reaches the revision that was current when it was reported.
+        An earlier revision therefore keeps exactly the step states it was last seen with,
+        which is what makes a plan change reviewable rather than invisible.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/RunIdPath'
+      responses:
+        '200':
+          description: Every plan of the run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanListResponse'
+              examples:
+                plans:
+                  summary: One plan with a single revision
+                  value:
+                    projectPosition: 17
+                    plans:
+                      - planId: plan-2026-08-04-0001
+                        runId: run-2026-08-04-0001
+                        agentId: orchestrator-root
+                        currentRevision: 1
+                        position: 6
+                        revisions:
+                          - revision: 1
+                            createdAt: '2026-08-04T09:00:06Z'
+                            createdByAgentId: orchestrator-root
+                            isCurrent: true
+                            position: 6
+                            steps:
+                              - stepId: step-extract
+                                order: 0
+                                title: Extract the tax module
+                                state: in_progress
+                                position: 6
+        '404':
+          $ref: '#/components/responses/RunNotFound'
+
+  /api/v1/projects/{projectId}/components/{componentId}:
+    get:
+      tags:
+        - Read models
+      operationId: getComponentInspector
+      summary: Get the component inspector for one run
+      description: |
+        Returns everything the inspector shows for one component: the applied descriptor, the
+        responsible agent, the current work step and the component scoped feedback, unified
+        diffs, risks, problems and pending proposals.
+
+        The response carries the evidence of **exactly one run** — the one named by `runId`, or
+        the current run when the parameter is omitted. Evidence of other runs is never mixed
+        in; the run spanning view is `…/history`.
+
+        `component` is `null` when the component left the applied model, for example after a
+        `remove` or a snapshot that no longer lists it. Its evidence and its history survive,
+        which is why that case is a body with `component: null` and not a `404`. A component
+        the project never mentioned at all is a `404`.
+
+        `responsibleAgent` is read from evidence rather than guessed: it is the agent of
+        `currentWorkStep`, or — when no work step named this component in this run — the agent
+        that applied the component in this run. Otherwise it is `null`.
+
+        Unified diffs are paged, because one component can accumulate more of them than a
+        single response should carry; every other collection is complete. See `diffLimit` and
+        `diffCursor`.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/ComponentIdPath'
+        - $ref: '#/components/parameters/RunIdQuery'
+        - $ref: '#/components/parameters/DiffLimitQuery'
+        - $ref: '#/components/parameters/DiffCursorQuery'
+      responses:
+        '200':
+          description: The component evidence of one run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComponentInspectorResponse'
+              examples:
+                inspector:
+                  summary: Feedback, one unified diff, a risk, a problem and a pending proposal
+                  externalValue: './examples/component-inspector.json'
+        '400':
+          $ref: '#/components/responses/InvalidQueryParameter'
+        '404':
+          $ref: '#/components/responses/ComponentNotFound'
+
+  /api/v1/projects/{projectId}/components/{componentId}/history:
+    get:
+      tags:
+        - Read models
+      operationId: getComponentHistory
+      summary: Page through everything ever reported about one component
+      description: |
+        Returns every event that touched one component, **across all runs** of the project,
+        descending by project position. Each entry names the run it belongs to, so the UI can
+        separate the current run from older evidence without a second request.
+
+        Entries are the reported events as they were stored. Corrections and retractions appear
+        as their own entries: the log is append-only and nothing is ever overwritten, so a
+        withdrawn statement stays visible as history rather than disappearing.
+
+        The list is served from the component index the backend maintains for exactly this
+        purpose; it is not a scan over event payloads.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/ComponentIdPath'
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/CursorQuery'
+      responses:
+        '200':
+          description: One page of component history.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComponentHistoryResponse'
+              examples:
+                history:
+                  summary: The newest two entries, with a cursor for the next page
+                  value:
+                    projectPosition: 17
+                    entries:
+                      - position: 17
+                        serverEventId: ad74501c-924e-432c-a604-3c100777a230
+                        clientEventId: be4032f2-4d1d-4715-ac62-a2dfc2fcff0a
+                        runId: run-2026-08-04-0001
+                        agentId: subagent-architecture-mapper
+                        parentAgentId: null
+                        type: relationship.change_planned
+                        schemaVersion: '1.0'
+                        occurredAt: '2026-08-04T09:00:17Z'
+                        receivedAt: '2026-08-04T07:10:36.220858Z'
+                        payload:
+                          changeId: change-2026-08-04-0009
+                          operation: add
+                          rationale: Pricing will call into the new tax module.
+                          relationship:
+                            relationshipId: rel-pricing-tax
+                            sourceComponentId: shop-platform.orders.domain.pricing
+                            targetComponentId: shop-platform.orders.domain.tax
+                            kind: dependency
+                            label: Delegates VAT calculation
+                    nextCursor: djF8MTY
+        '400':
+          $ref: '#/components/responses/InvalidQueryParameter'
+        '404':
+          $ref: '#/components/responses/ComponentNotFound'
+
   /healthz:
     get:
       tags:
@@ -325,9 +781,91 @@ components:
       name: projectId
       in: path
       required: true
-      description: Project whose event stream is requested.
+      description: Project the request is scoped to.
       schema:
         $ref: '#/components/schemas/ProjectId'
+
+    RunIdPath:
+      name: runId
+      in: path
+      required: true
+      description: |
+        Run inside the project, or the literal `current` for the run a root orchestrator opened
+        last. The alias wins over a run that happens to carry that identifier: the default view
+        of the cockpit must not depend on how an agent named its run.
+      schema:
+        $ref: '#/components/schemas/RunId'
+      example: current
+
+    ComponentIdPath:
+      name: componentId
+      in: path
+      required: true
+      description: Component of the project's architecture model.
+      schema:
+        $ref: '#/components/schemas/ComponentId'
+
+    RunIdQuery:
+      name: runId
+      in: query
+      required: false
+      description: |
+        Run the component evidence is read from. Omitted means the current run; `current` means
+        the same thing explicitly. Any other value must name a run of this project, otherwise
+        the request is rejected with `404` and code `run_not_found` rather than silently falling
+        back to the current run.
+      schema:
+        $ref: '#/components/schemas/RunId'
+      example: run-2026-08-04-0001
+
+    LimitQuery:
+      name: limit
+      in: query
+      required: false
+      description: |
+        Number of entries per page. Defaults to 50, maximum 200. A value outside that range is
+        rejected with `400` rather than clamped, so a client cannot believe it received
+        everything.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+      example: 50
+
+    CursorQuery:
+      name: cursor
+      in: query
+      required: false
+      description: |
+        Continuation token of the previous page, taken from its `nextCursor`. Opaque: it is
+        echoed back unchanged and its encoding is free to change.
+      schema:
+        $ref: '#/components/schemas/Cursor'
+
+    DiffLimitQuery:
+      name: diffLimit
+      in: query
+      required: false
+      description: |
+        Number of unified diffs in the component inspector. Defaults to 50, maximum 200; a value
+        outside that range is rejected with `400`.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+      example: 50
+
+    DiffCursorQuery:
+      name: diffCursor
+      in: query
+      required: false
+      description: |
+        Continuation token for the diffs of the component inspector, taken from the previous
+        response's `nextDiffCursor`.
+      schema:
+        $ref: '#/components/schemas/Cursor'
 
     LastEventPositionQuery:
       name: lastEventPosition
@@ -461,6 +999,77 @@ components:
                 status: 404
                 detail: No project with id "unknown-project" exists.
                 code: project_not_found
+
+    RunNotFound:
+      description: |
+        The project, or the requested run inside it, is unknown. Codes: `project_not_found`,
+        `run_not_found`, `current_run_not_found`. The last one is distinct on purpose: a project
+        whose runs were never opened by a root orchestrator has no current run, which a client
+        must be able to tell apart from a wrong run id.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            runNotFound:
+              summary: Unknown run id
+              value:
+                type: 'https://visualise-ai.local/problems/run-not-found'
+                title: Run not found
+                status: 404
+                detail: No run with id "run-does-not-exist" exists in project "visualise-ai".
+                code: run_not_found
+            currentRunNotFound:
+              summary: The project has no current run
+              value:
+                type: 'https://visualise-ai.local/problems/current-run-not-found'
+                title: No current run
+                status: 404
+                detail: Project "visualise-ai" has no current run; no root orchestrator has opened one.
+                code: current_run_not_found
+
+    ComponentNotFound:
+      description: |
+        The project, the requested run or the component is unknown. Codes:
+        `project_not_found`, `run_not_found`, `current_run_not_found`, `component_not_found`.
+
+        A component that left the applied model but still has history is **not** an error: it
+        is answered with `200` and `component: null`.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            componentNotFound:
+              summary: The project never reported this component
+              value:
+                type: 'https://visualise-ai.local/problems/component-not-found'
+                title: Component not found
+                status: 404
+                detail: Project "visualise-ai" has never reported component "shop-platform.unknown".
+                code: component_not_found
+
+    InvalidQueryParameter:
+      description: |
+        A query parameter of a read request is not acceptable. Code:
+        `invalid_query_parameter`. `errors[].field` names the rejected query parameter.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidationProblem'
+          examples:
+            limitOutOfRange:
+              summary: Limit above the documented maximum
+              value:
+                type: 'https://visualise-ai.local/problems/invalid-query-parameter'
+                title: Invalid query parameter
+                status: 400
+                detail: One or more query parameters of this request are not acceptable.
+                code: invalid_query_parameter
+                errors:
+                  - field: /limit
+                    code: out_of_range
+                    message: limit must be between 1 and 200
 
   schemas:
 
@@ -2034,7 +2643,9 @@ components:
             `client_event_id_conflict`, `event_too_large`, `unsupported_media_type`,
             `unknown_agent`, `run_already_finished`, `run_not_started`,
             `parent_agent_unknown`, `terminal_event_not_allowed`,
-            `correction_target_unknown`, `project_not_found` or `not_ready`.
+            `correction_target_unknown`, `project_not_found`, `run_not_found`,
+            `current_run_not_found`, `component_not_found`, `invalid_query_parameter` or
+            `not_ready`.
           minLength: 1
         instance:
           type: string
@@ -2056,7 +2667,8 @@ components:
           type: string
           description: |
             RFC 6901 JSON Pointer into the rejected request body, for example
-            `/payload/percent`.
+            `/payload/percent`. Read requests have no body, so there the pointer names the
+            rejected query parameter, for example `/limit`.
           minLength: 1
         code:
           type: string
@@ -2118,6 +2730,1162 @@ components:
         - detail
         - code
         - errors
+      additionalProperties: false
+
+    # ---------------------------------------------------------------------------
+    # Read models
+    #
+    # These are server side projections, not reported documents: they repeat what
+    # agents reported plus the positions that make a snapshot comparable with the
+    # SSE stream. They deliberately do not reuse the reported descriptor schemas
+    # above — a `Component` in an event is what an agent claims, an
+    # `AppliedComponent` is what the model currently holds.
+    # ---------------------------------------------------------------------------
+
+    ProjectPosition:
+      type: integer
+      format: int64
+      description: |
+        Server side project position at the moment the snapshot was read. It is the position of
+        the last event committed for the project, so a client can compare an HTTP snapshot with
+        its SSE cursor and know exactly which events it still has to apply. `0` means nothing
+        has been reported yet.
+      minimum: 0
+      examples:
+        - 17
+
+    AppliedPosition:
+      type: integer
+      format: int64
+      description: |
+        Project position of the event that last wrote this row. It lets the UI reconcile a
+        single node when a live event arrives instead of refetching the whole snapshot.
+      minimum: 0
+      examples:
+        - 11
+
+    Cursor:
+      type: string
+      description: |
+        Opaque continuation token. It encodes the sort key of the last returned entry; clients
+        echo it back unchanged and must not parse it.
+      minLength: 1
+      examples:
+        - djF8MTY
+
+    ProjectSummary:
+      type: object
+      description: One project as shown in the project list.
+      properties:
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        firstSeenAt:
+          description: When the first accepted event of this project was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastEventAt:
+          description: When the most recent accepted event of this project was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        currentRunId:
+          description: |
+            The run a root orchestrator opened last, or `null` while no root orchestrator has
+            opened one.
+          oneOf:
+            - $ref: '#/components/schemas/RunId'
+            - type: 'null'
+      required:
+        - projectId
+        - firstSeenAt
+        - lastEventAt
+        - lastPosition
+        - currentRunId
+      additionalProperties: false
+
+    ProjectCounts:
+      type: object
+      description: Sizes of the read models of one project.
+      properties:
+        runs:
+          type: integer
+          description: Runs of this project, current and historical.
+          minimum: 0
+        openRuns:
+          type: integer
+          description: Runs without an explicit `run.finished`.
+          minimum: 0
+        components:
+          type: integer
+          description: Components of the applied architecture model.
+          minimum: 0
+        relationships:
+          type: integer
+          description: Relationships of the applied architecture model.
+          minimum: 0
+        activeChanges:
+          type: integer
+          description: Pending change proposals, that is changes in state `planned`.
+          minimum: 0
+      required:
+        - runs
+        - openRuns
+        - components
+        - relationships
+        - activeChanges
+      additionalProperties: false
+
+    ProjectDetail:
+      type: object
+      description: One project together with the sizes of its read models.
+      properties:
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        firstSeenAt:
+          description: When the first accepted event of this project was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastEventAt:
+          description: When the most recent accepted event of this project was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        currentRunId:
+          description: The run a root orchestrator opened last, or `null`.
+          oneOf:
+            - $ref: '#/components/schemas/RunId'
+            - type: 'null'
+        counts:
+          $ref: '#/components/schemas/ProjectCounts'
+      required:
+        - projectId
+        - firstSeenAt
+        - lastEventAt
+        - lastPosition
+        - currentRunId
+        - counts
+      additionalProperties: false
+
+    ProjectListResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects`. Not scoped to one project, so `projectPosition` is the
+        highest position across the listed projects.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        projects:
+          type: array
+          description: Every known project, ordered by `projectId`.
+          items:
+            $ref: '#/components/schemas/ProjectSummary'
+      required:
+        - projectPosition
+        - projects
+      additionalProperties: false
+
+    ProjectResponse:
+      type: object
+      description: Body of `GET /api/v1/projects/{projectId}`.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        project:
+          $ref: '#/components/schemas/ProjectDetail'
+      required:
+        - projectPosition
+        - project
+      additionalProperties: false
+
+    AppliedComponent:
+      type: object
+      description: |
+        One node of the applied architecture model. `parentComponentId` is the only expression
+        of the hierarchy; the list itself is flat.
+      properties:
+        componentId:
+          $ref: '#/components/schemas/ComponentId'
+        name:
+          type: string
+          description: Human-readable display name shown on the architecture canvas.
+        kind:
+          type: string
+          description: Structural role of the component, as reported.
+          enum:
+            - system
+            - service
+            - module
+            - datastore
+            - queue
+            - topic
+            - ui
+            - external
+            - library
+        parentComponentId:
+          description: Parent node in the component hierarchy, or `null` for a root component.
+          oneOf:
+            - $ref: '#/components/schemas/ComponentId'
+            - type: 'null'
+        description:
+          type: string
+          description: Short explanation of the component's responsibility, empty when none was reported.
+        technology:
+          description: |
+            Reported technology metadata, handed through unchanged. An empty object means the
+            agent reported none.
+          allOf:
+            - $ref: '#/components/schemas/Technology'
+        tags:
+          type: array
+          description: Reported free-form labels, empty when none were reported.
+          items:
+            type: string
+        appliedAt:
+          description: When the event that last wrote this component was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        appliedByAgentId:
+          $ref: '#/components/schemas/AgentId'
+        appliedRunId:
+          $ref: '#/components/schemas/RunId'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - componentId
+        - name
+        - kind
+        - parentComponentId
+        - description
+        - technology
+        - tags
+        - appliedAt
+        - appliedByAgentId
+        - appliedRunId
+        - position
+      additionalProperties: false
+
+    AppliedRelationship:
+      type: object
+      description: |
+        One typed, directed edge of the applied model. Every NATS topic keeps its own row with
+        the topic name in `channel`; edges are never aggregated server side.
+      properties:
+        relationshipId:
+          $ref: '#/components/schemas/Identifier'
+        sourceComponentId:
+          $ref: '#/components/schemas/ComponentId'
+        targetComponentId:
+          $ref: '#/components/schemas/ComponentId'
+        kind:
+          type: string
+          description: Interaction type of the edge, as reported.
+          enum:
+            - http
+            - grpc
+            - data
+            - async
+            - nats_topic
+            - dependency
+        label:
+          type: string
+          description: Reported edge label, empty when none was reported.
+        protocol:
+          type: string
+          description: Reported protocol, empty when none was reported.
+        operation:
+          type: string
+          description: Reported operation, empty when none was reported.
+        channel:
+          type: string
+          description: |
+            Reported channel. For `kind: nats_topic` this is the topic name and identifies the
+            relationship semantically. Empty when none was reported.
+        appliedAt:
+          description: When the event that last wrote this relationship was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        appliedByAgentId:
+          $ref: '#/components/schemas/AgentId'
+        appliedRunId:
+          $ref: '#/components/schemas/RunId'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - relationshipId
+        - sourceComponentId
+        - targetComponentId
+        - kind
+        - label
+        - protocol
+        - operation
+        - channel
+        - appliedAt
+        - appliedByAgentId
+        - appliedRunId
+        - position
+      additionalProperties: false
+
+    ActiveChange:
+      type: object
+      description: |
+        A pending change proposal, that is a reported change that is still in state `planned`.
+        `snapshot` carries the reported component or relationship descriptor verbatim, so the
+        canvas can draw the proposal next to the applied model without a second lookup.
+      properties:
+        changeId:
+          $ref: '#/components/schemas/Identifier'
+        targetKind:
+          type: string
+          description: What the change is about.
+          enum:
+            - component
+            - relationship
+        targetId:
+          type: string
+          description: Identifier of the component or relationship the change targets.
+          minLength: 1
+        operation:
+          $ref: '#/components/schemas/ChangeOperation'
+        state:
+          type: string
+          description: |
+            Lifecycle state of the change. The read endpoints only return `planned`; `applied`
+            has become the model and `retracted` was withdrawn.
+          enum:
+            - planned
+            - applied
+            - retracted
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        plannedAt:
+          description: When the change was announced, or `null` when it was never planned.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        appliedAt:
+          description: When the change was applied, `null` while it is pending.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        retractedAt:
+          description: When the change was withdrawn, `null` while it stands.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        snapshot:
+          type: object
+          description: |
+            The reported descriptor of the proposal — a `Component` or a `Relationship`
+            document, selected by `targetKind` — stored and returned as reported.
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - changeId
+        - targetKind
+        - targetId
+        - operation
+        - state
+        - runId
+        - agentId
+        - plannedAt
+        - appliedAt
+        - retractedAt
+        - snapshot
+        - position
+      additionalProperties: false
+
+    ArchitectureResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/architecture`: the applied model plus the
+        proposals that are still pending. A planned change never appears in `components` or
+        `relationships`.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        components:
+          type: array
+          description: Every component of the applied model, ordered by `componentId`.
+          items:
+            $ref: '#/components/schemas/AppliedComponent'
+        relationships:
+          type: array
+          description: Every relationship of the applied model, ordered by `relationshipId`.
+          items:
+            $ref: '#/components/schemas/AppliedRelationship'
+        activeChanges:
+          type: array
+          description: Pending proposals, newest first.
+          items:
+            $ref: '#/components/schemas/ActiveChange'
+      required:
+        - projectPosition
+        - components
+        - relationships
+        - activeChanges
+      additionalProperties: false
+
+    RunSummary:
+      type: object
+      description: |
+        One run. It stays open until an explicit `run.finished` closes it; silence never
+        produces a terminal state.
+      properties:
+        runId:
+          $ref: '#/components/schemas/RunId'
+        rootAgentId:
+          description: |
+            The orchestrator that opened the run, or `null` while no root orchestrator reported
+            `agent.started` for it.
+          oneOf:
+            - $ref: '#/components/schemas/AgentId'
+            - type: 'null'
+        startedAt:
+          description: When the run was first seen.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        finishedAt:
+          description: When `run.finished` was reported, `null` while the run is open.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        outcome:
+          description: Reported terminal outcome, `null` while the run is open.
+          oneOf:
+            - $ref: '#/components/schemas/Outcome'
+            - type: 'null'
+        isOpen:
+          type: boolean
+          description: '`false` only after an explicit `run.finished`.'
+        isCurrent:
+          type: boolean
+          description: Whether this is the run `current` resolves to.
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - runId
+        - rootAgentId
+        - startedAt
+        - finishedAt
+        - outcome
+        - isOpen
+        - isCurrent
+        - position
+      additionalProperties: false
+
+    RunCounts:
+      type: object
+      description: Sizes of the read models of one run.
+      properties:
+        agents:
+          type: integer
+          description: Agents that reported `agent.started` in this run.
+          minimum: 0
+        plans:
+          type: integer
+          description: Plans published in this run.
+          minimum: 0
+        workSteps:
+          type: integer
+          description: Work steps reported in this run.
+          minimum: 0
+      required:
+        - agents
+        - plans
+        - workSteps
+      additionalProperties: false
+
+    RunDetail:
+      type: object
+      description: One run together with the sizes of the collections hanging off it.
+      properties:
+        runId:
+          $ref: '#/components/schemas/RunId'
+        rootAgentId:
+          description: The orchestrator that opened the run, or `null`.
+          oneOf:
+            - $ref: '#/components/schemas/AgentId'
+            - type: 'null'
+        startedAt:
+          description: When the run was first seen.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        finishedAt:
+          description: When `run.finished` was reported, `null` while the run is open.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        outcome:
+          description: Reported terminal outcome, `null` while the run is open.
+          oneOf:
+            - $ref: '#/components/schemas/Outcome'
+            - type: 'null'
+        isOpen:
+          type: boolean
+          description: '`false` only after an explicit `run.finished`.'
+        isCurrent:
+          type: boolean
+          description: Whether this is the run `current` resolves to.
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+        counts:
+          $ref: '#/components/schemas/RunCounts'
+      required:
+        - runId
+        - rootAgentId
+        - startedAt
+        - finishedAt
+        - outcome
+        - isOpen
+        - isCurrent
+        - position
+        - counts
+      additionalProperties: false
+
+    RunListResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/runs`. Current and historical runs in one
+        list, descending by start.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        runs:
+          type: array
+          description: One page of runs.
+          items:
+            $ref: '#/components/schemas/RunSummary'
+        nextCursor:
+          description: Cursor of the next page, `null` on the last one.
+          oneOf:
+            - $ref: '#/components/schemas/Cursor'
+            - type: 'null'
+      required:
+        - projectPosition
+        - runs
+        - nextCursor
+      additionalProperties: false
+
+    RunResponse:
+      type: object
+      description: Body of `GET /api/v1/projects/{projectId}/runs/{runId}`.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        run:
+          $ref: '#/components/schemas/RunDetail'
+      required:
+        - projectPosition
+        - run
+      additionalProperties: false
+
+    AgentProgress:
+      type: object
+      description: |
+        Progress **as reported by the agent itself**. `scope` separates a subagent's own task
+        from an orchestrator's estimate for the whole run; `basis` separates a free estimate
+        from counted steps. The cockpit displays it as reported and checks nothing.
+      properties:
+        percent:
+          type: integer
+          description: Reported completion in percent.
+          minimum: 0
+          maximum: 100
+        scope:
+          description: What the percentage refers to, `null` when it was not reported.
+          oneOf:
+            - type: string
+              enum:
+                - own_task
+                - overall_estimate
+            - type: 'null'
+        basis:
+          description: How the number was derived, `null` when it was not reported.
+          oneOf:
+            - type: string
+              enum:
+                - reported_estimate
+                - completed_steps
+            - type: 'null'
+      required:
+        - percent
+        - scope
+        - basis
+      additionalProperties: false
+
+    RunAgent:
+      type: object
+      description: |
+        One node of the agent tree of a run. The tree is expressed through `parentAgentId`;
+        the list is flat.
+
+        Nothing here is derived: `status` stays empty until `agent.status_reported` arrives,
+        `progress` stays `null` until the agent reported a number, and `finishedOutcome` stays
+        `null` until `agent.finished`. Silence changes nothing.
+      properties:
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        parentAgentId:
+          description: The delegating agent, `null` for the root orchestrator.
+          oneOf:
+            - $ref: '#/components/schemas/AgentId'
+            - type: 'null'
+        role:
+          type: string
+          description: Position of the agent in the run hierarchy, as reported.
+          enum:
+            - ''
+            - orchestrator
+            - subagent
+        displayName:
+          type: string
+          description: Name shown for this agent, empty when the agent never reported `agent.started`.
+        assignedTask:
+          type: string
+          description: The task the agent was given, in its own words. Empty when never reported.
+        status:
+          type: string
+          description: Last explicitly reported status. Empty means none was ever reported.
+          enum:
+            - ''
+            - working
+            - waiting
+            - blocked
+            - idle
+            - done
+        statusNote:
+          type: string
+          description: Optional one-line explanation that came with the status.
+        progress:
+          description: Self-assessed progress, `null` until the agent reported one.
+          oneOf:
+            - $ref: '#/components/schemas/AgentProgress'
+            - type: 'null'
+        finishedOutcome:
+          description: Reported outcome of `agent.finished`, `null` while the agent has not finished.
+          oneOf:
+            - $ref: '#/components/schemas/Outcome'
+            - type: 'null'
+        startedAt:
+          description: When the agent was first seen in this run.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastEventAt:
+          description: When this agent last reported anything.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - agentId
+        - runId
+        - parentAgentId
+        - role
+        - displayName
+        - assignedTask
+        - status
+        - statusNote
+        - progress
+        - finishedOutcome
+        - startedAt
+        - lastEventAt
+        - position
+      additionalProperties: false
+
+    AgentListResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/runs/{runId}/agents`. Flat, ordered so a
+        parent precedes the subagents it spawned.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        agents:
+          type: array
+          description: Every agent of the run.
+          items:
+            $ref: '#/components/schemas/RunAgent'
+      required:
+        - projectPosition
+        - agents
+      additionalProperties: false
+
+    RunPlanStep:
+      type: object
+      description: One step of one plan revision, in the reported order.
+      properties:
+        stepId:
+          $ref: '#/components/schemas/Identifier'
+        order:
+          type: integer
+          description: Zero-based position of the step within its revision.
+          minimum: 0
+        title:
+          type: string
+          description: Short description of what the step achieves.
+        state:
+          $ref: '#/components/schemas/PlanStepState'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - stepId
+        - order
+        - title
+        - state
+        - position
+      additionalProperties: false
+
+    RunPlanRevision:
+      type: object
+      description: |
+        One published revision of a plan. Revisions are append-only: a `plan.step_updated` only
+        reaches the revision that was current when it was reported, so an earlier revision keeps
+        exactly the states it was last seen with.
+      properties:
+        revision:
+          type: integer
+          description: Revision number, starting at 1 and strictly increasing per plan.
+          minimum: 1
+        createdAt:
+          description: When this revision was published.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        createdByAgentId:
+          $ref: '#/components/schemas/AgentId'
+        isCurrent:
+          type: boolean
+          description: Whether `plan.step_updated` currently writes to this revision.
+        steps:
+          type: array
+          description: All steps of this revision, ordered by `order`.
+          items:
+            $ref: '#/components/schemas/RunPlanStep'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - revision
+        - createdAt
+        - createdByAgentId
+        - isCurrent
+        - steps
+        - position
+      additionalProperties: false
+
+    RunPlan:
+      type: object
+      description: One plan of a run with every revision it ever had, ascending.
+      properties:
+        planId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        currentRevision:
+          type: integer
+          description: The revision the cockpit shows by default.
+          minimum: 0
+        revisions:
+          type: array
+          description: Every published revision, ascending.
+          items:
+            $ref: '#/components/schemas/RunPlanRevision'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - planId
+        - runId
+        - agentId
+        - currentRevision
+        - revisions
+        - position
+      additionalProperties: false
+
+    PlanListResponse:
+      type: object
+      description: Body of `GET /api/v1/projects/{projectId}/runs/{runId}/plans`.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        plans:
+          type: array
+          description: Every plan of the run, ordered by `planId`.
+          items:
+            $ref: '#/components/schemas/RunPlan'
+      required:
+        - projectPosition
+        - plans
+      additionalProperties: false
+
+    InspectorWorkStep:
+      type: object
+      description: |
+        A concrete unit of work an agent reported. The inspector shows the open work step of
+        the selected run, or the most recently started one when all of them completed.
+      properties:
+        workStepId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        planStepId:
+          description: The planned step this work followed, `null` for unplanned work.
+          oneOf:
+            - $ref: '#/components/schemas/Identifier'
+            - type: 'null'
+        title:
+          type: string
+          description: Short description of the work.
+        startedAt:
+          description: When the work step was reported as started.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        completedAt:
+          description: When it was reported as completed, `null` while it is open.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        summary:
+          description: Reported result summary, `null` while the step is open.
+          type:
+            - string
+            - 'null'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - workStepId
+        - runId
+        - agentId
+        - planStepId
+        - title
+        - startedAt
+        - completedAt
+        - summary
+        - position
+      additionalProperties: false
+
+    FeedbackEntry:
+      type: object
+      description: |
+        One published, component scoped feedback item. `body` is untrusted markdown and is
+        handed through verbatim — sanitising it before rendering is the client's job.
+      properties:
+        feedbackId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        format:
+          type: string
+          description: Body format. v0 reports markdown only.
+          enum:
+            - markdown
+        title:
+          type: string
+          description: Reported headline, empty when none was reported.
+        body:
+          type: string
+          description: The feedback text as reported.
+        createdAt:
+          description: When the feedback was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - feedbackId
+        - runId
+        - agentId
+        - format
+        - title
+        - body
+        - createdAt
+        - position
+      additionalProperties: false
+
+    ReportedDiff:
+      type: object
+      description: |
+        One reported unified diff of exactly one repository file. The backend never splits or
+        merges diffs; `changeId` is what groups the files of one logical change.
+      properties:
+        diffId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        changeId:
+          description: The change this file belongs to, `null` for an unattributed diff.
+          oneOf:
+            - $ref: '#/components/schemas/Identifier'
+            - type: 'null'
+        filePath:
+          $ref: '#/components/schemas/RepositoryFilePath'
+        unifiedDiff:
+          type: string
+          description: The unified diff of this one file, exactly as reported.
+        createdAt:
+          description: When the diff was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - diffId
+        - runId
+        - agentId
+        - changeId
+        - filePath
+        - unifiedDiff
+        - createdAt
+        - position
+      additionalProperties: false
+
+    ReportedRisk:
+      type: object
+      description: |
+        A risk **as stated by the reporting agent**. The system never derives, scores or
+        aggregates risks; the human reviewer judges.
+      properties:
+        riskId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        title:
+          type: string
+          description: Short headline of the risk.
+        detail:
+          type: string
+          description: Longer explanation, empty when none was reported.
+        severity:
+          type: string
+          description: Severity as assessed by the reporting agent.
+          enum:
+            - low
+            - medium
+            - high
+        createdAt:
+          description: When the risk was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - riskId
+        - runId
+        - agentId
+        - title
+        - detail
+        - severity
+        - createdAt
+        - position
+      additionalProperties: false
+
+    ReportedProblem:
+      type: object
+      description: A problem as stated by the reporting agent, never a system-side evaluation.
+      properties:
+        problemId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        title:
+          type: string
+          description: Short headline of the problem.
+        detail:
+          type: string
+          description: Longer explanation, empty when none was reported.
+        createdAt:
+          description: When the problem was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - problemId
+        - runId
+        - agentId
+        - title
+        - detail
+        - createdAt
+        - position
+      additionalProperties: false
+
+    ComponentInspectorResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/components/{componentId}`. Everything here
+        belongs to **one** run — the one named in `runId`. Evidence of other runs is reachable
+        through `…/history` only.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        runId:
+          description: |
+            The run this evidence belongs to, `null` when the project has no run at all yet.
+          oneOf:
+            - $ref: '#/components/schemas/RunId'
+            - type: 'null'
+        component:
+          description: |
+            The applied descriptor, `null` when the component left the applied model but is
+            still known from the history.
+          oneOf:
+            - $ref: '#/components/schemas/AppliedComponent'
+            - type: 'null'
+        responsibleAgent:
+          description: |
+            The agent of `currentWorkStep`, or the agent that applied the component in this run.
+            `null` when neither was reported — responsibility is read from evidence, not guessed.
+          oneOf:
+            - $ref: '#/components/schemas/RunAgent'
+            - type: 'null'
+        currentWorkStep:
+          description: |
+            The open work step of this run touching the component, or the most recently started
+            one when all of them completed. `null` when no work step named the component.
+          oneOf:
+            - $ref: '#/components/schemas/InspectorWorkStep'
+            - type: 'null'
+        feedback:
+          type: array
+          description: Component scoped feedback of this run, newest first. Complete, not paged.
+          items:
+            $ref: '#/components/schemas/FeedbackEntry'
+        diffs:
+          type: array
+          description: |
+            Unified diffs of this run touching the component, newest first. Paged — see
+            `nextDiffCursor`.
+          items:
+            $ref: '#/components/schemas/ReportedDiff'
+        nextDiffCursor:
+          description: Cursor for the next page of diffs, `null` when the last page was returned.
+          oneOf:
+            - $ref: '#/components/schemas/Cursor'
+            - type: 'null'
+        risks:
+          type: array
+          description: Risks reported for this component in this run, newest first.
+          items:
+            $ref: '#/components/schemas/ReportedRisk'
+        problems:
+          type: array
+          description: Problems reported for this component in this run, newest first.
+          items:
+            $ref: '#/components/schemas/ReportedProblem'
+        activeChanges:
+          type: array
+          description: |
+            Pending proposals of this run that target this component. Proposals that target a
+            relationship are shown on the architecture endpoint instead.
+          items:
+            $ref: '#/components/schemas/ActiveChange'
+      required:
+        - projectPosition
+        - runId
+        - component
+        - responsibleAgent
+        - currentWorkStep
+        - feedback
+        - diffs
+        - nextDiffCursor
+        - risks
+        - problems
+        - activeChanges
+      additionalProperties: false
+
+    ComponentHistoryEntry:
+      type: object
+      description: |
+        One reported event that touched the component, as it was stored. Corrections and
+        retractions appear as their own entries; nothing is ever overwritten.
+      properties:
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+        serverEventId:
+          description: Server-assigned identity of the stored event.
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+        clientEventId:
+          description: The idempotency key the agent assigned.
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        parentAgentId:
+          description: The delegating agent, `null` for the root orchestrator.
+          oneOf:
+            - $ref: '#/components/schemas/AgentId'
+            - type: 'null'
+        type:
+          $ref: '#/components/schemas/EventType'
+        schemaVersion:
+          $ref: '#/components/schemas/SchemaVersion'
+        occurredAt:
+          description: When the reported step happened, as observed by the agent.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        receivedAt:
+          description: When the backend accepted and committed the event.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        payload:
+          type: object
+          description: |
+            The reported payload, canonicalised but otherwise unchanged. Its effective schema is
+            fixed by `type`, exactly as during ingestion.
+      required:
+        - position
+        - serverEventId
+        - clientEventId
+        - runId
+        - agentId
+        - parentAgentId
+        - type
+        - schemaVersion
+        - occurredAt
+        - receivedAt
+        - payload
+      additionalProperties: false
+
+    ComponentHistoryResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/components/{componentId}/history`: the run
+        spanning evidence of one component, descending by project position.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        entries:
+          type: array
+          description: One page of history, newest first.
+          items:
+            $ref: '#/components/schemas/ComponentHistoryEntry'
+        nextCursor:
+          description: Cursor of the next page, `null` on the last one.
+          oneOf:
+            - $ref: '#/components/schemas/Cursor'
+            - type: 'null'
+      required:
+        - projectPosition
+        - entries
+        - nextCursor
       additionalProperties: false
 
     LivenessStatus:

--- a/api/scripts/validate-examples.mjs
+++ b/api/scripts/validate-examples.mjs
@@ -30,6 +30,8 @@ const EXPECTED_SCHEMA = {
   'diff-reported.json': 'IngestEventRequest',
   'correction-issued.json': 'IngestEventRequest',
   'run-finished.json': 'IngestEventRequest',
+  'architecture-read-model.json': 'ArchitectureResponse',
+  'component-inspector.json': 'ComponentInspectorResponse',
   'retry-idempotent-response.json': 'EventAccepted',
   'conflict-response.json': 'Problem',
   'validation-error-response.json': 'ValidationProblem',

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/risqyy/visualise-ai/backend/internal/httpapi"
 	"github.com/risqyy/visualise-ai/backend/internal/ingest"
 	"github.com/risqyy/visualise-ai/backend/internal/logging"
+	"github.com/risqyy/visualise-ai/backend/internal/readapi"
 	"github.com/risqyy/visualise-ai/backend/internal/store"
 )
 
@@ -76,6 +77,7 @@ func run() error {
 		Health:  checker,
 		Version: version,
 		Ingest:  ingestHandler,
+		Read:    readapi.New(db),
 	})
 
 	server := &http.Server{

--- a/backend/internal/httpapi/read.go
+++ b/backend/internal/httpapi/read.go
@@ -1,0 +1,242 @@
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+
+	"github.com/risqyy/visualise-ai/backend/internal/readapi"
+)
+
+// problemBaseURI prefixes the `type` of every problem document this API serves.
+const problemBaseURI = "https://visualise-ai.local/problems/"
+
+// problemContentType is the media type RFC 9457 prescribes.
+const problemContentType = "application/problem+json"
+
+// registerRead mounts the project scoped read endpoints.
+//
+// It is the single entry point of this work package into the router, so the
+// read models can be wired without touching any other registration.
+func registerRead(engine *gin.Engine, service *readapi.Service, logger zerolog.Logger) {
+	if service == nil {
+		// A router built without the read models — the probe tests do that —
+		// simply does not offer them, instead of panicking on a nil service.
+		return
+	}
+
+	group := engine.Group(APIPrefix)
+	group.GET("/projects", listProjectsHandler(service, logger))
+	group.GET("/projects/:projectId", getProjectHandler(service, logger))
+	group.GET("/projects/:projectId/architecture", getArchitectureHandler(service, logger))
+	group.GET("/projects/:projectId/runs", listRunsHandler(service, logger))
+	group.GET("/projects/:projectId/runs/:runId", getRunHandler(service, logger))
+	group.GET("/projects/:projectId/runs/:runId/agents", listAgentsHandler(service, logger))
+	group.GET("/projects/:projectId/runs/:runId/plans", listPlansHandler(service, logger))
+	group.GET("/projects/:projectId/components/:componentId", getComponentHandler(service, logger))
+	group.GET("/projects/:projectId/components/:componentId/history", getComponentHistoryHandler(service, logger))
+}
+
+func listProjectsHandler(service *readapi.Service, logger zerolog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		response, err := service.Projects(c.Request.Context())
+		if err != nil {
+			failRead(c, logger, err)
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	}
+}
+
+func getProjectHandler(service *readapi.Service, logger zerolog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		response, err := service.Project(c.Request.Context(), c.Param("projectId"))
+		if err != nil {
+			failRead(c, logger, err)
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	}
+}
+
+func getArchitectureHandler(service *readapi.Service, logger zerolog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		response, err := service.Architecture(c.Request.Context(), c.Param("projectId"))
+		if err != nil {
+			failRead(c, logger, err)
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	}
+}
+
+func listRunsHandler(service *readapi.Service, logger zerolog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		response, err := service.Runs(
+			c.Request.Context(),
+			c.Param("projectId"),
+			c.Query("limit"),
+			c.Query("cursor"),
+		)
+		if err != nil {
+			failRead(c, logger, err)
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	}
+}
+
+func getRunHandler(service *readapi.Service, logger zerolog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		response, err := service.Run(c.Request.Context(), c.Param("projectId"), c.Param("runId"))
+		if err != nil {
+			failRead(c, logger, err)
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	}
+}
+
+func listAgentsHandler(service *readapi.Service, logger zerolog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		response, err := service.Agents(c.Request.Context(), c.Param("projectId"), c.Param("runId"))
+		if err != nil {
+			failRead(c, logger, err)
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	}
+}
+
+func listPlansHandler(service *readapi.Service, logger zerolog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		response, err := service.Plans(c.Request.Context(), c.Param("projectId"), c.Param("runId"))
+		if err != nil {
+			failRead(c, logger, err)
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	}
+}
+
+func getComponentHandler(service *readapi.Service, logger zerolog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		response, err := service.Component(
+			c.Request.Context(),
+			c.Param("projectId"),
+			c.Param("componentId"),
+			readapi.ComponentQuery{
+				RunID:      c.Query("runId"),
+				DiffLimit:  c.Query("diffLimit"),
+				DiffCursor: c.Query("diffCursor"),
+			},
+		)
+		if err != nil {
+			failRead(c, logger, err)
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	}
+}
+
+func getComponentHistoryHandler(service *readapi.Service, logger zerolog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		response, err := service.History(
+			c.Request.Context(),
+			c.Param("projectId"),
+			c.Param("componentId"),
+			c.Query("limit"),
+			c.Query("cursor"),
+		)
+		if err != nil {
+			failRead(c, logger, err)
+			return
+		}
+		c.JSON(http.StatusOK, response)
+	}
+}
+
+// failRead maps a read error onto the RFC 9457 problem the contract promises.
+//
+// Everything the read layer can report is a client error with a stable `code`;
+// anything else is a defect of this service and is logged rather than leaked to
+// the client.
+func failRead(c *gin.Context, logger zerolog.Logger, err error) {
+	var invalid *readapi.ValidationError
+	switch {
+	case errors.As(err, &invalid):
+		writeValidationProblem(c, invalid)
+	case errors.Is(err, readapi.ErrProjectNotFound):
+		writeProblem(c, http.StatusNotFound, "project_not_found", "Project not found",
+			"No project with id "+quoted(c.Param("projectId"))+" exists.")
+	case errors.Is(err, readapi.ErrCurrentRunNotFound):
+		writeProblem(c, http.StatusNotFound, "current_run_not_found", "No current run",
+			"Project "+quoted(c.Param("projectId"))+" has no current run; no root orchestrator has opened one.")
+	case errors.Is(err, readapi.ErrRunNotFound):
+		writeProblem(c, http.StatusNotFound, "run_not_found", "Run not found",
+			"No run with id "+quoted(c.Param("runId"))+" exists in project "+quoted(c.Param("projectId"))+".")
+	case errors.Is(err, readapi.ErrComponentNotFound):
+		writeProblem(c, http.StatusNotFound, "component_not_found", "Component not found",
+			"Project "+quoted(c.Param("projectId"))+" has never reported component "+quoted(c.Param("componentId"))+".")
+	default:
+		logger.Error().Err(err).
+			Str("path", c.Request.URL.Path).
+			Msg("read query failed")
+		writeProblem(c, http.StatusInternalServerError, "internal_error", "Internal Server Error",
+			"The read model could not be served.")
+	}
+}
+
+func writeProblem(c *gin.Context, status int, code, title, detail string) {
+	c.Abort()
+	c.Header("Content-Type", problemContentType)
+	c.JSON(status, gin.H{
+		"type":   problemBaseURI + problemPath(code),
+		"title":  title,
+		"status": status,
+		"detail": detail,
+		"code":   code,
+	})
+}
+
+func writeValidationProblem(c *gin.Context, invalid *readapi.ValidationError) {
+	const code = "invalid_query_parameter"
+
+	errorsOut := make([]gin.H, 0, len(invalid.Errors))
+	for _, fieldError := range invalid.Errors {
+		errorsOut = append(errorsOut, gin.H{
+			"field":   fieldError.Field,
+			"code":    fieldError.Code,
+			"message": fieldError.Message,
+		})
+	}
+
+	c.Abort()
+	c.Header("Content-Type", problemContentType)
+	c.JSON(http.StatusBadRequest, gin.H{
+		"type":   problemBaseURI + problemPath(code),
+		"title":  "Invalid query parameter",
+		"status": http.StatusBadRequest,
+		"detail": "One or more query parameters of this request are not acceptable.",
+		"code":   code,
+		"errors": errorsOut,
+	})
+}
+
+// problemPath turns a snake_case code into the kebab-case slug used in `type`.
+func problemPath(code string) string {
+	out := make([]byte, 0, len(code))
+	for i := 0; i < len(code); i++ {
+		if code[i] == '_' {
+			out = append(out, '-')
+			continue
+		}
+		out = append(out, code[i])
+	}
+	return string(out)
+}
+
+// quoted wraps a value so an identifier stays recognisable inside a sentence.
+func quoted(value string) string { return `"` + value + `"` }

--- a/backend/internal/httpapi/router.go
+++ b/backend/internal/httpapi/router.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/risqyy/visualise-ai/backend/internal/health"
 	"github.com/risqyy/visualise-ai/backend/internal/ingest"
+	"github.com/risqyy/visualise-ai/backend/internal/readapi"
 )
 
 // APIPrefix is the single versioned prefix Nginx proxies to the backend.
@@ -30,6 +31,9 @@ type Options struct {
 	Version string
 	// Ingest serves POST /api/v1/events. Nil leaves the route unregistered.
 	Ingest *ingest.Handler
+	// Read serves the project scoped read models. A nil value leaves the read
+	// routes unmounted, which keeps the probe-only router usable in tests.
+	Read *readapi.Service
 }
 
 // New builds the Gin engine.
@@ -48,6 +52,7 @@ func New(opts Options) *gin.Engine {
 	engine.Group(APIPrefix)
 
 	registerIngestRoutes(engine, opts.Ingest)
+	registerRead(engine, opts.Read, opts.Logger)
 
 	engine.NoRoute(notFoundHandler())
 

--- a/backend/internal/ingest/contract/openapi.yaml
+++ b/backend/internal/ingest/contract/openapi.yaml
@@ -2,8 +2,8 @@ openapi: 3.1.0
 
 info:
   title: Visualise AI — Agent Cockpit Event Contract
-  version: 1.0.0
-  summary: Versioned contract for agent event ingestion and project event streaming.
+  version: 1.1.0
+  summary: Versioned contract for agent event ingestion, project event streaming and the read models.
   description: |
     The Visualise AI Agent Cockpit is fed exclusively by this contract. An orchestrator and
     its subagents report **semantic work steps**; the cockpit is observing and read-only and
@@ -15,10 +15,26 @@ info:
     | --- | --- |
     | `POST /api/v1/events` | Single-event ingestion, idempotent per `clientEventId`. |
     | `GET /api/v1/projects/{projectId}/stream` | Server-Sent Events: gap-free replay followed by the live stream. |
+    | `GET /api/v1/projects` … `GET /api/v1/projects/{projectId}/components/{componentId}/history` | Project scoped read models: projects, architecture, runs, agents, plans and component evidence. |
     | `GET /healthz`, `GET /readyz` | Internal container probes, not reachable from outside the Compose network. |
 
-    The historical read API (paged history and materialised snapshots over plain HTTP) is
-    specified separately and is deliberately **not** part of this document.
+    ## The read models
+
+    The read endpoints answer from normalised projections the backend advances in the same
+    transaction that appends the event. A client never queries the event log; the only place
+    the log is exposed is the component history, and there as a paged, component filtered list.
+
+    Three rules hold for every read response:
+
+    * **`projectPosition` is always present.** It is the server side project position at the
+      moment the snapshot was read, so an HTTP snapshot and the SSE stream can be reconciled
+      without guessing which one is ahead. Every row additionally carries the position of the
+      event that last wrote it as `position`.
+    * **Everything is scoped to one project.** A response never contains a row of another
+      project, even when two projects reuse the same run, agent or component identifiers.
+    * **Current run and history are separate views.** The component inspector shows the
+      evidence of exactly one run; `…/components/{componentId}/history` is the run spanning,
+      paged view. Neither ever mixes into the other.
 
     ## Versioning
 
@@ -76,6 +92,11 @@ tags:
   - name: Streaming
     description: |
       Read path used by the cockpit UI. Server-Sent Events with replay from a known position.
+  - name: Read models
+    description: |
+      Project scoped HTTP snapshots the cockpit renders from: projects, the applied
+      architecture, runs, agents, plans and component evidence. Answered from the normalised
+      projections, never from the event log.
   - name: Operations
     description: |
       Container probes for the internal Go backend. Not exposed through the Nginx frontend.
@@ -260,6 +281,441 @@ paths:
         '404':
           $ref: '#/components/responses/ProjectNotFound'
 
+  /api/v1/projects:
+    get:
+      tags:
+        - Read models
+      operationId: listProjects
+      summary: List every known project
+      description: |
+        Lists every project the backend has accepted an event for, ordered by `projectId`.
+
+        This is the only read endpoint that is not scoped to a single project, so its
+        `projectPosition` is the highest position across the listed projects. The value a
+        client needs for reconciling one project is repeated on every entry as `lastPosition`.
+      responses:
+        '200':
+          description: |
+            The known projects. Empty, with `projectPosition: 0`, before the first event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectListResponse'
+              examples:
+                projects:
+                  summary: One observed project with an open run
+                  value:
+                    projectPosition: 17
+                    projects:
+                      - projectId: visualise-ai
+                        firstSeenAt: '2026-08-04T09:00:01Z'
+                        lastEventAt: '2026-08-04T09:00:17Z'
+                        lastPosition: 17
+                        currentRunId: run-2026-08-04-0001
+
+  /api/v1/projects/{projectId}:
+    get:
+      tags:
+        - Read models
+      operationId: getProject
+      summary: Get one project with the sizes of its read models
+      description: |
+        Returns the project head row together with the sizes of its read models, so the shell
+        can render its navigation without fetching every collection first.
+
+        `counts.activeChanges` counts pending proposals only — see the architecture endpoint.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+      responses:
+        '200':
+          description: The project.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+              examples:
+                project:
+                  summary: Project with an open run and a mapped architecture
+                  value:
+                    projectPosition: 17
+                    project:
+                      projectId: visualise-ai
+                      firstSeenAt: '2026-08-04T09:00:01Z'
+                      lastEventAt: '2026-08-04T09:00:17Z'
+                      lastPosition: 17
+                      currentRunId: run-2026-08-04-0001
+                      counts:
+                        runs: 1
+                        openRuns: 1
+                        components: 16
+                        relationships: 8
+                        activeChanges: 2
+        '404':
+          $ref: '#/components/responses/ProjectNotFound'
+
+  /api/v1/projects/{projectId}/architecture:
+    get:
+      tags:
+        - Read models
+      operationId: getProjectArchitecture
+      summary: Get the applied architecture model and the pending proposals
+      description: |
+        Returns the **applied** architecture model — every component and every relationship the
+        project currently has — plus the change proposals that are still pending.
+
+        The two are kept strictly apart:
+
+        * `components` and `relationships` are what `architecture.snapshot_published` and the
+          `*.change_applied` events produced. Every NATS topic keeps its own relationship; edges
+          are never aggregated server side.
+        * `activeChanges` holds the changes in state `planned`. An applied change *is* the model
+          and a retracted change was withdrawn, so neither is active any more. A planned change
+          never modifies `components` or `relationships`.
+
+        The component hierarchy is expressed exclusively through `parentComponentId`; the list
+        itself is flat and ordered by `componentId`, which makes the layout deterministic.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+      responses:
+        '200':
+          description: The applied model and the pending proposals.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArchitectureResponse'
+              examples:
+                architecture:
+                  summary: Four hierarchy levels, every relationship kind, three separate NATS topics
+                  externalValue: './examples/architecture-read-model.json'
+        '404':
+          $ref: '#/components/responses/ProjectNotFound'
+
+  /api/v1/projects/{projectId}/runs:
+    get:
+      tags:
+        - Read models
+      operationId: listProjectRuns
+      summary: List current and historical runs
+      description: |
+        Lists the runs of one project, descending by reported start time. Current and
+        historical runs appear in the same list; `isOpen` and `isCurrent` distinguish them.
+
+        A run stays open until an explicit `run.finished` closes it — silence never produces a
+        terminal state, so an abandoned run keeps `isOpen: true` and its last reported values.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/CursorQuery'
+      responses:
+        '200':
+          description: One page of runs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunListResponse'
+              examples:
+                runs:
+                  summary: A single open run
+                  value:
+                    projectPosition: 17
+                    runs:
+                      - runId: run-2026-08-04-0001
+                        rootAgentId: orchestrator-root
+                        startedAt: '2026-08-04T09:00:01Z'
+                        finishedAt: null
+                        outcome: null
+                        isOpen: true
+                        isCurrent: true
+                        position: 17
+                    nextCursor: null
+        '400':
+          $ref: '#/components/responses/InvalidQueryParameter'
+        '404':
+          $ref: '#/components/responses/ProjectNotFound'
+
+  /api/v1/projects/{projectId}/runs/{runId}:
+    get:
+      tags:
+        - Read models
+      operationId: getProjectRun
+      summary: Get one run, or the current one
+      description: |
+        Returns one run together with the sizes of the collections hanging off it.
+
+        The literal `current` resolves to the run a root orchestrator opened last. A project
+        that never saw a root orchestrator has no current run, which is reported as `404` with
+        the distinct code `current_run_not_found` — "no run yet" is not the same failure as
+        "this run id is wrong".
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/RunIdPath'
+      responses:
+        '200':
+          description: The run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunResponse'
+              examples:
+                currentRun:
+                  summary: The current, open run
+                  value:
+                    projectPosition: 17
+                    run:
+                      runId: run-2026-08-04-0001
+                      rootAgentId: orchestrator-root
+                      startedAt: '2026-08-04T09:00:01Z'
+                      finishedAt: null
+                      outcome: null
+                      isOpen: true
+                      isCurrent: true
+                      position: 17
+                      counts:
+                        agents: 4
+                        plans: 1
+                        workSteps: 1
+        '404':
+          $ref: '#/components/responses/RunNotFound'
+
+  /api/v1/projects/{projectId}/runs/{runId}/agents:
+    get:
+      tags:
+        - Read models
+      operationId: listRunAgents
+      summary: Get the agent tree of one run
+      description: |
+        Returns every agent of one run as a **flat list**; the tree is expressed through
+        `parentAgentId`. A flat list keeps arbitrarily deep spawn chains renderable without the
+        server committing to a nesting depth.
+
+        Entries are ordered by start time, so a parent always precedes the subagents it
+        spawned and a consumer can build the tree in a single pass.
+
+        Reported values stay where they were reported: `status` is empty until the agent sent
+        `agent.status_reported`, `progress` is `null` until it reported a number itself, and
+        `finishedOutcome` is `null` until it sent `agent.finished`. Nothing is derived from
+        silence. `progress.scope` separates a subagent's own task from an orchestrator's
+        overall estimate.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/RunIdPath'
+      responses:
+        '200':
+          description: Every agent of the run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentListResponse'
+              examples:
+                agentTree:
+                  summary: Root orchestrator with two subagents and one nested subagent
+                  value:
+                    projectPosition: 17
+                    agents:
+                      - agentId: orchestrator-root
+                        runId: run-2026-08-04-0001
+                        parentAgentId: null
+                        role: orchestrator
+                        displayName: Root Orchestrator
+                        assignedTask: Extract VAT handling out of pricing.
+                        status: ''
+                        statusNote: ''
+                        progress: null
+                        finishedOutcome: null
+                        startedAt: '2026-08-04T09:00:01Z'
+                        lastEventAt: '2026-08-04T09:00:06Z'
+                        position: 6
+                      - agentId: subagent-implementer
+                        runId: run-2026-08-04-0001
+                        parentAgentId: orchestrator-root
+                        role: subagent
+                        displayName: Implementer
+                        assignedTask: Move VAT handling out of the pricing module.
+                        status: working
+                        statusNote: Rewriting Total().
+                        progress:
+                          percent: 70
+                          scope: own_task
+                          basis: completed_steps
+                        finishedOutcome: null
+                        startedAt: '2026-08-04T09:00:03Z'
+                        lastEventAt: '2026-08-04T09:00:11Z'
+                        position: 11
+                      - agentId: subagent-reviewer
+                        runId: run-2026-08-04-0001
+                        parentAgentId: subagent-implementer
+                        role: subagent
+                        displayName: Reviewer
+                        assignedTask: Review the extraction.
+                        status: ''
+                        statusNote: ''
+                        progress: null
+                        finishedOutcome: null
+                        startedAt: '2026-08-04T09:00:04Z'
+                        lastEventAt: '2026-08-04T09:00:15Z'
+                        position: 15
+        '404':
+          $ref: '#/components/responses/RunNotFound'
+
+  /api/v1/projects/{projectId}/runs/{runId}/plans:
+    get:
+      tags:
+        - Read models
+      operationId: listRunPlans
+      summary: Get every plan of one run with all of its revisions
+      description: |
+        Returns every plan of one run together with **all** of its revisions and their steps.
+
+        Revisions are append-only: publishing a new revision never rewrites an earlier one, and
+        a `plan.step_updated` only reaches the revision that was current when it was reported.
+        An earlier revision therefore keeps exactly the step states it was last seen with,
+        which is what makes a plan change reviewable rather than invisible.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/RunIdPath'
+      responses:
+        '200':
+          description: Every plan of the run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanListResponse'
+              examples:
+                plans:
+                  summary: One plan with a single revision
+                  value:
+                    projectPosition: 17
+                    plans:
+                      - planId: plan-2026-08-04-0001
+                        runId: run-2026-08-04-0001
+                        agentId: orchestrator-root
+                        currentRevision: 1
+                        position: 6
+                        revisions:
+                          - revision: 1
+                            createdAt: '2026-08-04T09:00:06Z'
+                            createdByAgentId: orchestrator-root
+                            isCurrent: true
+                            position: 6
+                            steps:
+                              - stepId: step-extract
+                                order: 0
+                                title: Extract the tax module
+                                state: in_progress
+                                position: 6
+        '404':
+          $ref: '#/components/responses/RunNotFound'
+
+  /api/v1/projects/{projectId}/components/{componentId}:
+    get:
+      tags:
+        - Read models
+      operationId: getComponentInspector
+      summary: Get the component inspector for one run
+      description: |
+        Returns everything the inspector shows for one component: the applied descriptor, the
+        responsible agent, the current work step and the component scoped feedback, unified
+        diffs, risks, problems and pending proposals.
+
+        The response carries the evidence of **exactly one run** — the one named by `runId`, or
+        the current run when the parameter is omitted. Evidence of other runs is never mixed
+        in; the run spanning view is `…/history`.
+
+        `component` is `null` when the component left the applied model, for example after a
+        `remove` or a snapshot that no longer lists it. Its evidence and its history survive,
+        which is why that case is a body with `component: null` and not a `404`. A component
+        the project never mentioned at all is a `404`.
+
+        `responsibleAgent` is read from evidence rather than guessed: it is the agent of
+        `currentWorkStep`, or — when no work step named this component in this run — the agent
+        that applied the component in this run. Otherwise it is `null`.
+
+        Unified diffs are paged, because one component can accumulate more of them than a
+        single response should carry; every other collection is complete. See `diffLimit` and
+        `diffCursor`.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/ComponentIdPath'
+        - $ref: '#/components/parameters/RunIdQuery'
+        - $ref: '#/components/parameters/DiffLimitQuery'
+        - $ref: '#/components/parameters/DiffCursorQuery'
+      responses:
+        '200':
+          description: The component evidence of one run.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComponentInspectorResponse'
+              examples:
+                inspector:
+                  summary: Feedback, one unified diff, a risk, a problem and a pending proposal
+                  externalValue: './examples/component-inspector.json'
+        '400':
+          $ref: '#/components/responses/InvalidQueryParameter'
+        '404':
+          $ref: '#/components/responses/ComponentNotFound'
+
+  /api/v1/projects/{projectId}/components/{componentId}/history:
+    get:
+      tags:
+        - Read models
+      operationId: getComponentHistory
+      summary: Page through everything ever reported about one component
+      description: |
+        Returns every event that touched one component, **across all runs** of the project,
+        descending by project position. Each entry names the run it belongs to, so the UI can
+        separate the current run from older evidence without a second request.
+
+        Entries are the reported events as they were stored. Corrections and retractions appear
+        as their own entries: the log is append-only and nothing is ever overwritten, so a
+        withdrawn statement stays visible as history rather than disappearing.
+
+        The list is served from the component index the backend maintains for exactly this
+        purpose; it is not a scan over event payloads.
+      parameters:
+        - $ref: '#/components/parameters/ProjectIdPath'
+        - $ref: '#/components/parameters/ComponentIdPath'
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/CursorQuery'
+      responses:
+        '200':
+          description: One page of component history.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComponentHistoryResponse'
+              examples:
+                history:
+                  summary: The newest two entries, with a cursor for the next page
+                  value:
+                    projectPosition: 17
+                    entries:
+                      - position: 17
+                        serverEventId: ad74501c-924e-432c-a604-3c100777a230
+                        clientEventId: be4032f2-4d1d-4715-ac62-a2dfc2fcff0a
+                        runId: run-2026-08-04-0001
+                        agentId: subagent-architecture-mapper
+                        parentAgentId: null
+                        type: relationship.change_planned
+                        schemaVersion: '1.0'
+                        occurredAt: '2026-08-04T09:00:17Z'
+                        receivedAt: '2026-08-04T07:10:36.220858Z'
+                        payload:
+                          changeId: change-2026-08-04-0009
+                          operation: add
+                          rationale: Pricing will call into the new tax module.
+                          relationship:
+                            relationshipId: rel-pricing-tax
+                            sourceComponentId: shop-platform.orders.domain.pricing
+                            targetComponentId: shop-platform.orders.domain.tax
+                            kind: dependency
+                            label: Delegates VAT calculation
+                    nextCursor: djF8MTY
+        '400':
+          $ref: '#/components/responses/InvalidQueryParameter'
+        '404':
+          $ref: '#/components/responses/ComponentNotFound'
+
   /healthz:
     get:
       tags:
@@ -325,9 +781,91 @@ components:
       name: projectId
       in: path
       required: true
-      description: Project whose event stream is requested.
+      description: Project the request is scoped to.
       schema:
         $ref: '#/components/schemas/ProjectId'
+
+    RunIdPath:
+      name: runId
+      in: path
+      required: true
+      description: |
+        Run inside the project, or the literal `current` for the run a root orchestrator opened
+        last. The alias wins over a run that happens to carry that identifier: the default view
+        of the cockpit must not depend on how an agent named its run.
+      schema:
+        $ref: '#/components/schemas/RunId'
+      example: current
+
+    ComponentIdPath:
+      name: componentId
+      in: path
+      required: true
+      description: Component of the project's architecture model.
+      schema:
+        $ref: '#/components/schemas/ComponentId'
+
+    RunIdQuery:
+      name: runId
+      in: query
+      required: false
+      description: |
+        Run the component evidence is read from. Omitted means the current run; `current` means
+        the same thing explicitly. Any other value must name a run of this project, otherwise
+        the request is rejected with `404` and code `run_not_found` rather than silently falling
+        back to the current run.
+      schema:
+        $ref: '#/components/schemas/RunId'
+      example: run-2026-08-04-0001
+
+    LimitQuery:
+      name: limit
+      in: query
+      required: false
+      description: |
+        Number of entries per page. Defaults to 50, maximum 200. A value outside that range is
+        rejected with `400` rather than clamped, so a client cannot believe it received
+        everything.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+      example: 50
+
+    CursorQuery:
+      name: cursor
+      in: query
+      required: false
+      description: |
+        Continuation token of the previous page, taken from its `nextCursor`. Opaque: it is
+        echoed back unchanged and its encoding is free to change.
+      schema:
+        $ref: '#/components/schemas/Cursor'
+
+    DiffLimitQuery:
+      name: diffLimit
+      in: query
+      required: false
+      description: |
+        Number of unified diffs in the component inspector. Defaults to 50, maximum 200; a value
+        outside that range is rejected with `400`.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+      example: 50
+
+    DiffCursorQuery:
+      name: diffCursor
+      in: query
+      required: false
+      description: |
+        Continuation token for the diffs of the component inspector, taken from the previous
+        response's `nextDiffCursor`.
+      schema:
+        $ref: '#/components/schemas/Cursor'
 
     LastEventPositionQuery:
       name: lastEventPosition
@@ -423,12 +961,21 @@ components:
       description: |
         The event is well-formed and schema-valid but contradicts the current state of the
         project. Codes: `unknown_agent`, `run_already_finished`, `run_not_started`,
-        `parent_agent_unknown`, `terminal_event_not_allowed`, `correction_target_unknown`.
+        `run_already_started`, `parent_agent_unknown`, `terminal_event_not_allowed`,
+        `correction_target_unknown`.
       content:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/Problem'
           examples:
+            runAlreadyStarted:
+              summary: A second root agent.started for a run that already exists
+              value:
+                type: 'https://visualise-ai.local/problems/run-already-started'
+                title: Run already started
+                status: 422
+                detail: Run "run-2026-08-04-0001" was already opened by a root agent.started in this project.
+                code: run_already_started
             runAlreadyFinished:
               summary: Work event after run.finished
               value:
@@ -461,6 +1008,77 @@ components:
                 status: 404
                 detail: No project with id "unknown-project" exists.
                 code: project_not_found
+
+    RunNotFound:
+      description: |
+        The project, or the requested run inside it, is unknown. Codes: `project_not_found`,
+        `run_not_found`, `current_run_not_found`. The last one is distinct on purpose: a project
+        whose runs were never opened by a root orchestrator has no current run, which a client
+        must be able to tell apart from a wrong run id.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            runNotFound:
+              summary: Unknown run id
+              value:
+                type: 'https://visualise-ai.local/problems/run-not-found'
+                title: Run not found
+                status: 404
+                detail: No run with id "run-does-not-exist" exists in project "visualise-ai".
+                code: run_not_found
+            currentRunNotFound:
+              summary: The project has no current run
+              value:
+                type: 'https://visualise-ai.local/problems/current-run-not-found'
+                title: No current run
+                status: 404
+                detail: Project "visualise-ai" has no current run; no root orchestrator has opened one.
+                code: current_run_not_found
+
+    ComponentNotFound:
+      description: |
+        The project, the requested run or the component is unknown. Codes:
+        `project_not_found`, `run_not_found`, `current_run_not_found`, `component_not_found`.
+
+        A component that left the applied model but still has history is **not** an error: it
+        is answered with `200` and `component: null`.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            componentNotFound:
+              summary: The project never reported this component
+              value:
+                type: 'https://visualise-ai.local/problems/component-not-found'
+                title: Component not found
+                status: 404
+                detail: Project "visualise-ai" has never reported component "shop-platform.unknown".
+                code: component_not_found
+
+    InvalidQueryParameter:
+      description: |
+        A query parameter of a read request is not acceptable. Code:
+        `invalid_query_parameter`. `errors[].field` names the rejected query parameter.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidationProblem'
+          examples:
+            limitOutOfRange:
+              summary: Limit above the documented maximum
+              value:
+                type: 'https://visualise-ai.local/problems/invalid-query-parameter'
+                title: Invalid query parameter
+                status: 400
+                detail: One or more query parameters of this request are not acceptable.
+                code: invalid_query_parameter
+                errors:
+                  - field: /limit
+                    code: out_of_range
+                    message: limit must be between 1 and 200
 
   schemas:
 
@@ -2033,8 +2651,10 @@ components:
             `unsupported_event_type`, `unsupported_schema_version`,
             `client_event_id_conflict`, `event_too_large`, `unsupported_media_type`,
             `unknown_agent`, `run_already_finished`, `run_not_started`,
-            `parent_agent_unknown`, `terminal_event_not_allowed`,
-            `correction_target_unknown`, `project_not_found` or `not_ready`.
+            `run_already_started`, `parent_agent_unknown`, `terminal_event_not_allowed`,
+            `correction_target_unknown`, `project_not_found`, `run_not_found`,
+            `current_run_not_found`, `component_not_found`, `invalid_query_parameter` or
+            `not_ready`.
           minLength: 1
         instance:
           type: string
@@ -2056,7 +2676,8 @@ components:
           type: string
           description: |
             RFC 6901 JSON Pointer into the rejected request body, for example
-            `/payload/percent`.
+            `/payload/percent`. Read requests have no body, so there the pointer names the
+            rejected query parameter, for example `/limit`.
           minLength: 1
         code:
           type: string
@@ -2118,6 +2739,1162 @@ components:
         - detail
         - code
         - errors
+      additionalProperties: false
+
+    # ---------------------------------------------------------------------------
+    # Read models
+    #
+    # These are server side projections, not reported documents: they repeat what
+    # agents reported plus the positions that make a snapshot comparable with the
+    # SSE stream. They deliberately do not reuse the reported descriptor schemas
+    # above — a `Component` in an event is what an agent claims, an
+    # `AppliedComponent` is what the model currently holds.
+    # ---------------------------------------------------------------------------
+
+    ProjectPosition:
+      type: integer
+      format: int64
+      description: |
+        Server side project position at the moment the snapshot was read. It is the position of
+        the last event committed for the project, so a client can compare an HTTP snapshot with
+        its SSE cursor and know exactly which events it still has to apply. `0` means nothing
+        has been reported yet.
+      minimum: 0
+      examples:
+        - 17
+
+    AppliedPosition:
+      type: integer
+      format: int64
+      description: |
+        Project position of the event that last wrote this row. It lets the UI reconcile a
+        single node when a live event arrives instead of refetching the whole snapshot.
+      minimum: 0
+      examples:
+        - 11
+
+    Cursor:
+      type: string
+      description: |
+        Opaque continuation token. It encodes the sort key of the last returned entry; clients
+        echo it back unchanged and must not parse it.
+      minLength: 1
+      examples:
+        - djF8MTY
+
+    ProjectSummary:
+      type: object
+      description: One project as shown in the project list.
+      properties:
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        firstSeenAt:
+          description: When the first accepted event of this project was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastEventAt:
+          description: When the most recent accepted event of this project was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        currentRunId:
+          description: |
+            The run a root orchestrator opened last, or `null` while no root orchestrator has
+            opened one.
+          oneOf:
+            - $ref: '#/components/schemas/RunId'
+            - type: 'null'
+      required:
+        - projectId
+        - firstSeenAt
+        - lastEventAt
+        - lastPosition
+        - currentRunId
+      additionalProperties: false
+
+    ProjectCounts:
+      type: object
+      description: Sizes of the read models of one project.
+      properties:
+        runs:
+          type: integer
+          description: Runs of this project, current and historical.
+          minimum: 0
+        openRuns:
+          type: integer
+          description: Runs without an explicit `run.finished`.
+          minimum: 0
+        components:
+          type: integer
+          description: Components of the applied architecture model.
+          minimum: 0
+        relationships:
+          type: integer
+          description: Relationships of the applied architecture model.
+          minimum: 0
+        activeChanges:
+          type: integer
+          description: Pending change proposals, that is changes in state `planned`.
+          minimum: 0
+      required:
+        - runs
+        - openRuns
+        - components
+        - relationships
+        - activeChanges
+      additionalProperties: false
+
+    ProjectDetail:
+      type: object
+      description: One project together with the sizes of its read models.
+      properties:
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        firstSeenAt:
+          description: When the first accepted event of this project was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastEventAt:
+          description: When the most recent accepted event of this project was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        currentRunId:
+          description: The run a root orchestrator opened last, or `null`.
+          oneOf:
+            - $ref: '#/components/schemas/RunId'
+            - type: 'null'
+        counts:
+          $ref: '#/components/schemas/ProjectCounts'
+      required:
+        - projectId
+        - firstSeenAt
+        - lastEventAt
+        - lastPosition
+        - currentRunId
+        - counts
+      additionalProperties: false
+
+    ProjectListResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects`. Not scoped to one project, so `projectPosition` is the
+        highest position across the listed projects.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        projects:
+          type: array
+          description: Every known project, ordered by `projectId`.
+          items:
+            $ref: '#/components/schemas/ProjectSummary'
+      required:
+        - projectPosition
+        - projects
+      additionalProperties: false
+
+    ProjectResponse:
+      type: object
+      description: Body of `GET /api/v1/projects/{projectId}`.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        project:
+          $ref: '#/components/schemas/ProjectDetail'
+      required:
+        - projectPosition
+        - project
+      additionalProperties: false
+
+    AppliedComponent:
+      type: object
+      description: |
+        One node of the applied architecture model. `parentComponentId` is the only expression
+        of the hierarchy; the list itself is flat.
+      properties:
+        componentId:
+          $ref: '#/components/schemas/ComponentId'
+        name:
+          type: string
+          description: Human-readable display name shown on the architecture canvas.
+        kind:
+          type: string
+          description: Structural role of the component, as reported.
+          enum:
+            - system
+            - service
+            - module
+            - datastore
+            - queue
+            - topic
+            - ui
+            - external
+            - library
+        parentComponentId:
+          description: Parent node in the component hierarchy, or `null` for a root component.
+          oneOf:
+            - $ref: '#/components/schemas/ComponentId'
+            - type: 'null'
+        description:
+          type: string
+          description: Short explanation of the component's responsibility, empty when none was reported.
+        technology:
+          description: |
+            Reported technology metadata, handed through unchanged. An empty object means the
+            agent reported none.
+          allOf:
+            - $ref: '#/components/schemas/Technology'
+        tags:
+          type: array
+          description: Reported free-form labels, empty when none were reported.
+          items:
+            type: string
+        appliedAt:
+          description: When the event that last wrote this component was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        appliedByAgentId:
+          $ref: '#/components/schemas/AgentId'
+        appliedRunId:
+          $ref: '#/components/schemas/RunId'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - componentId
+        - name
+        - kind
+        - parentComponentId
+        - description
+        - technology
+        - tags
+        - appliedAt
+        - appliedByAgentId
+        - appliedRunId
+        - position
+      additionalProperties: false
+
+    AppliedRelationship:
+      type: object
+      description: |
+        One typed, directed edge of the applied model. Every NATS topic keeps its own row with
+        the topic name in `channel`; edges are never aggregated server side.
+      properties:
+        relationshipId:
+          $ref: '#/components/schemas/Identifier'
+        sourceComponentId:
+          $ref: '#/components/schemas/ComponentId'
+        targetComponentId:
+          $ref: '#/components/schemas/ComponentId'
+        kind:
+          type: string
+          description: Interaction type of the edge, as reported.
+          enum:
+            - http
+            - grpc
+            - data
+            - async
+            - nats_topic
+            - dependency
+        label:
+          type: string
+          description: Reported edge label, empty when none was reported.
+        protocol:
+          type: string
+          description: Reported protocol, empty when none was reported.
+        operation:
+          type: string
+          description: Reported operation, empty when none was reported.
+        channel:
+          type: string
+          description: |
+            Reported channel. For `kind: nats_topic` this is the topic name and identifies the
+            relationship semantically. Empty when none was reported.
+        appliedAt:
+          description: When the event that last wrote this relationship was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        appliedByAgentId:
+          $ref: '#/components/schemas/AgentId'
+        appliedRunId:
+          $ref: '#/components/schemas/RunId'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - relationshipId
+        - sourceComponentId
+        - targetComponentId
+        - kind
+        - label
+        - protocol
+        - operation
+        - channel
+        - appliedAt
+        - appliedByAgentId
+        - appliedRunId
+        - position
+      additionalProperties: false
+
+    ActiveChange:
+      type: object
+      description: |
+        A pending change proposal, that is a reported change that is still in state `planned`.
+        `snapshot` carries the reported component or relationship descriptor verbatim, so the
+        canvas can draw the proposal next to the applied model without a second lookup.
+      properties:
+        changeId:
+          $ref: '#/components/schemas/Identifier'
+        targetKind:
+          type: string
+          description: What the change is about.
+          enum:
+            - component
+            - relationship
+        targetId:
+          type: string
+          description: Identifier of the component or relationship the change targets.
+          minLength: 1
+        operation:
+          $ref: '#/components/schemas/ChangeOperation'
+        state:
+          type: string
+          description: |
+            Lifecycle state of the change. The read endpoints only return `planned`; `applied`
+            has become the model and `retracted` was withdrawn.
+          enum:
+            - planned
+            - applied
+            - retracted
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        plannedAt:
+          description: When the change was announced, or `null` when it was never planned.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        appliedAt:
+          description: When the change was applied, `null` while it is pending.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        retractedAt:
+          description: When the change was withdrawn, `null` while it stands.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        snapshot:
+          type: object
+          description: |
+            The reported descriptor of the proposal — a `Component` or a `Relationship`
+            document, selected by `targetKind` — stored and returned as reported.
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - changeId
+        - targetKind
+        - targetId
+        - operation
+        - state
+        - runId
+        - agentId
+        - plannedAt
+        - appliedAt
+        - retractedAt
+        - snapshot
+        - position
+      additionalProperties: false
+
+    ArchitectureResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/architecture`: the applied model plus the
+        proposals that are still pending. A planned change never appears in `components` or
+        `relationships`.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        components:
+          type: array
+          description: Every component of the applied model, ordered by `componentId`.
+          items:
+            $ref: '#/components/schemas/AppliedComponent'
+        relationships:
+          type: array
+          description: Every relationship of the applied model, ordered by `relationshipId`.
+          items:
+            $ref: '#/components/schemas/AppliedRelationship'
+        activeChanges:
+          type: array
+          description: Pending proposals, newest first.
+          items:
+            $ref: '#/components/schemas/ActiveChange'
+      required:
+        - projectPosition
+        - components
+        - relationships
+        - activeChanges
+      additionalProperties: false
+
+    RunSummary:
+      type: object
+      description: |
+        One run. It stays open until an explicit `run.finished` closes it; silence never
+        produces a terminal state.
+      properties:
+        runId:
+          $ref: '#/components/schemas/RunId'
+        rootAgentId:
+          description: |
+            The orchestrator that opened the run, or `null` while no root orchestrator reported
+            `agent.started` for it.
+          oneOf:
+            - $ref: '#/components/schemas/AgentId'
+            - type: 'null'
+        startedAt:
+          description: When the run was first seen.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        finishedAt:
+          description: When `run.finished` was reported, `null` while the run is open.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        outcome:
+          description: Reported terminal outcome, `null` while the run is open.
+          oneOf:
+            - $ref: '#/components/schemas/Outcome'
+            - type: 'null'
+        isOpen:
+          type: boolean
+          description: '`false` only after an explicit `run.finished`.'
+        isCurrent:
+          type: boolean
+          description: Whether this is the run `current` resolves to.
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - runId
+        - rootAgentId
+        - startedAt
+        - finishedAt
+        - outcome
+        - isOpen
+        - isCurrent
+        - position
+      additionalProperties: false
+
+    RunCounts:
+      type: object
+      description: Sizes of the read models of one run.
+      properties:
+        agents:
+          type: integer
+          description: Agents that reported `agent.started` in this run.
+          minimum: 0
+        plans:
+          type: integer
+          description: Plans published in this run.
+          minimum: 0
+        workSteps:
+          type: integer
+          description: Work steps reported in this run.
+          minimum: 0
+      required:
+        - agents
+        - plans
+        - workSteps
+      additionalProperties: false
+
+    RunDetail:
+      type: object
+      description: One run together with the sizes of the collections hanging off it.
+      properties:
+        runId:
+          $ref: '#/components/schemas/RunId'
+        rootAgentId:
+          description: The orchestrator that opened the run, or `null`.
+          oneOf:
+            - $ref: '#/components/schemas/AgentId'
+            - type: 'null'
+        startedAt:
+          description: When the run was first seen.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        finishedAt:
+          description: When `run.finished` was reported, `null` while the run is open.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        outcome:
+          description: Reported terminal outcome, `null` while the run is open.
+          oneOf:
+            - $ref: '#/components/schemas/Outcome'
+            - type: 'null'
+        isOpen:
+          type: boolean
+          description: '`false` only after an explicit `run.finished`.'
+        isCurrent:
+          type: boolean
+          description: Whether this is the run `current` resolves to.
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+        counts:
+          $ref: '#/components/schemas/RunCounts'
+      required:
+        - runId
+        - rootAgentId
+        - startedAt
+        - finishedAt
+        - outcome
+        - isOpen
+        - isCurrent
+        - position
+        - counts
+      additionalProperties: false
+
+    RunListResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/runs`. Current and historical runs in one
+        list, descending by start.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        runs:
+          type: array
+          description: One page of runs.
+          items:
+            $ref: '#/components/schemas/RunSummary'
+        nextCursor:
+          description: Cursor of the next page, `null` on the last one.
+          oneOf:
+            - $ref: '#/components/schemas/Cursor'
+            - type: 'null'
+      required:
+        - projectPosition
+        - runs
+        - nextCursor
+      additionalProperties: false
+
+    RunResponse:
+      type: object
+      description: Body of `GET /api/v1/projects/{projectId}/runs/{runId}`.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        run:
+          $ref: '#/components/schemas/RunDetail'
+      required:
+        - projectPosition
+        - run
+      additionalProperties: false
+
+    AgentProgress:
+      type: object
+      description: |
+        Progress **as reported by the agent itself**. `scope` separates a subagent's own task
+        from an orchestrator's estimate for the whole run; `basis` separates a free estimate
+        from counted steps. The cockpit displays it as reported and checks nothing.
+      properties:
+        percent:
+          type: integer
+          description: Reported completion in percent.
+          minimum: 0
+          maximum: 100
+        scope:
+          description: What the percentage refers to, `null` when it was not reported.
+          oneOf:
+            - type: string
+              enum:
+                - own_task
+                - overall_estimate
+            - type: 'null'
+        basis:
+          description: How the number was derived, `null` when it was not reported.
+          oneOf:
+            - type: string
+              enum:
+                - reported_estimate
+                - completed_steps
+            - type: 'null'
+      required:
+        - percent
+        - scope
+        - basis
+      additionalProperties: false
+
+    RunAgent:
+      type: object
+      description: |
+        One node of the agent tree of a run. The tree is expressed through `parentAgentId`;
+        the list is flat.
+
+        Nothing here is derived: `status` stays empty until `agent.status_reported` arrives,
+        `progress` stays `null` until the agent reported a number, and `finishedOutcome` stays
+        `null` until `agent.finished`. Silence changes nothing.
+      properties:
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        parentAgentId:
+          description: The delegating agent, `null` for the root orchestrator.
+          oneOf:
+            - $ref: '#/components/schemas/AgentId'
+            - type: 'null'
+        role:
+          type: string
+          description: Position of the agent in the run hierarchy, as reported.
+          enum:
+            - ''
+            - orchestrator
+            - subagent
+        displayName:
+          type: string
+          description: Name shown for this agent, empty when the agent never reported `agent.started`.
+        assignedTask:
+          type: string
+          description: The task the agent was given, in its own words. Empty when never reported.
+        status:
+          type: string
+          description: Last explicitly reported status. Empty means none was ever reported.
+          enum:
+            - ''
+            - working
+            - waiting
+            - blocked
+            - idle
+            - done
+        statusNote:
+          type: string
+          description: Optional one-line explanation that came with the status.
+        progress:
+          description: Self-assessed progress, `null` until the agent reported one.
+          oneOf:
+            - $ref: '#/components/schemas/AgentProgress'
+            - type: 'null'
+        finishedOutcome:
+          description: Reported outcome of `agent.finished`, `null` while the agent has not finished.
+          oneOf:
+            - $ref: '#/components/schemas/Outcome'
+            - type: 'null'
+        startedAt:
+          description: When the agent was first seen in this run.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        lastEventAt:
+          description: When this agent last reported anything.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - agentId
+        - runId
+        - parentAgentId
+        - role
+        - displayName
+        - assignedTask
+        - status
+        - statusNote
+        - progress
+        - finishedOutcome
+        - startedAt
+        - lastEventAt
+        - position
+      additionalProperties: false
+
+    AgentListResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/runs/{runId}/agents`. Flat, ordered so a
+        parent precedes the subagents it spawned.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        agents:
+          type: array
+          description: Every agent of the run.
+          items:
+            $ref: '#/components/schemas/RunAgent'
+      required:
+        - projectPosition
+        - agents
+      additionalProperties: false
+
+    RunPlanStep:
+      type: object
+      description: One step of one plan revision, in the reported order.
+      properties:
+        stepId:
+          $ref: '#/components/schemas/Identifier'
+        order:
+          type: integer
+          description: Zero-based position of the step within its revision.
+          minimum: 0
+        title:
+          type: string
+          description: Short description of what the step achieves.
+        state:
+          $ref: '#/components/schemas/PlanStepState'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - stepId
+        - order
+        - title
+        - state
+        - position
+      additionalProperties: false
+
+    RunPlanRevision:
+      type: object
+      description: |
+        One published revision of a plan. Revisions are append-only: a `plan.step_updated` only
+        reaches the revision that was current when it was reported, so an earlier revision keeps
+        exactly the states it was last seen with.
+      properties:
+        revision:
+          type: integer
+          description: Revision number, starting at 1 and strictly increasing per plan.
+          minimum: 1
+        createdAt:
+          description: When this revision was published.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        createdByAgentId:
+          $ref: '#/components/schemas/AgentId'
+        isCurrent:
+          type: boolean
+          description: Whether `plan.step_updated` currently writes to this revision.
+        steps:
+          type: array
+          description: All steps of this revision, ordered by `order`.
+          items:
+            $ref: '#/components/schemas/RunPlanStep'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - revision
+        - createdAt
+        - createdByAgentId
+        - isCurrent
+        - steps
+        - position
+      additionalProperties: false
+
+    RunPlan:
+      type: object
+      description: One plan of a run with every revision it ever had, ascending.
+      properties:
+        planId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        currentRevision:
+          type: integer
+          description: The revision the cockpit shows by default.
+          minimum: 0
+        revisions:
+          type: array
+          description: Every published revision, ascending.
+          items:
+            $ref: '#/components/schemas/RunPlanRevision'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - planId
+        - runId
+        - agentId
+        - currentRevision
+        - revisions
+        - position
+      additionalProperties: false
+
+    PlanListResponse:
+      type: object
+      description: Body of `GET /api/v1/projects/{projectId}/runs/{runId}/plans`.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        plans:
+          type: array
+          description: Every plan of the run, ordered by `planId`.
+          items:
+            $ref: '#/components/schemas/RunPlan'
+      required:
+        - projectPosition
+        - plans
+      additionalProperties: false
+
+    InspectorWorkStep:
+      type: object
+      description: |
+        A concrete unit of work an agent reported. The inspector shows the open work step of
+        the selected run, or the most recently started one when all of them completed.
+      properties:
+        workStepId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        planStepId:
+          description: The planned step this work followed, `null` for unplanned work.
+          oneOf:
+            - $ref: '#/components/schemas/Identifier'
+            - type: 'null'
+        title:
+          type: string
+          description: Short description of the work.
+        startedAt:
+          description: When the work step was reported as started.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        completedAt:
+          description: When it was reported as completed, `null` while it is open.
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+        summary:
+          description: Reported result summary, `null` while the step is open.
+          type:
+            - string
+            - 'null'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - workStepId
+        - runId
+        - agentId
+        - planStepId
+        - title
+        - startedAt
+        - completedAt
+        - summary
+        - position
+      additionalProperties: false
+
+    FeedbackEntry:
+      type: object
+      description: |
+        One published, component scoped feedback item. `body` is untrusted markdown and is
+        handed through verbatim — sanitising it before rendering is the client's job.
+      properties:
+        feedbackId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        format:
+          type: string
+          description: Body format. v0 reports markdown only.
+          enum:
+            - markdown
+        title:
+          type: string
+          description: Reported headline, empty when none was reported.
+        body:
+          type: string
+          description: The feedback text as reported.
+        createdAt:
+          description: When the feedback was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - feedbackId
+        - runId
+        - agentId
+        - format
+        - title
+        - body
+        - createdAt
+        - position
+      additionalProperties: false
+
+    ReportedDiff:
+      type: object
+      description: |
+        One reported unified diff of exactly one repository file. The backend never splits or
+        merges diffs; `changeId` is what groups the files of one logical change.
+      properties:
+        diffId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        changeId:
+          description: The change this file belongs to, `null` for an unattributed diff.
+          oneOf:
+            - $ref: '#/components/schemas/Identifier'
+            - type: 'null'
+        filePath:
+          $ref: '#/components/schemas/RepositoryFilePath'
+        unifiedDiff:
+          type: string
+          description: The unified diff of this one file, exactly as reported.
+        createdAt:
+          description: When the diff was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - diffId
+        - runId
+        - agentId
+        - changeId
+        - filePath
+        - unifiedDiff
+        - createdAt
+        - position
+      additionalProperties: false
+
+    ReportedRisk:
+      type: object
+      description: |
+        A risk **as stated by the reporting agent**. The system never derives, scores or
+        aggregates risks; the human reviewer judges.
+      properties:
+        riskId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        title:
+          type: string
+          description: Short headline of the risk.
+        detail:
+          type: string
+          description: Longer explanation, empty when none was reported.
+        severity:
+          type: string
+          description: Severity as assessed by the reporting agent.
+          enum:
+            - low
+            - medium
+            - high
+        createdAt:
+          description: When the risk was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - riskId
+        - runId
+        - agentId
+        - title
+        - detail
+        - severity
+        - createdAt
+        - position
+      additionalProperties: false
+
+    ReportedProblem:
+      type: object
+      description: A problem as stated by the reporting agent, never a system-side evaluation.
+      properties:
+        problemId:
+          $ref: '#/components/schemas/Identifier'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        title:
+          type: string
+          description: Short headline of the problem.
+        detail:
+          type: string
+          description: Longer explanation, empty when none was reported.
+        createdAt:
+          description: When the problem was reported.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+      required:
+        - problemId
+        - runId
+        - agentId
+        - title
+        - detail
+        - createdAt
+        - position
+      additionalProperties: false
+
+    ComponentInspectorResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/components/{componentId}`. Everything here
+        belongs to **one** run — the one named in `runId`. Evidence of other runs is reachable
+        through `…/history` only.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        runId:
+          description: |
+            The run this evidence belongs to, `null` when the project has no run at all yet.
+          oneOf:
+            - $ref: '#/components/schemas/RunId'
+            - type: 'null'
+        component:
+          description: |
+            The applied descriptor, `null` when the component left the applied model but is
+            still known from the history.
+          oneOf:
+            - $ref: '#/components/schemas/AppliedComponent'
+            - type: 'null'
+        responsibleAgent:
+          description: |
+            The agent of `currentWorkStep`, or the agent that applied the component in this run.
+            `null` when neither was reported — responsibility is read from evidence, not guessed.
+          oneOf:
+            - $ref: '#/components/schemas/RunAgent'
+            - type: 'null'
+        currentWorkStep:
+          description: |
+            The open work step of this run touching the component, or the most recently started
+            one when all of them completed. `null` when no work step named the component.
+          oneOf:
+            - $ref: '#/components/schemas/InspectorWorkStep'
+            - type: 'null'
+        feedback:
+          type: array
+          description: Component scoped feedback of this run, newest first. Complete, not paged.
+          items:
+            $ref: '#/components/schemas/FeedbackEntry'
+        diffs:
+          type: array
+          description: |
+            Unified diffs of this run touching the component, newest first. Paged — see
+            `nextDiffCursor`.
+          items:
+            $ref: '#/components/schemas/ReportedDiff'
+        nextDiffCursor:
+          description: Cursor for the next page of diffs, `null` when the last page was returned.
+          oneOf:
+            - $ref: '#/components/schemas/Cursor'
+            - type: 'null'
+        risks:
+          type: array
+          description: Risks reported for this component in this run, newest first.
+          items:
+            $ref: '#/components/schemas/ReportedRisk'
+        problems:
+          type: array
+          description: Problems reported for this component in this run, newest first.
+          items:
+            $ref: '#/components/schemas/ReportedProblem'
+        activeChanges:
+          type: array
+          description: |
+            Pending proposals of this run that target this component. Proposals that target a
+            relationship are shown on the architecture endpoint instead.
+          items:
+            $ref: '#/components/schemas/ActiveChange'
+      required:
+        - projectPosition
+        - runId
+        - component
+        - responsibleAgent
+        - currentWorkStep
+        - feedback
+        - diffs
+        - nextDiffCursor
+        - risks
+        - problems
+        - activeChanges
+      additionalProperties: false
+
+    ComponentHistoryEntry:
+      type: object
+      description: |
+        One reported event that touched the component, as it was stored. Corrections and
+        retractions appear as their own entries; nothing is ever overwritten.
+      properties:
+        position:
+          $ref: '#/components/schemas/AppliedPosition'
+        serverEventId:
+          description: Server-assigned identity of the stored event.
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+        clientEventId:
+          description: The idempotency key the agent assigned.
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+        runId:
+          $ref: '#/components/schemas/RunId'
+        agentId:
+          $ref: '#/components/schemas/AgentId'
+        parentAgentId:
+          description: The delegating agent, `null` for the root orchestrator.
+          oneOf:
+            - $ref: '#/components/schemas/AgentId'
+            - type: 'null'
+        type:
+          $ref: '#/components/schemas/EventType'
+        schemaVersion:
+          $ref: '#/components/schemas/SchemaVersion'
+        occurredAt:
+          description: When the reported step happened, as observed by the agent.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        receivedAt:
+          description: When the backend accepted and committed the event.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+        payload:
+          type: object
+          description: |
+            The reported payload, canonicalised but otherwise unchanged. Its effective schema is
+            fixed by `type`, exactly as during ingestion.
+      required:
+        - position
+        - serverEventId
+        - clientEventId
+        - runId
+        - agentId
+        - parentAgentId
+        - type
+        - schemaVersion
+        - occurredAt
+        - receivedAt
+        - payload
+      additionalProperties: false
+
+    ComponentHistoryResponse:
+      type: object
+      description: |
+        Body of `GET /api/v1/projects/{projectId}/components/{componentId}/history`: the run
+        spanning evidence of one component, descending by project position.
+      properties:
+        projectPosition:
+          $ref: '#/components/schemas/ProjectPosition'
+        entries:
+          type: array
+          description: One page of history, newest first.
+          items:
+            $ref: '#/components/schemas/ComponentHistoryEntry'
+        nextCursor:
+          description: Cursor of the next page, `null` on the last one.
+          oneOf:
+            - $ref: '#/components/schemas/Cursor'
+            - type: 'null'
+      required:
+        - projectPosition
+        - entries
+        - nextCursor
       additionalProperties: false
 
     LivenessStatus:

--- a/backend/internal/readapi/components.go
+++ b/backend/internal/readapi/components.go
@@ -1,0 +1,378 @@
+package readapi
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/risqyy/visualise-ai/backend/internal/store"
+)
+
+// ComponentQuery narrows the component inspector.
+type ComponentQuery struct {
+	// RunID selects the run the evidence is read from. Empty means the current
+	// run of the project; the literal CurrentRunAlias means the same thing
+	// explicitly. Any other value must name a run of this project.
+	RunID string
+	// DiffLimit and DiffCursor page the unified diffs. See ComponentResponse.
+	DiffLimit  string
+	DiffCursor string
+}
+
+// Component returns everything the inspector shows for one component.
+//
+// The response is scoped to **exactly one run**. Evidence of other runs is
+// never mixed in, so "what is happening here right now" cannot be confused with
+// "what happened here at some point"; the run spanning view is History.
+//
+// Statement count is fixed at ten and independent of how much evidence exists:
+// project, component, component history probe (only when the component left the
+// applied model), work step, responsible agent, feedback, diffs, risks,
+// problems, pending changes. Every collection is loaded through its join table
+// in one statement — there is no query per row and no JSONB scan over `events`.
+func (s *Service) Component(ctx context.Context, projectID, componentID string, query ComponentQuery) (ComponentResponse, error) {
+	project, err := s.project(ctx, projectID)
+	if err != nil {
+		return ComponentResponse{}, err
+	}
+
+	page, invalid := parsePage("diffLimit", "diffCursor", query.DiffLimit, query.DiffCursor)
+	if invalid != nil {
+		return ComponentResponse{}, invalid
+	}
+
+	runID := project.CurrentRunID
+	if query.RunID != "" {
+		run, runErr := s.resolveRun(ctx, project, query.RunID)
+		if runErr != nil {
+			return ComponentResponse{}, runErr
+		}
+		runID = run.RunID
+	}
+
+	component, err := s.componentOfProject(ctx, projectID, componentID)
+	if err != nil {
+		return ComponentResponse{}, err
+	}
+
+	response := ComponentResponse{
+		ProjectPosition: project.LastPosition,
+		RunID:           nonEmpty(runID),
+		Component:       component,
+		Feedback:        []FeedbackEntry{},
+		Diffs:           []Diff{},
+		Risks:           []Risk{},
+		Problems:        []Problem{},
+		ActiveChanges:   []ActiveChange{},
+	}
+	if runID == "" {
+		// The project exists but no run has ever been opened, so there is no
+		// evidence to attribute to one. Empty lists, no guessing.
+		return response, nil
+	}
+
+	workStep, err := s.currentWorkStep(ctx, projectID, runID, componentID)
+	if err != nil {
+		return ComponentResponse{}, err
+	}
+	response.CurrentWorkStep = workStep
+
+	responsibleAgentID := ""
+	switch {
+	case workStep != nil:
+		responsibleAgentID = workStep.AgentID
+	case component != nil && component.AppliedRunID == runID:
+		// No work step named this component in this run, but the component was
+		// applied here — the applying agent is the reported responsibility.
+		responsibleAgentID = component.AppliedByAgentID
+	}
+	if responsibleAgentID != "" {
+		agent, agentErr := s.agent(ctx, projectID, runID, responsibleAgentID)
+		if agentErr != nil {
+			return ComponentResponse{}, agentErr
+		}
+		response.ResponsibleAgent = agent
+	}
+
+	// Every collection below narrows through its join table first and then
+	// through (project_id, run_id) on the entry itself.
+	linked := func(model any, column string) *gorm.DB {
+		return s.db.WithContext(ctx).Model(model).
+			Select(column).
+			Where("project_id = ? AND component_id = ?", projectID, componentID)
+	}
+
+	var feedbackRows []store.FeedbackEntry
+	if err := s.db.WithContext(ctx).
+		Model(&store.FeedbackEntry{}).
+		Where("project_id = ? AND run_id = ? AND feedback_id IN (?)",
+			projectID, runID, linked(&store.FeedbackComponent{}, "feedback_id")).
+		Order("source_position DESC").
+		Find(&feedbackRows).Error; err != nil {
+		return ComponentResponse{}, err
+	}
+	for _, row := range feedbackRows {
+		response.Feedback = append(response.Feedback, FeedbackEntry{
+			FeedbackID: row.FeedbackID,
+			RunID:      row.RunID,
+			AgentID:    row.AgentID,
+			Format:     row.Format,
+			Title:      row.Title,
+			Body:       row.Body,
+			CreatedAt:  utc(row.CreatedAt),
+			Position:   row.SourcePosition,
+		})
+	}
+
+	diffQuery := s.db.WithContext(ctx).
+		Model(&store.Diff{}).
+		Where("project_id = ? AND run_id = ? AND diff_id IN (?)",
+			projectID, runID, linked(&store.DiffComponent{}, "diff_id"))
+	if page.Cursor != "" {
+		position, ok := parsePositionCursor(page.Cursor)
+		if !ok {
+			return ComponentResponse{}, &ValidationError{Errors: []FieldError{{
+				Field:   "/diffCursor",
+				Code:    codeInvalid,
+				Message: "cursor does not belong to the diff collection",
+			}}}
+		}
+		diffQuery = diffQuery.Where("source_position < ?", position)
+	}
+	var diffRows []store.Diff
+	if err := diffQuery.
+		Order("source_position DESC").
+		Limit(page.Limit + 1).
+		Find(&diffRows).Error; err != nil {
+		return ComponentResponse{}, err
+	}
+	if len(diffRows) > page.Limit {
+		cursor := positionCursor(diffRows[page.Limit-1].SourcePosition)
+		response.NextDiffCursor = &cursor
+		diffRows = diffRows[:page.Limit]
+	}
+	for _, row := range diffRows {
+		response.Diffs = append(response.Diffs, Diff{
+			DiffID:      row.DiffID,
+			RunID:       row.RunID,
+			AgentID:     row.AgentID,
+			ChangeID:    row.ChangeID,
+			FilePath:    row.FilePath,
+			UnifiedDiff: row.UnifiedDiff,
+			CreatedAt:   utc(row.CreatedAt),
+			Position:    row.SourcePosition,
+		})
+	}
+
+	var riskRows []store.Risk
+	if err := s.db.WithContext(ctx).
+		Model(&store.Risk{}).
+		Where("project_id = ? AND run_id = ? AND risk_id IN (?)",
+			projectID, runID, linked(&store.RiskComponent{}, "risk_id")).
+		Order("source_position DESC").
+		Find(&riskRows).Error; err != nil {
+		return ComponentResponse{}, err
+	}
+	for _, row := range riskRows {
+		response.Risks = append(response.Risks, Risk{
+			RiskID:    row.RiskID,
+			RunID:     row.RunID,
+			AgentID:   row.AgentID,
+			Title:     row.Title,
+			Detail:    row.Detail,
+			Severity:  row.Severity,
+			CreatedAt: utc(row.CreatedAt),
+			Position:  row.SourcePosition,
+		})
+	}
+
+	var problemRows []store.Problem
+	if err := s.db.WithContext(ctx).
+		Model(&store.Problem{}).
+		Where("project_id = ? AND run_id = ? AND problem_id IN (?)",
+			projectID, runID, linked(&store.ProblemComponent{}, "problem_id")).
+		Order("source_position DESC").
+		Find(&problemRows).Error; err != nil {
+		return ComponentResponse{}, err
+	}
+	for _, row := range problemRows {
+		response.Problems = append(response.Problems, Problem{
+			ProblemID: row.ProblemID,
+			RunID:     row.RunID,
+			AgentID:   row.AgentID,
+			Title:     row.Title,
+			Detail:    row.Detail,
+			CreatedAt: utc(row.CreatedAt),
+			Position:  row.SourcePosition,
+		})
+	}
+
+	changes, err := s.plannedChanges(ctx, projectID, runID, componentID)
+	if err != nil {
+		return ComponentResponse{}, err
+	}
+	response.ActiveChanges = changes
+
+	return response, nil
+}
+
+// History pages through every event that touched one component, across all runs
+// of the project, descending by project position.
+//
+// Three statements: project, the existence probe for the component and one page
+// of events. The events are reached through `event_components`, the join table
+// the store maintains precisely so that component history is an index lookup
+// instead of a JSONB scan over the log.
+func (s *Service) History(ctx context.Context, projectID, componentID, rawLimit, rawCursor string) (HistoryResponse, error) {
+	project, err := s.project(ctx, projectID)
+	if err != nil {
+		return HistoryResponse{}, err
+	}
+	page, invalid := parsePage("limit", "cursor", rawLimit, rawCursor)
+	if invalid != nil {
+		return HistoryResponse{}, invalid
+	}
+	if _, err := s.componentOfProject(ctx, projectID, componentID); err != nil {
+		return HistoryResponse{}, err
+	}
+
+	positions := s.db.WithContext(ctx).
+		Model(&store.EventComponent{}).
+		Select("position").
+		Where("project_id = ? AND component_id = ?", projectID, componentID)
+
+	query := s.db.WithContext(ctx).
+		Model(&store.Event{}).
+		Where("project_id = ? AND position IN (?)", projectID, positions)
+	if page.Cursor != "" {
+		position, ok := parsePositionCursor(page.Cursor)
+		if !ok {
+			return HistoryResponse{}, &ValidationError{Errors: []FieldError{{
+				Field:   "/cursor",
+				Code:    codeInvalid,
+				Message: "cursor does not belong to the history collection",
+			}}}
+		}
+		query = query.Where("position < ?", position)
+	}
+
+	var rows []store.Event
+	if err := query.
+		Order("position DESC").
+		Limit(page.Limit + 1).
+		Find(&rows).Error; err != nil {
+		return HistoryResponse{}, err
+	}
+
+	response := HistoryResponse{ProjectPosition: project.LastPosition}
+	if len(rows) > page.Limit {
+		cursor := positionCursor(rows[page.Limit-1].Position)
+		response.NextCursor = &cursor
+		rows = rows[:page.Limit]
+	}
+
+	response.Entries = make([]HistoryEntry, 0, len(rows))
+	for _, row := range rows {
+		response.Entries = append(response.Entries, HistoryEntry{
+			Position:      row.Position,
+			ServerEventID: row.ID,
+			ClientEventID: row.ClientEventID,
+			RunID:         row.RunID,
+			AgentID:       row.AgentID,
+			ParentAgentID: row.ParentAgentID,
+			Type:          row.Type,
+			SchemaVersion: row.SchemaVersion,
+			OccurredAt:    utc(row.OccurredAt),
+			ReceivedAt:    utc(row.ReceivedAt),
+			Payload:       rawJSON(row.Payload, "{}"),
+		})
+	}
+	return response, nil
+}
+
+// componentOfProject resolves a component of the applied model.
+//
+// A component that was removed from the model still has a history, so a miss in
+// `components` is only a 404 when `event_components` has never heard of it
+// either. The second statement runs only in that case.
+func (s *Service) componentOfProject(ctx context.Context, projectID, componentID string) (*Component, error) {
+	var row store.Component
+	err := s.db.WithContext(ctx).
+		Where("project_id = ? AND component_id = ?", projectID, componentID).
+		Take(&row).Error
+	switch {
+	case err == nil:
+		component := componentOf(row)
+		return &component, nil
+	case !errors.Is(err, gorm.ErrRecordNotFound):
+		return nil, err
+	}
+
+	var touched int64
+	if err := s.db.WithContext(ctx).
+		Model(&store.EventComponent{}).
+		Where("project_id = ? AND component_id = ?", projectID, componentID).
+		Limit(1).
+		Count(&touched).Error; err != nil {
+		return nil, err
+	}
+	if touched == 0 {
+		return nil, ErrComponentNotFound
+	}
+	return nil, nil
+}
+
+// currentWorkStep returns the work step of one run that the inspector shows for
+// a component: an open one if there is any, otherwise the most recently started.
+//
+// The ordering does the selection, so this is one statement returning one row.
+func (s *Service) currentWorkStep(ctx context.Context, projectID, runID, componentID string) (*WorkStep, error) {
+	linked := s.db.WithContext(ctx).
+		Model(&store.WorkStepComponent{}).
+		Select("work_step_id").
+		Where("project_id = ? AND component_id = ?", projectID, componentID)
+
+	var rows []store.WorkStep
+	if err := s.db.WithContext(ctx).
+		Model(&store.WorkStep{}).
+		Where("project_id = ? AND run_id = ? AND work_step_id IN (?)", projectID, runID, linked).
+		Order("(completed_at IS NULL) DESC, started_at DESC, work_step_id DESC").
+		Limit(1).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	row := rows[0]
+	return &WorkStep{
+		WorkStepID:  row.WorkStepID,
+		RunID:       row.RunID,
+		AgentID:     row.AgentID,
+		PlanStepID:  row.PlanStepID,
+		Title:       row.Title,
+		StartedAt:   utc(row.StartedAt),
+		CompletedAt: utcPtr(row.CompletedAt),
+		Summary:     row.Summary,
+		Position:    row.LastAppliedProjectPosition,
+	}, nil
+}
+
+// agent loads one agent of a run, or nil when it never reported agent.started.
+func (s *Service) agent(ctx context.Context, projectID, runID, agentID string) (*Agent, error) {
+	var row store.Agent
+	err := s.db.WithContext(ctx).
+		Where("project_id = ? AND run_id = ? AND agent_id = ?", projectID, runID, agentID).
+		Take(&row).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return nil, nil
+	case err != nil:
+		return nil, err
+	default:
+		agent := agentOf(row)
+		return &agent, nil
+	}
+}

--- a/backend/internal/readapi/models.go
+++ b/backend/internal/readapi/models.go
@@ -1,0 +1,388 @@
+package readapi
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Every response repeats `projectPosition`, the server side project position at
+// the moment the snapshot was read. It is `projects.last_position` and is the
+// value an SSE client compares its own cursor against, so a snapshot and the
+// stream can be merged without guessing which one is ahead.
+//
+// Every row carries the project position of the event that last wrote it as
+// `position`, which lets the UI reconcile a single node instead of the whole
+// snapshot when a live event arrives.
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+// ProjectsResponse is the body of `GET /api/v1/projects`.
+type ProjectsResponse struct {
+	// ProjectPosition is the highest position across the listed projects, or 0
+	// when there is none. The collection is not scoped to one project, so the
+	// per-project value lives on each summary instead.
+	ProjectPosition int64            `json:"projectPosition"`
+	Projects        []ProjectSummary `json:"projects"`
+}
+
+// ProjectSummary is one row of the project list.
+type ProjectSummary struct {
+	ProjectID    string    `json:"projectId"`
+	FirstSeenAt  time.Time `json:"firstSeenAt"`
+	LastEventAt  time.Time `json:"lastEventAt"`
+	LastPosition int64     `json:"lastPosition"`
+	// CurrentRunID is null until a root orchestrator has opened a run.
+	CurrentRunID *string `json:"currentRunId"`
+}
+
+// ProjectResponse is the body of `GET /api/v1/projects/{projectId}`.
+type ProjectResponse struct {
+	ProjectPosition int64         `json:"projectPosition"`
+	Project         ProjectDetail `json:"project"`
+}
+
+// ProjectDetail is one project plus the sizes of its read models, so the shell
+// can render its navigation without fetching every collection first.
+type ProjectDetail struct {
+	ProjectSummary
+	Counts ProjectCounts `json:"counts"`
+}
+
+// ProjectCounts sizes the read models of one project.
+type ProjectCounts struct {
+	Runs          int64 `json:"runs"`
+	OpenRuns      int64 `json:"openRuns"`
+	Components    int64 `json:"components"`
+	Relationships int64 `json:"relationships"`
+	// ActiveChanges counts pending proposals only — see ArchitectureResponse.
+	ActiveChanges int64 `json:"activeChanges"`
+}
+
+// ---------------------------------------------------------------------------
+// Architecture
+// ---------------------------------------------------------------------------
+
+// ArchitectureResponse is the body of
+// `GET /api/v1/projects/{projectId}/architecture`.
+//
+// Components and relationships are the *applied* model. ActiveChanges lists the
+// changes that are still pending (`state: planned`); an applied change has
+// become the model and a retracted one was withdrawn, so neither is active.
+type ArchitectureResponse struct {
+	ProjectPosition int64          `json:"projectPosition"`
+	Components      []Component    `json:"components"`
+	Relationships   []Relationship `json:"relationships"`
+	ActiveChanges   []ActiveChange `json:"activeChanges"`
+}
+
+// Component is one node of the applied architecture model. The hierarchy is
+// expressed exclusively through ParentComponentID; the response is flat.
+type Component struct {
+	ComponentID       string          `json:"componentId"`
+	Name              string          `json:"name"`
+	Kind              string          `json:"kind"`
+	ParentComponentID *string         `json:"parentComponentId"`
+	Description       string          `json:"description"`
+	Technology        json.RawMessage `json:"technology"`
+	Tags              json.RawMessage `json:"tags"`
+	AppliedAt         time.Time       `json:"appliedAt"`
+	AppliedByAgentID  string          `json:"appliedByAgentId"`
+	AppliedRunID      string          `json:"appliedRunId"`
+	Position          int64           `json:"position"`
+}
+
+// Relationship is one typed, directed edge of the applied model. Every message
+// topic keeps its own row; edges are never aggregated server side.
+type Relationship struct {
+	RelationshipID    string    `json:"relationshipId"`
+	SourceComponentID string    `json:"sourceComponentId"`
+	TargetComponentID string    `json:"targetComponentId"`
+	Kind              string    `json:"kind"`
+	Label             string    `json:"label"`
+	Protocol          string    `json:"protocol"`
+	Operation         string    `json:"operation"`
+	Channel           string    `json:"channel"`
+	AppliedAt         time.Time `json:"appliedAt"`
+	AppliedByAgentID  string    `json:"appliedByAgentId"`
+	AppliedRunID      string    `json:"appliedRunId"`
+	Position          int64     `json:"position"`
+}
+
+// ActiveChange is a pending change proposal. Snapshot carries the reported
+// component or relationship descriptor verbatim, so the canvas can render the
+// proposal next to the applied model without a second lookup.
+type ActiveChange struct {
+	ChangeID    string          `json:"changeId"`
+	TargetKind  string          `json:"targetKind"`
+	TargetID    string          `json:"targetId"`
+	Operation   string          `json:"operation"`
+	State       string          `json:"state"`
+	RunID       string          `json:"runId"`
+	AgentID     string          `json:"agentId"`
+	PlannedAt   *time.Time      `json:"plannedAt"`
+	AppliedAt   *time.Time      `json:"appliedAt"`
+	RetractedAt *time.Time      `json:"retractedAt"`
+	Snapshot    json.RawMessage `json:"snapshot"`
+	Position    int64           `json:"position"`
+}
+
+// ---------------------------------------------------------------------------
+// Runs, agents and plans
+// ---------------------------------------------------------------------------
+
+// RunsResponse is the body of `GET /api/v1/projects/{projectId}/runs`. It lists
+// current and historical runs alike, newest start first.
+type RunsResponse struct {
+	ProjectPosition int64        `json:"projectPosition"`
+	Runs            []RunSummary `json:"runs"`
+	// NextCursor is null on the last page.
+	NextCursor *string `json:"nextCursor"`
+}
+
+// RunSummary is one run. A run stays open until an explicit `run.finished`
+// closes it; silence is never a terminal state.
+type RunSummary struct {
+	RunID string `json:"runId"`
+	// RootAgentID is null until a root orchestrator reported agent.started.
+	RootAgentID *string    `json:"rootAgentId"`
+	StartedAt   time.Time  `json:"startedAt"`
+	FinishedAt  *time.Time `json:"finishedAt"`
+	Outcome     *string    `json:"outcome"`
+	IsOpen      bool       `json:"isOpen"`
+	// IsCurrent marks the run `projects.current_run_id` points at.
+	IsCurrent bool  `json:"isCurrent"`
+	Position  int64 `json:"position"`
+}
+
+// RunResponse is the body of `GET /api/v1/projects/{projectId}/runs/{runId}`.
+type RunResponse struct {
+	ProjectPosition int64     `json:"projectPosition"`
+	Run             RunDetail `json:"run"`
+}
+
+// RunDetail is one run plus the sizes of the collections hanging off it.
+type RunDetail struct {
+	RunSummary
+	Counts RunCounts `json:"counts"`
+}
+
+// RunCounts sizes the read models of one run.
+type RunCounts struct {
+	Agents    int64 `json:"agents"`
+	Plans     int64 `json:"plans"`
+	WorkSteps int64 `json:"workSteps"`
+}
+
+// AgentsResponse is the body of
+// `GET /api/v1/projects/{projectId}/runs/{runId}/agents`.
+//
+// The list is flat and every entry carries its ParentAgentID; the UI builds the
+// tree. A flat list keeps arbitrarily deep spawn chains renderable without the
+// server deciding on a nesting depth.
+type AgentsResponse struct {
+	ProjectPosition int64   `json:"projectPosition"`
+	Agents          []Agent `json:"agents"`
+}
+
+// Agent is one node of the agent tree of a run.
+type Agent struct {
+	AgentID string `json:"agentId"`
+	RunID   string `json:"runId"`
+	// ParentAgentID is null for the root orchestrator.
+	ParentAgentID *string `json:"parentAgentId"`
+	Role          string  `json:"role"`
+	DisplayName   string  `json:"displayName"`
+	AssignedTask  string  `json:"assignedTask"`
+	// Status is the last explicitly reported status, empty while none was
+	// reported. It is never derived from silence.
+	Status     string `json:"status"`
+	StatusNote string `json:"statusNote"`
+	// Progress is null until the agent reported a number itself.
+	Progress *AgentProgress `json:"progress"`
+	// FinishedOutcome is null while the agent has not reported agent.finished.
+	FinishedOutcome *string   `json:"finishedOutcome"`
+	StartedAt       time.Time `json:"startedAt"`
+	LastEventAt     time.Time `json:"lastEventAt"`
+	Position        int64     `json:"position"`
+}
+
+// AgentProgress is a self-assessment of the reporting agent, not a measurement.
+// Scope separates an agent's own task from an orchestrator's overall estimate;
+// Basis separates a free estimate from counted steps.
+type AgentProgress struct {
+	Percent int     `json:"percent"`
+	Scope   *string `json:"scope"`
+	Basis   *string `json:"basis"`
+}
+
+// PlansResponse is the body of
+// `GET /api/v1/projects/{projectId}/runs/{runId}/plans`.
+type PlansResponse struct {
+	ProjectPosition int64  `json:"projectPosition"`
+	Plans           []Plan `json:"plans"`
+}
+
+// Plan is one plan of a run with every revision it ever had.
+type Plan struct {
+	PlanID          string `json:"planId"`
+	RunID           string `json:"runId"`
+	AgentID         string `json:"agentId"`
+	CurrentRevision int    `json:"currentRevision"`
+	// Revisions are append-only and ascending. Publishing a new revision never
+	// rewrites an earlier one, so the whole history stays inspectable.
+	Revisions []PlanRevision `json:"revisions"`
+	Position  int64          `json:"position"`
+}
+
+// PlanRevision is one published revision of a plan.
+type PlanRevision struct {
+	Revision         int       `json:"revision"`
+	CreatedAt        time.Time `json:"createdAt"`
+	CreatedByAgentID string    `json:"createdByAgentId"`
+	// IsCurrent marks the revision `plan.step_updated` writes to.
+	IsCurrent bool       `json:"isCurrent"`
+	Steps     []PlanStep `json:"steps"`
+	Position  int64      `json:"position"`
+}
+
+// PlanStep is one step of one revision, in the reported order.
+type PlanStep struct {
+	StepID   string `json:"stepId"`
+	Order    int    `json:"order"`
+	Title    string `json:"title"`
+	State    string `json:"state"`
+	Position int64  `json:"position"`
+}
+
+// ---------------------------------------------------------------------------
+// Component inspector and history
+// ---------------------------------------------------------------------------
+
+// ComponentResponse is the body of
+// `GET /api/v1/projects/{projectId}/components/{componentId}`.
+//
+// It carries the evidence of **exactly one run** — the requested one, or the
+// current one when no `runId` was given. Evidence of other runs is never mixed
+// in; the run spanning view is `/history`.
+type ComponentResponse struct {
+	ProjectPosition int64 `json:"projectPosition"`
+	// RunID is the run the evidence belongs to, null when the project has no
+	// run at all yet.
+	RunID *string `json:"runId"`
+	// Component is null when the component is known from the history but no
+	// longer part of the applied model, for example after a remove.
+	Component *Component `json:"component"`
+	// ResponsibleAgent is the agent of CurrentWorkStep, or the agent that last
+	// applied the component within this run. Null when neither is reported —
+	// responsibility is read from evidence, never guessed.
+	ResponsibleAgent *Agent `json:"responsibleAgent"`
+	// CurrentWorkStep is the open work step of this run touching the component,
+	// or the most recently started one when all of them completed.
+	CurrentWorkStep *WorkStep       `json:"currentWorkStep"`
+	Feedback        []FeedbackEntry `json:"feedback"`
+	// Diffs is paginated: a single component can accumulate more unified diffs
+	// than one response should carry. See NextDiffCursor.
+	Diffs []Diff `json:"diffs"`
+	// NextDiffCursor is null when the last page of diffs was returned.
+	NextDiffCursor *string        `json:"nextDiffCursor"`
+	Risks          []Risk         `json:"risks"`
+	Problems       []Problem      `json:"problems"`
+	ActiveChanges  []ActiveChange `json:"activeChanges"`
+}
+
+// WorkStep is a concrete unit of work an agent reported.
+type WorkStep struct {
+	WorkStepID string `json:"workStepId"`
+	RunID      string `json:"runId"`
+	AgentID    string `json:"agentId"`
+	// PlanStepID links the work back to the plan when it followed a planned step.
+	PlanStepID  *string    `json:"planStepId"`
+	Title       string     `json:"title"`
+	StartedAt   time.Time  `json:"startedAt"`
+	CompletedAt *time.Time `json:"completedAt"`
+	Summary     *string    `json:"summary"`
+	Position    int64      `json:"position"`
+}
+
+// FeedbackEntry is one published, component scoped feedback item. Body is
+// untrusted markdown and is handed through verbatim; sanitising it is the
+// renderer's job.
+type FeedbackEntry struct {
+	FeedbackID string    `json:"feedbackId"`
+	RunID      string    `json:"runId"`
+	AgentID    string    `json:"agentId"`
+	Format     string    `json:"format"`
+	Title      string    `json:"title"`
+	Body       string    `json:"body"`
+	CreatedAt  time.Time `json:"createdAt"`
+	Position   int64     `json:"position"`
+}
+
+// Diff is one reported unified diff of exactly one repository file. The backend
+// never splits or merges diffs; ChangeID is what groups several files of one
+// logical change.
+type Diff struct {
+	DiffID      string    `json:"diffId"`
+	RunID       string    `json:"runId"`
+	AgentID     string    `json:"agentId"`
+	ChangeID    *string   `json:"changeId"`
+	FilePath    string    `json:"filePath"`
+	UnifiedDiff string    `json:"unifiedDiff"`
+	CreatedAt   time.Time `json:"createdAt"`
+	Position    int64     `json:"position"`
+}
+
+// Risk is a risk as stated by the reporting agent. The system never derives,
+// scores or aggregates risks on its own.
+type Risk struct {
+	RiskID    string    `json:"riskId"`
+	RunID     string    `json:"runId"`
+	AgentID   string    `json:"agentId"`
+	Title     string    `json:"title"`
+	Detail    string    `json:"detail"`
+	Severity  string    `json:"severity"`
+	CreatedAt time.Time `json:"createdAt"`
+	Position  int64     `json:"position"`
+}
+
+// Problem is a problem as stated by the reporting agent.
+type Problem struct {
+	ProblemID string    `json:"problemId"`
+	RunID     string    `json:"runId"`
+	AgentID   string    `json:"agentId"`
+	Title     string    `json:"title"`
+	Detail    string    `json:"detail"`
+	CreatedAt time.Time `json:"createdAt"`
+	Position  int64     `json:"position"`
+}
+
+// HistoryResponse is the body of
+// `GET /api/v1/projects/{projectId}/components/{componentId}/history`.
+//
+// Unlike the inspector this view spans **all** runs of the project, descending
+// by project position, and every entry names the run it belongs to.
+type HistoryResponse struct {
+	ProjectPosition int64          `json:"projectPosition"`
+	Entries         []HistoryEntry `json:"entries"`
+	// NextCursor is null on the last page.
+	NextCursor *string `json:"nextCursor"`
+}
+
+// HistoryEntry is one reported event that touched the component, as recorded.
+// Corrections and retractions appear as their own entries; nothing is
+// overwritten.
+type HistoryEntry struct {
+	Position      int64           `json:"position"`
+	ServerEventID string          `json:"serverEventId"`
+	ClientEventID string          `json:"clientEventId"`
+	RunID         string          `json:"runId"`
+	AgentID       string          `json:"agentId"`
+	ParentAgentID *string         `json:"parentAgentId"`
+	Type          string          `json:"type"`
+	SchemaVersion string          `json:"schemaVersion"`
+	OccurredAt    time.Time       `json:"occurredAt"`
+	ReceivedAt    time.Time       `json:"receivedAt"`
+	Payload       json.RawMessage `json:"payload"`
+}

--- a/backend/internal/readapi/pagination.go
+++ b/backend/internal/readapi/pagination.go
@@ -1,0 +1,159 @@
+package readapi
+
+import (
+	"encoding/base64"
+	"strconv"
+	"strings"
+)
+
+// Paging bounds of every paginated read endpoint.
+const (
+	// DefaultLimit applies when the client sends no limit.
+	DefaultLimit = 50
+	// MaxLimit is the largest page a client may ask for. A larger value is a
+	// client error rather than a silently clamped page, so a UI cannot believe
+	// it received everything.
+	MaxLimit = 200
+)
+
+// cursorVersion prefixes every cursor payload. It makes the encoding
+// recognisable and lets a future format be rejected instead of misread.
+const cursorVersion = "v1"
+
+// cursorSeparator joins the key parts inside a cursor. No identifier of the
+// contract may contain it: run and component ids are restricted to lowercase
+// alphanumerics plus `-`, `.` and `_`, and positions are decimal digits.
+const cursorSeparator = "|"
+
+// Violation codes reported through ValidationError.
+const (
+	codeOutOfRange = "out_of_range"
+	codeInvalid    = "invalid_format"
+)
+
+// Page is a validated pagination request.
+type Page struct {
+	// Limit is the number of rows to return, already defaulted and bounded.
+	Limit int
+	// Cursor is the raw cursor as sent by the client, empty for a first page.
+	Cursor string
+}
+
+// parsePage validates the `limit` and `cursor` query parameters.
+//
+// Both are reported together when both are wrong, so a client fixes one round
+// trip instead of two. The `field` prefix lets one request carry several
+// paginated collections — the inspector paginates its diffs under `diffLimit`
+// and `diffCursor`.
+func parsePage(limitParam, cursorParam, rawLimit, rawCursor string) (Page, *ValidationError) {
+	page := Page{Limit: DefaultLimit, Cursor: strings.TrimSpace(rawCursor)}
+	var problem ValidationError
+
+	if trimmed := strings.TrimSpace(rawLimit); trimmed != "" {
+		limit, err := strconv.Atoi(trimmed)
+		switch {
+		case err != nil:
+			problem.Errors = append(problem.Errors, FieldError{
+				Field:   "/" + limitParam,
+				Code:    codeInvalid,
+				Message: "limit must be an integer",
+			})
+		case limit < 1 || limit > MaxLimit:
+			problem.Errors = append(problem.Errors, FieldError{
+				Field:   "/" + limitParam,
+				Code:    codeOutOfRange,
+				Message: "limit must be between 1 and " + strconv.Itoa(MaxLimit),
+			})
+		default:
+			page.Limit = limit
+		}
+	}
+
+	if page.Cursor != "" {
+		if _, err := decodeCursor(page.Cursor); err != nil {
+			problem.Errors = append(problem.Errors, FieldError{
+				Field:   "/" + cursorParam,
+				Code:    codeInvalid,
+				Message: "cursor is not a cursor issued by this API",
+			})
+		}
+	}
+
+	if len(problem.Errors) > 0 {
+		return Page{}, &problem
+	}
+	return page, nil
+}
+
+// encodeCursor renders an opaque continuation token.
+//
+// The token is base64url over a versioned, internal sort key. Clients must
+// treat it as opaque: it is echoed back unchanged and its shape is free to
+// change with the version prefix.
+func encodeCursor(parts ...string) string {
+	joined := strings.Join(append([]string{cursorVersion}, parts...), cursorSeparator)
+	return base64.RawURLEncoding.EncodeToString([]byte(joined))
+}
+
+// decodeCursor reads a token produced by encodeCursor.
+func decodeCursor(raw string) ([]string, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(string(decoded), cursorSeparator)
+	if len(parts) < 2 || parts[0] != cursorVersion {
+		return nil, errUnknownCursor
+	}
+	return parts[1:], nil
+}
+
+// positionCursor renders the cursor of a collection ordered by project position.
+func positionCursor(position int64) string {
+	return encodeCursor(strconv.FormatInt(position, 10))
+}
+
+// parsePositionCursor reads a cursor produced by positionCursor. An unusable
+// token yields ok=false; the caller has already validated the encoding through
+// parsePage, so this only guards against a mismatching key shape.
+func parsePositionCursor(raw string) (int64, bool) {
+	parts, err := decodeCursor(raw)
+	if err != nil || len(parts) != 1 {
+		return 0, false
+	}
+	position, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return position, true
+}
+
+// runCursor renders the cursor of the run list.
+//
+// Runs are ordered by reported start time, which is not a project position and
+// can repeat, so the key is the pair (startedAt, runId). The pair is unique —
+// runId is a primary key column — which is what makes paging gap free and
+// duplicate free.
+func runCursor(startedAtUnixNano int64, runID string) string {
+	return encodeCursor(strconv.FormatInt(startedAtUnixNano, 10), runID)
+}
+
+// parseRunCursor reads a cursor produced by runCursor.
+func parseRunCursor(raw string) (int64, string, bool) {
+	parts, err := decodeCursor(raw)
+	if err != nil || len(parts) != 2 {
+		return 0, "", false
+	}
+	nanos, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, "", false
+	}
+	return nanos, parts[1], true
+}
+
+// errUnknownCursor marks a token this version cannot read.
+var errUnknownCursor = &cursorError{}
+
+type cursorError struct{}
+
+func (*cursorError) Error() string { return "readapi: unknown cursor format" }

--- a/backend/internal/readapi/projects.go
+++ b/backend/internal/readapi/projects.go
@@ -1,0 +1,228 @@
+package readapi
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/risqyy/visualise-ai/backend/internal/store"
+)
+
+// Projects lists every project the backend has ever seen.
+//
+// One statement. This is the only endpoint that is not scoped to a single
+// project, so its `projectPosition` is the highest position across the listed
+// projects; each summary repeats its own `lastPosition`.
+func (s *Service) Projects(ctx context.Context) (ProjectsResponse, error) {
+	var rows []store.Project
+	if err := s.db.WithContext(ctx).
+		Model(&store.Project{}).
+		Order("project_id ASC").
+		Find(&rows).Error; err != nil {
+		return ProjectsResponse{}, err
+	}
+
+	response := ProjectsResponse{Projects: make([]ProjectSummary, 0, len(rows))}
+	for _, row := range rows {
+		if row.LastPosition > response.ProjectPosition {
+			response.ProjectPosition = row.LastPosition
+		}
+		response.Projects = append(response.Projects, projectSummary(row))
+	}
+	return response, nil
+}
+
+// Project returns one project together with the sizes of its read models.
+//
+// Two statements: the project head row, then one row of scalar subqueries for
+// the counts.
+func (s *Service) Project(ctx context.Context, projectID string) (ProjectResponse, error) {
+	project, err := s.project(ctx, projectID)
+	if err != nil {
+		return ProjectResponse{}, err
+	}
+
+	var counts ProjectCounts
+	if err := s.db.WithContext(ctx).Raw(`
+		SELECT
+			(SELECT count(*) FROM runs          WHERE project_id = ?)                      AS runs,
+			(SELECT count(*) FROM runs          WHERE project_id = ? AND is_open)          AS open_runs,
+			(SELECT count(*) FROM components    WHERE project_id = ?)                      AS components,
+			(SELECT count(*) FROM relationships WHERE project_id = ?)                      AS relationships,
+			(SELECT count(*) FROM active_changes WHERE project_id = ? AND state = ?)       AS active_changes`,
+		projectID, projectID, projectID, projectID, projectID, store.ChangeStatePlanned,
+	).Scan(&counts).Error; err != nil {
+		return ProjectResponse{}, err
+	}
+
+	return ProjectResponse{
+		ProjectPosition: project.LastPosition,
+		Project: ProjectDetail{
+			ProjectSummary: projectSummary(project),
+			Counts:         counts,
+		},
+	}, nil
+}
+
+// Architecture returns the applied architecture model plus the change proposals
+// that are still pending.
+//
+// Four statements, one per collection. The applied model and the proposals are
+// kept apart on purpose: a planned change never touches `components` or
+// `relationships`, so a proposal cannot be mistaken for reality.
+func (s *Service) Architecture(ctx context.Context, projectID string) (ArchitectureResponse, error) {
+	project, err := s.project(ctx, projectID)
+	if err != nil {
+		return ArchitectureResponse{}, err
+	}
+
+	var componentRows []store.Component
+	if err := s.db.WithContext(ctx).
+		Model(&store.Component{}).
+		Where("project_id = ?", projectID).
+		Order("component_id ASC").
+		Find(&componentRows).Error; err != nil {
+		return ArchitectureResponse{}, err
+	}
+
+	var relationshipRows []store.Relationship
+	if err := s.db.WithContext(ctx).
+		Model(&store.Relationship{}).
+		Where("project_id = ?", projectID).
+		Order("relationship_id ASC").
+		Find(&relationshipRows).Error; err != nil {
+		return ArchitectureResponse{}, err
+	}
+
+	changes, err := s.plannedChanges(ctx, projectID, "", "")
+	if err != nil {
+		return ArchitectureResponse{}, err
+	}
+
+	response := ArchitectureResponse{
+		ProjectPosition: project.LastPosition,
+		Components:      make([]Component, 0, len(componentRows)),
+		Relationships:   make([]Relationship, 0, len(relationshipRows)),
+		ActiveChanges:   changes,
+	}
+	for _, row := range componentRows {
+		response.Components = append(response.Components, componentOf(row))
+	}
+	for _, row := range relationshipRows {
+		response.Relationships = append(response.Relationships, Relationship{
+			RelationshipID:    row.RelationshipID,
+			SourceComponentID: row.SourceComponentID,
+			TargetComponentID: row.TargetComponentID,
+			Kind:              row.Kind,
+			Label:             row.Label,
+			Protocol:          row.Protocol,
+			Operation:         row.Operation,
+			Channel:           row.Channel,
+			AppliedAt:         utc(row.AppliedAt),
+			AppliedByAgentID:  row.AppliedByAgentID,
+			AppliedRunID:      row.AppliedRunID,
+			Position:          row.LastAppliedProjectPosition,
+		})
+	}
+	return response, nil
+}
+
+// plannedChanges loads the pending proposals of a project in one statement.
+//
+// runID and targetID narrow the result for the component inspector, which shows
+// the proposals of exactly one run for exactly one component. Empty values mean
+// "do not narrow", which is what the architecture endpoint asks for.
+func (s *Service) plannedChanges(ctx context.Context, projectID, runID, targetID string) ([]ActiveChange, error) {
+	query := s.db.WithContext(ctx).
+		Model(&store.ActiveChange{}).
+		Where("project_id = ? AND state = ?", projectID, store.ChangeStatePlanned)
+	if runID != "" {
+		query = query.Where("run_id = ?", runID)
+	}
+	if targetID != "" {
+		query = query.Where("target_kind = ? AND target_id = ?", store.ChangeTargetComponent, targetID)
+	}
+
+	var rows []store.ActiveChange
+	if err := query.Order("planned_at DESC, change_id ASC").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	changes := make([]ActiveChange, 0, len(rows))
+	for _, row := range rows {
+		changes = append(changes, ActiveChange{
+			ChangeID:    row.ChangeID,
+			TargetKind:  row.TargetKind,
+			TargetID:    row.TargetID,
+			Operation:   row.Operation,
+			State:       row.State,
+			RunID:       row.RunID,
+			AgentID:     row.AgentID,
+			PlannedAt:   utcPtr(row.PlannedAt),
+			AppliedAt:   utcPtr(row.AppliedAt),
+			RetractedAt: utcPtr(row.RetractedAt),
+			Snapshot:    rawJSON(row.Snapshot, "{}"),
+			Position:    row.LastAppliedProjectPosition,
+		})
+	}
+	return changes, nil
+}
+
+func projectSummary(row store.Project) ProjectSummary {
+	return ProjectSummary{
+		ProjectID:    row.ProjectID,
+		FirstSeenAt:  utc(row.FirstSeenAt),
+		LastEventAt:  utc(row.LastEventAt),
+		LastPosition: row.LastPosition,
+		CurrentRunID: nonEmpty(row.CurrentRunID),
+	}
+}
+
+func componentOf(row store.Component) Component {
+	return Component{
+		ComponentID:       row.ComponentID,
+		Name:              row.Name,
+		Kind:              row.Kind,
+		ParentComponentID: row.ParentComponentID,
+		Description:       row.Description,
+		Technology:        rawJSON(row.Technology, "{}"),
+		Tags:              rawJSON(row.Tags, "[]"),
+		AppliedAt:         utc(row.AppliedAt),
+		AppliedByAgentID:  row.AppliedByAgentID,
+		AppliedRunID:      row.AppliedRunID,
+		Position:          row.LastAppliedProjectPosition,
+	}
+}
+
+// rawJSON hands a stored jsonb document through unchanged and substitutes an
+// empty document for a column that was never written, so the response never
+// carries a bare `null` where the contract promises an object or an array.
+func rawJSON(value store.JSON, fallback string) json.RawMessage {
+	if len(value) == 0 {
+		return json.RawMessage(fallback)
+	}
+	return json.RawMessage(value)
+}
+
+// nonEmpty maps the empty string of a NOT NULL column to a JSON null, which is
+// what "not reported yet" means to the UI.
+func nonEmpty(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+// utc normalises a `timestamptz` that the driver returned in the session's time
+// zone. Without it the rendered offset would depend on where the container runs,
+// while the contract states timestamps in UTC.
+func utc(value time.Time) time.Time { return value.UTC() }
+
+// utcPtr is utc for an optional timestamp, keeping a NULL a JSON null.
+func utcPtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	normalised := value.UTC()
+	return &normalised
+}

--- a/backend/internal/readapi/readapi.go
+++ b/backend/internal/readapi/readapi.go
@@ -1,0 +1,139 @@
+// Package readapi serves the UI oriented read models of one project.
+//
+// Every query reads the normalised projections the store advances inside the
+// append transaction. The event log itself is touched in exactly one place —
+// the component history — and even there through the `event_components` join
+// table rather than a JSONB scan over `events`.
+//
+// Two properties are structural rather than conventional here:
+//
+//   - Every statement filters on `project_id`, so a response can never carry a
+//     row of another project, not even when two projects reuse the same run,
+//     agent or component identifiers.
+//   - Component scoped evidence is loaded through the join tables
+//     (`feedback_components`, `diff_components`, `risk_components`,
+//     `problem_components`, `work_step_components`) with one statement per
+//     collection. No handler runs a query per row.
+//
+// Composing an HTTP response, mapping the errors below onto status codes and
+// serving RFC 9457 problems are not this package's concern; the httpapi layer
+// owns them.
+package readapi
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/risqyy/visualise-ai/backend/internal/store"
+)
+
+// CurrentRunAlias is the literal that `runs/{runId}` accepts in place of a run
+// identifier. It resolves to `projects.current_run_id`, which the store sets
+// when a root orchestrator opens a run.
+//
+// The alias wins over a run that happens to carry the same identifier: the
+// cockpit's default view must not depend on how an agent named its run.
+const CurrentRunAlias = "current"
+
+// The read API rejects a request for something that does not exist rather than
+// inventing an empty answer, so a stale deep link is visible instead of silent.
+var (
+	// ErrProjectNotFound reports an unknown projectId.
+	ErrProjectNotFound = errors.New("readapi: project not found")
+	// ErrRunNotFound reports a run that does not exist in this project.
+	ErrRunNotFound = errors.New("readapi: run not found")
+	// ErrCurrentRunNotFound reports that the project has never had a run opened
+	// by a root orchestrator. It is deliberately distinct from ErrRunNotFound so
+	// the UI can tell "no run yet" from "this run id is wrong".
+	ErrCurrentRunNotFound = errors.New("readapi: project has no current run")
+	// ErrComponentNotFound reports a component the project has never reported,
+	// neither in the applied model nor in its history.
+	ErrComponentNotFound = errors.New("readapi: component not found")
+)
+
+// FieldError is one violated query parameter.
+type FieldError struct {
+	// Field is a JSON Pointer style reference to the rejected parameter, for
+	// example `/limit`. The read endpoints have no request body, so the pointer
+	// names the query parameter.
+	Field string
+	// Code is the stable, machine-readable violation code.
+	Code string
+	// Message explains this single violation.
+	Message string
+}
+
+// ValidationError collects every rejected query parameter of one request. The
+// httpapi layer turns it into a `400` ValidationProblem.
+type ValidationError struct {
+	Errors []FieldError
+}
+
+// Error implements error.
+func (e *ValidationError) Error() string {
+	if len(e.Errors) == 0 {
+		return "readapi: invalid request"
+	}
+	return "readapi: invalid request: " + e.Errors[0].Field + " " + e.Errors[0].Message
+}
+
+// Service answers the read endpoints of the cockpit.
+type Service struct {
+	db *gorm.DB
+}
+
+// New returns a Service reading through db.
+func New(db *gorm.DB) *Service { return &Service{db: db} }
+
+// project loads the head row of one project.
+//
+// It is the first statement of every project scoped endpoint: it establishes
+// that the project exists and yields `last_position`, which every response
+// repeats as `projectPosition` so an HTTP snapshot and the SSE stream can be
+// reconciled deterministically.
+func (s *Service) project(ctx context.Context, projectID string) (store.Project, error) {
+	var project store.Project
+	err := s.db.WithContext(ctx).Where("project_id = ?", projectID).Take(&project).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return store.Project{}, ErrProjectNotFound
+	case err != nil:
+		return store.Project{}, err
+	default:
+		return project, nil
+	}
+}
+
+// resolveRun turns a requested run identifier into a run of this project.
+//
+// The literal CurrentRunAlias resolves to the project's current run; every
+// other value must name a run the project actually has.
+func (s *Service) resolveRun(ctx context.Context, project store.Project, runID string) (store.Run, error) {
+	wanted := runID
+	if wanted == CurrentRunAlias {
+		if project.CurrentRunID == "" {
+			return store.Run{}, ErrCurrentRunNotFound
+		}
+		wanted = project.CurrentRunID
+	}
+
+	var run store.Run
+	err := s.db.WithContext(ctx).
+		Where("project_id = ? AND run_id = ?", project.ProjectID, wanted).
+		Take(&run).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		if runID == CurrentRunAlias {
+			// projects.current_run_id points at a run that no longer exists.
+			// Reporting the alias failure is the honest answer.
+			return store.Run{}, ErrCurrentRunNotFound
+		}
+		return store.Run{}, ErrRunNotFound
+	case err != nil:
+		return store.Run{}, err
+	default:
+		return run, nil
+	}
+}

--- a/backend/internal/readapi/readapi_test.go
+++ b/backend/internal/readapi/readapi_test.go
@@ -1,0 +1,1299 @@
+package readapi_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/risqyy/visualise-ai/backend/internal/readapi"
+	"github.com/risqyy/visualise-ai/backend/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Empty project and unknown project
+// ---------------------------------------------------------------------------
+
+// A project that has only opened a run has no architecture, no plan and no
+// component evidence. Every endpoint must still answer with empty collections
+// rather than null or a panic — the shell renders before anything was reported.
+func TestEmptyProjectAnswersEveryEndpointWithEmptyCollections(t *testing.T) {
+	h := newHarness(t)
+	h.run("visualise-ai", "run-2026-08-04-0001").startRoot("orchestrator-root", "Deliver the v0 cockpit.")
+
+	position := h.lastPosition("visualise-ai")
+
+	var projects readapi.ProjectsResponse
+	h.getJSON("/api/v1/projects", &projects)
+	if len(projects.Projects) != 1 || projects.Projects[0].ProjectID != "visualise-ai" {
+		t.Fatalf("want exactly the seeded project, got %+v", projects.Projects)
+	}
+	if projects.ProjectPosition != position {
+		t.Fatalf("projects: want projectPosition %d, got %d", position, projects.ProjectPosition)
+	}
+
+	var detail readapi.ProjectResponse
+	h.getJSON("/api/v1/projects/visualise-ai", &detail)
+	if detail.Project.Counts.Runs != 1 || detail.Project.Counts.OpenRuns != 1 {
+		t.Fatalf("want one open run, got %+v", detail.Project.Counts)
+	}
+	if detail.Project.Counts.Components != 0 || detail.Project.Counts.Relationships != 0 {
+		t.Fatalf("want an empty architecture, got %+v", detail.Project.Counts)
+	}
+
+	// The JSON must carry `[]`, not `null`: a UI that maps over the collections
+	// must not have to defend against a missing array.
+	body := h.request("/api/v1/projects/visualise-ai/architecture").Body.String()
+	for _, wanted := range []string{`"components":[]`, `"relationships":[]`, `"activeChanges":[]`} {
+		if !strings.Contains(body, wanted) {
+			t.Fatalf("architecture body lacks %s: %s", wanted, body)
+		}
+	}
+
+	var plans readapi.PlansResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs/current/plans", &plans)
+	if len(plans.Plans) != 0 {
+		t.Fatalf("want no plans, got %+v", plans.Plans)
+	}
+
+	var runs readapi.RunsResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs", &runs)
+	if len(runs.Runs) != 1 || !runs.Runs[0].IsOpen || !runs.Runs[0].IsCurrent {
+		t.Fatalf("want one open, current run, got %+v", runs.Runs)
+	}
+	if runs.NextCursor != nil {
+		t.Fatalf("a single run must not report a next page, got %q", *runs.NextCursor)
+	}
+
+	var agents readapi.AgentsResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs/current/agents", &agents)
+	if len(agents.Agents) != 1 || agents.Agents[0].ParentAgentID != nil {
+		t.Fatalf("want the root orchestrator alone, got %+v", agents.Agents)
+	}
+	if agents.Agents[0].Progress != nil || agents.Agents[0].Status != "" {
+		t.Fatalf("nothing was reported, so nothing may be shown: %+v", agents.Agents[0])
+	}
+
+	// A component the project never mentioned is a 404, not an empty inspector.
+	problem := h.getProblem("/api/v1/projects/visualise-ai/components/shop-platform.orders", http.StatusNotFound)
+	if problem.Code != "component_not_found" {
+		t.Fatalf("want component_not_found, got %q", problem.Code)
+	}
+	problem = h.getProblem("/api/v1/projects/visualise-ai/components/shop-platform.orders/history", http.StatusNotFound)
+	if problem.Code != "component_not_found" {
+		t.Fatalf("want component_not_found for the history, got %q", problem.Code)
+	}
+}
+
+// With no project at all the collection endpoint is empty and reports position 0.
+func TestProjectListIsEmptyBeforeTheFirstEvent(t *testing.T) {
+	h := newHarness(t)
+
+	var projects readapi.ProjectsResponse
+	h.getJSON("/api/v1/projects", &projects)
+	if projects.ProjectPosition != 0 {
+		t.Fatalf("want projectPosition 0, got %d", projects.ProjectPosition)
+	}
+	if len(projects.Projects) != 0 {
+		t.Fatalf("want no projects, got %+v", projects.Projects)
+	}
+	if body := h.request("/api/v1/projects").Body.String(); !strings.Contains(body, `"projects":[]`) {
+		t.Fatalf("want an empty array, got %s", body)
+	}
+}
+
+// Every project scoped endpoint refuses an unknown project with the same code.
+func TestUnknownProjectIsAlways404(t *testing.T) {
+	h := newHarness(t)
+	h.run("visualise-ai", "run-2026-08-04-0001").startRoot("orchestrator-root", "Deliver the v0 cockpit.")
+
+	paths := []string{
+		"/api/v1/projects/nope",
+		"/api/v1/projects/nope/architecture",
+		"/api/v1/projects/nope/runs",
+		"/api/v1/projects/nope/runs/current",
+		"/api/v1/projects/nope/runs/run-2026-08-04-0001/agents",
+		"/api/v1/projects/nope/runs/run-2026-08-04-0001/plans",
+		"/api/v1/projects/nope/components/shop-platform",
+		"/api/v1/projects/nope/components/shop-platform/history",
+	}
+	for _, path := range paths {
+		problem := h.getProblem(path, http.StatusNotFound)
+		if problem.Code != "project_not_found" {
+			t.Fatalf("GET %s: want project_not_found, got %q", path, problem.Code)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Agent tree
+// ---------------------------------------------------------------------------
+
+// A run with a root orchestrator and several nested subagents must come back
+// complete and unambiguous: every node keeps its parent, so the UI can rebuild
+// the tree without the server flattening the hierarchy away.
+func TestActiveRunReturnsTheCompleteNestedAgentTree(t *testing.T) {
+	h := newHarness(t)
+	run := h.run("visualise-ai", "run-2026-08-04-0001")
+
+	run.startRoot("orchestrator-root", "Deliver the v0 cockpit.")
+	run.startSub("subagent-contract", "orchestrator-root", "Define the event contract.")
+	run.startSub("subagent-backend", "orchestrator-root", "Implement the backend.")
+	run.startSub("subagent-store", "subagent-backend", "Implement the event store.")
+	run.startSub("subagent-readapi", "subagent-backend", "Implement the read API.")
+	run.startSub("subagent-queries", "subagent-readapi", "Write the projections queries.")
+
+	run.emit("subagent-readapi", nil, store.TypeAgentStatusReported, `{"status":"working","note":"Writing queries."}`)
+	run.emit("subagent-readapi", nil, store.TypeAgentProgressReported,
+		`{"percent":40,"scope":"own_task","basis":"completed_steps"}`)
+	run.emit("orchestrator-root", nil, store.TypeAgentProgressReported,
+		`{"percent":55,"scope":"overall_estimate","basis":"reported_estimate"}`)
+	run.emit("subagent-contract", nil, store.TypeAgentFinished, `{"outcome":"completed","summary":"Contract merged."}`)
+
+	var agents readapi.AgentsResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs/current/agents", &agents)
+	if len(agents.Agents) != 6 {
+		t.Fatalf("want six agents, got %d: %+v", len(agents.Agents), agents.Agents)
+	}
+
+	byID := make(map[string]readapi.Agent, len(agents.Agents))
+	seen := make(map[string]bool, len(agents.Agents))
+	for _, agent := range agents.Agents {
+		byID[agent.AgentID] = agent
+		// The list is ordered so a parent is emitted before its children, which
+		// lets a consumer build the tree in a single pass.
+		if agent.ParentAgentID != nil && !seen[*agent.ParentAgentID] {
+			t.Fatalf("agent %q appears before its parent %q", agent.AgentID, *agent.ParentAgentID)
+		}
+		seen[agent.AgentID] = true
+	}
+
+	wantParents := map[string]string{
+		"orchestrator-root": "",
+		"subagent-contract": "orchestrator-root",
+		"subagent-backend":  "orchestrator-root",
+		"subagent-store":    "subagent-backend",
+		"subagent-readapi":  "subagent-backend",
+		"subagent-queries":  "subagent-readapi",
+	}
+	for agentID, wantParent := range wantParents {
+		agent, ok := byID[agentID]
+		if !ok {
+			t.Fatalf("agent %q is missing from the tree", agentID)
+		}
+		got := ""
+		if agent.ParentAgentID != nil {
+			got = *agent.ParentAgentID
+		}
+		if got != wantParent {
+			t.Fatalf("agent %q: want parent %q, got %q", agentID, wantParent, got)
+		}
+	}
+
+	// Reported values are shown exactly where they were reported, and nowhere else.
+	if progress := byID["subagent-readapi"].Progress; progress == nil ||
+		progress.Percent != 40 || progress.Scope == nil || *progress.Scope != "own_task" {
+		t.Fatalf("subagent progress was not reported through: %+v", byID["subagent-readapi"].Progress)
+	}
+	if progress := byID["orchestrator-root"].Progress; progress == nil ||
+		progress.Scope == nil || *progress.Scope != "overall_estimate" {
+		t.Fatalf("the orchestrator estimate lost its scope: %+v", byID["orchestrator-root"].Progress)
+	}
+	if byID["subagent-store"].Progress != nil {
+		t.Fatalf("an agent that reported no progress must not show one: %+v", byID["subagent-store"].Progress)
+	}
+	if outcome := byID["subagent-contract"].FinishedOutcome; outcome == nil || *outcome != "completed" {
+		t.Fatalf("want the reported outcome, got %v", outcome)
+	}
+	if byID["subagent-backend"].FinishedOutcome != nil {
+		t.Fatalf("an unfinished agent must not carry an outcome")
+	}
+	if byID["subagent-readapi"].Status != "working" {
+		t.Fatalf("want the last reported status, got %q", byID["subagent-readapi"].Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Current run versus history
+// ---------------------------------------------------------------------------
+
+// A finished run stays listed, but the current run is the one that was opened
+// last. Historical runs never overlay the current view.
+func TestFinishedRunStaysListedWhileCurrentResolvesToTheOpenRun(t *testing.T) {
+	h := newHarness(t)
+
+	past := h.run("visualise-ai", "run-2026-08-03-0001")
+	past.startRoot("orchestrator-root", "Yesterday's run.")
+	past.emit("orchestrator-root", nil, store.TypeRunFinished, `{"outcome":"completed","summary":"Done."}`)
+
+	open := h.run("visualise-ai", "run-2026-08-04-0001")
+	open.startRoot("orchestrator-root", "Today's run.")
+
+	var runs readapi.RunsResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs", &runs)
+	if len(runs.Runs) != 2 {
+		t.Fatalf("want both runs, got %+v", runs.Runs)
+	}
+	// Descending by start: the newest run comes first.
+	if runs.Runs[0].RunID != "run-2026-08-04-0001" || runs.Runs[1].RunID != "run-2026-08-03-0001" {
+		t.Fatalf("runs are not ordered newest first: %+v", runs.Runs)
+	}
+	if !runs.Runs[0].IsOpen || !runs.Runs[0].IsCurrent {
+		t.Fatalf("the newest run must be open and current: %+v", runs.Runs[0])
+	}
+	if runs.Runs[1].IsOpen || runs.Runs[1].IsCurrent {
+		t.Fatalf("the finished run must be neither open nor current: %+v", runs.Runs[1])
+	}
+	if outcome := runs.Runs[1].Outcome; outcome == nil || *outcome != "completed" {
+		t.Fatalf("want the reported outcome on the finished run, got %v", outcome)
+	}
+	if runs.Runs[1].FinishedAt == nil {
+		t.Fatalf("a finished run must report when it finished")
+	}
+
+	var current readapi.RunResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs/current", &current)
+	if current.Run.RunID != "run-2026-08-04-0001" {
+		t.Fatalf("current resolved to %q", current.Run.RunID)
+	}
+
+	// The historical run stays addressable by its own id and keeps its state.
+	var historical readapi.RunResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs/run-2026-08-03-0001", &historical)
+	if historical.Run.IsOpen || historical.Run.IsCurrent {
+		t.Fatalf("the historical run changed state when addressed directly: %+v", historical.Run)
+	}
+
+	problem := h.getProblem("/api/v1/projects/visualise-ai/runs/run-does-not-exist", http.StatusNotFound)
+	if problem.Code != "run_not_found" {
+		t.Fatalf("want run_not_found, got %q", problem.Code)
+	}
+}
+
+// Without a root orchestrator the project has no current run, and that is its
+// own error code — "no run yet" is not the same as "wrong run id".
+func TestCurrentRunIsItsOwnErrorCodeWhenNoRunWasOpened(t *testing.T) {
+	h := newHarness(t)
+	// A subagent event alone creates the run row but never makes it current.
+	h.run("visualise-ai", "run-2026-08-04-0001").
+		startSub("subagent-orphan", "orchestrator-root", "Work without an orchestrator.")
+
+	for _, path := range []string{
+		"/api/v1/projects/visualise-ai/runs/current",
+		"/api/v1/projects/visualise-ai/runs/current/agents",
+		"/api/v1/projects/visualise-ai/runs/current/plans",
+	} {
+		problem := h.getProblem(path, http.StatusNotFound)
+		if problem.Code != "current_run_not_found" {
+			t.Fatalf("GET %s: want current_run_not_found, got %q", path, problem.Code)
+		}
+	}
+
+	// The run itself is listed and addressable — only "current" is undefined.
+	var runs readapi.RunsResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs", &runs)
+	if len(runs.Runs) != 1 || runs.Runs[0].IsCurrent || runs.Runs[0].RootAgentID != nil {
+		t.Fatalf("want one non-current run without a root agent, got %+v", runs.Runs)
+	}
+}
+
+// The inspector shows the evidence of exactly one run; the history spans them
+// all. Mixing the two would make "what is happening now" unreadable.
+func TestInspectorIsRunScopedWhileHistorySpansRuns(t *testing.T) {
+	h := newHarness(t)
+	const componentID = "shop-platform.orders.domain.pricing"
+
+	past := h.run("visualise-ai", "run-2026-08-03-0001")
+	past.startRoot("orchestrator-root", "Yesterday's run.")
+	past.emit("orchestrator-root", nil, store.TypeFeedbackPublished, feedbackPayload(
+		"feedback-past", componentID, "Yesterday's review"))
+	past.emit("orchestrator-root", nil, store.TypeDiffReported, diffPayload(
+		"diff-past", componentID, "internal/orders/domain/pricing/old.go"))
+	past.emit("orchestrator-root", nil, store.TypeRunFinished, `{"outcome":"completed","summary":"Done."}`)
+
+	open := h.run("visualise-ai", "run-2026-08-04-0001")
+	open.startRoot("orchestrator-root", "Today's run.")
+	open.emit("orchestrator-root", nil, store.TypeFeedbackPublished, feedbackPayload(
+		"feedback-today", componentID, "Today's review"))
+	open.emit("orchestrator-root", nil, store.TypeDiffReported, diffPayload(
+		"diff-today", componentID, "internal/orders/domain/pricing/pricing.go"))
+
+	// No runId: the current run, and only it.
+	var current readapi.ComponentResponse
+	h.getJSON("/api/v1/projects/visualise-ai/components/"+componentID, &current)
+	assertSingleEvidence(t, current, "run-2026-08-04-0001", "feedback-today", "diff-today")
+
+	// The alias means the same thing explicitly.
+	var alias readapi.ComponentResponse
+	h.getJSON("/api/v1/projects/visualise-ai/components/"+componentID+"?runId=current", &alias)
+	assertSingleEvidence(t, alias, "run-2026-08-04-0001", "feedback-today", "diff-today")
+
+	// An explicit historical run yields that run's evidence and nothing else.
+	var historical readapi.ComponentResponse
+	h.getJSON("/api/v1/projects/visualise-ai/components/"+componentID+"?runId=run-2026-08-03-0001", &historical)
+	assertSingleEvidence(t, historical, "run-2026-08-03-0001", "feedback-past", "diff-past")
+
+	// The history is the run spanning view, descending by project position.
+	var history readapi.HistoryResponse
+	h.getJSON("/api/v1/projects/visualise-ai/components/"+componentID+"/history", &history)
+	if len(history.Entries) != 4 {
+		t.Fatalf("want the four component touching events, got %d: %+v", len(history.Entries), history.Entries)
+	}
+	runsSeen := map[string]int{}
+	for i, entry := range history.Entries {
+		runsSeen[entry.RunID]++
+		if i > 0 && history.Entries[i-1].Position <= entry.Position {
+			t.Fatalf("history is not strictly descending: %d then %d",
+				history.Entries[i-1].Position, entry.Position)
+		}
+		if len(entry.Payload) == 0 {
+			t.Fatalf("history entry %d carries no payload", i)
+		}
+	}
+	if runsSeen["run-2026-08-03-0001"] != 2 || runsSeen["run-2026-08-04-0001"] != 2 {
+		t.Fatalf("history did not span both runs: %v", runsSeen)
+	}
+
+	// An unknown run is rejected rather than silently falling back to current.
+	problem := h.getProblem(
+		"/api/v1/projects/visualise-ai/components/"+componentID+"?runId=run-does-not-exist",
+		http.StatusNotFound)
+	if problem.Code != "run_not_found" {
+		t.Fatalf("want run_not_found, got %q", problem.Code)
+	}
+}
+
+func assertSingleEvidence(t *testing.T, response readapi.ComponentResponse, wantRun, wantFeedback, wantDiff string) {
+	t.Helper()
+	if response.RunID == nil || *response.RunID != wantRun {
+		t.Fatalf("want run %q, got %v", wantRun, response.RunID)
+	}
+	if len(response.Feedback) != 1 || response.Feedback[0].FeedbackID != wantFeedback {
+		t.Fatalf("want exactly feedback %q, got %+v", wantFeedback, response.Feedback)
+	}
+	if len(response.Diffs) != 1 || response.Diffs[0].DiffID != wantDiff {
+		t.Fatalf("want exactly diff %q, got %+v", wantDiff, response.Diffs)
+	}
+	if response.Feedback[0].RunID != wantRun || response.Diffs[0].RunID != wantRun {
+		t.Fatalf("evidence of another run leaked in: %+v / %+v", response.Feedback[0], response.Diffs[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Project isolation
+// ---------------------------------------------------------------------------
+
+// Two projects deliberately reuse the same run, agent and component ids. Not a
+// single row of one may appear in a response of the other.
+func TestProjectsWithIdenticalIdentifiersStayIsolated(t *testing.T) {
+	h := newHarness(t)
+
+	const (
+		runID       = "run-2026-08-04-0001"
+		agentID     = "orchestrator-root"
+		componentID = "shop-platform.orders"
+	)
+
+	for _, projectID := range []string{"alpha-project", "beta-project"} {
+		run := h.run(projectID, runID)
+		run.startRoot(agentID, "Deliver "+projectID+".")
+		run.emit(agentID, nil, store.TypeArchitectureSnapshotPublished, fmt.Sprintf(`{
+			"snapshotId": "snapshot-%s",
+			"components": [
+				{"componentId": %q, "name": %q, "kind": "service", "parentComponentId": null}
+			],
+			"relationships": []
+		}`, projectID, componentID, projectID+" orders"))
+		run.emit(agentID, nil, store.TypeFeedbackPublished, feedbackPayload(
+			"feedback-"+projectID, componentID, projectID+" review"))
+		run.emit(agentID, nil, store.TypeDiffReported, diffPayload(
+			"diff-"+projectID, componentID, "internal/"+projectID+"/orders.go"))
+		run.emit(agentID, nil, store.TypeRiskReported, fmt.Sprintf(
+			`{"riskId":"risk-%s","componentIds":[%q],"title":"%s risk","severity":"low"}`,
+			projectID, componentID, projectID))
+	}
+
+	// beta got one extra event, so the two projects also disagree on position.
+	h.run("beta-project", runID).emit(agentID, nil, store.TypeProblemReported, fmt.Sprintf(
+		`{"problemId":"problem-beta","componentIds":[%q],"title":"beta problem"}`, componentID))
+
+	for _, projectID := range []string{"alpha-project", "beta-project"} {
+		var architecture readapi.ArchitectureResponse
+		h.getJSON("/api/v1/projects/"+projectID+"/architecture", &architecture)
+		if len(architecture.Components) != 1 {
+			t.Fatalf("%s: want exactly one component, got %+v", projectID, architecture.Components)
+		}
+		if want := projectID + " orders"; architecture.Components[0].Name != want {
+			t.Fatalf("%s: want the own component %q, got %q", projectID, want, architecture.Components[0].Name)
+		}
+
+		var inspector readapi.ComponentResponse
+		h.getJSON("/api/v1/projects/"+projectID+"/components/"+componentID, &inspector)
+		if len(inspector.Feedback) != 1 || inspector.Feedback[0].FeedbackID != "feedback-"+projectID {
+			t.Fatalf("%s: feedback of another project leaked in: %+v", projectID, inspector.Feedback)
+		}
+		if len(inspector.Diffs) != 1 || inspector.Diffs[0].DiffID != "diff-"+projectID {
+			t.Fatalf("%s: diffs of another project leaked in: %+v", projectID, inspector.Diffs)
+		}
+		if len(inspector.Risks) != 1 || inspector.Risks[0].RiskID != "risk-"+projectID {
+			t.Fatalf("%s: risks of another project leaked in: %+v", projectID, inspector.Risks)
+		}
+
+		var runs readapi.RunsResponse
+		h.getJSON("/api/v1/projects/"+projectID+"/runs", &runs)
+		if len(runs.Runs) != 1 {
+			t.Fatalf("%s: want exactly one run, got %+v", projectID, runs.Runs)
+		}
+
+		var agents readapi.AgentsResponse
+		h.getJSON("/api/v1/projects/"+projectID+"/runs/"+runID+"/agents", &agents)
+		if len(agents.Agents) != 1 {
+			t.Fatalf("%s: want exactly one agent, got %+v", projectID, agents.Agents)
+		}
+		if want := "Deliver " + projectID + "."; agents.Agents[0].AssignedTask != want {
+			t.Fatalf("%s: agent of another project leaked in: %+v", projectID, agents.Agents[0])
+		}
+
+		other := "beta-project"
+		if projectID == other {
+			other = "alpha-project"
+		}
+		var history readapi.HistoryResponse
+		h.getJSON("/api/v1/projects/"+projectID+"/components/"+componentID+"/history", &history)
+		for _, entry := range history.Entries {
+			if strings.Contains(string(entry.Payload), other) {
+				t.Fatalf("%s: history entry of %s: %+v", projectID, other, entry)
+			}
+		}
+	}
+
+	// Positions are per project and must not be shared.
+	alpha := h.lastPosition("alpha-project")
+	beta := h.lastPosition("beta-project")
+	if alpha == beta {
+		t.Fatalf("the two projects should not share a position (%d)", alpha)
+	}
+
+	var alphaProject, betaProject readapi.ProjectResponse
+	h.getJSON("/api/v1/projects/alpha-project", &alphaProject)
+	h.getJSON("/api/v1/projects/beta-project", &betaProject)
+	if alphaProject.ProjectPosition != alpha || betaProject.ProjectPosition != beta {
+		t.Fatalf("projectPosition is not per project: %d/%d vs %d/%d",
+			alphaProject.ProjectPosition, alpha, betaProject.ProjectPosition, beta)
+	}
+	if alphaProject.Project.Counts.Components != 1 || betaProject.Project.Counts.Components != 1 {
+		t.Fatalf("the counts crossed the project boundary: %+v / %+v",
+			alphaProject.Project.Counts, betaProject.Project.Counts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Architecture read model
+// ---------------------------------------------------------------------------
+
+// The contract example carries four hierarchy levels and every relationship
+// kind, including three separate NATS topic edges. All of it must survive the
+// projection and the query unaggregated.
+func TestArchitectureReadModelReturnsTheFullContractSnapshot(t *testing.T) {
+	h := newHarness(t)
+	run := h.run("visualise-ai", "run-2026-08-04-0001")
+	run.startRoot("orchestrator-root", "Map the architecture.")
+	run.emitExample("architecture-snapshot.json")
+
+	var architecture readapi.ArchitectureResponse
+	h.getJSON("/api/v1/projects/visualise-ai/architecture", &architecture)
+
+	if len(architecture.Components) != 15 {
+		t.Fatalf("want the 15 snapshot components, got %d: %v",
+			len(architecture.Components), componentIDs(architecture.Components))
+	}
+	if len(architecture.Relationships) != 8 {
+		t.Fatalf("want the 8 snapshot relationships, got %d", len(architecture.Relationships))
+	}
+
+	byID := make(map[string]readapi.Component, len(architecture.Components))
+	for _, component := range architecture.Components {
+		byID[component.ComponentID] = component
+	}
+
+	// Four levels of nesting: system -> service -> module -> module.
+	chain := []string{
+		"shop-platform",
+		"shop-platform.orders",
+		"shop-platform.orders.domain",
+		"shop-platform.orders.domain.pricing",
+	}
+	for i, componentID := range chain {
+		component, ok := byID[componentID]
+		if !ok {
+			t.Fatalf("component %q is missing", componentID)
+		}
+		switch {
+		case i == 0:
+			if component.ParentComponentID != nil {
+				t.Fatalf("the root component must have no parent, got %v", component.ParentComponentID)
+			}
+		default:
+			if component.ParentComponentID == nil || *component.ParentComponentID != chain[i-1] {
+				t.Fatalf("component %q lost its parent %q: %v", componentID, chain[i-1], component.ParentComponentID)
+			}
+		}
+	}
+
+	// Reported technology and tags are handed through as documents, not flattened.
+	storefront := byID["shop-platform.storefront"]
+	if !strings.Contains(string(storefront.Technology), `"React"`) {
+		t.Fatalf("technology was not handed through: %s", storefront.Technology)
+	}
+	if !strings.Contains(string(storefront.Tags), `"frontend"`) {
+		t.Fatalf("tags were not handed through: %s", storefront.Tags)
+	}
+	// A component that reported neither must still carry an empty document.
+	if got := string(byID["shop-platform"].Technology); got != "{}" {
+		t.Fatalf("want an empty technology object, got %s", got)
+	}
+	if got := string(byID["shop-platform"].Tags); got != "[]" {
+		t.Fatalf("want an empty tags array, got %s", got)
+	}
+
+	kinds := map[string]int{}
+	topics := map[string]string{}
+	for _, relationship := range architecture.Relationships {
+		kinds[relationship.Kind]++
+		if relationship.Kind == "nats_topic" {
+			topics[relationship.RelationshipID] = relationship.Channel
+		}
+	}
+	for _, kind := range []string{"http", "grpc", "data", "async", "nats_topic", "dependency"} {
+		if kinds[kind] == 0 {
+			t.Fatalf("relationship kind %q is missing: %v", kind, kinds)
+		}
+	}
+	// Every topic keeps its own edge; they are never merged into one messaging edge.
+	if len(topics) != 3 {
+		t.Fatalf("want three separate nats_topic relationships, got %v", topics)
+	}
+	wantTopics := map[string]string{
+		"rel-orders-publishes-order-created":         "orders.order.created",
+		"rel-inventory-publishes-inventory-reserved": "inventory.item.reserved",
+		"rel-inventory-consumes-order-created":       "orders.order.created",
+	}
+	for relationshipID, channel := range wantTopics {
+		if topics[relationshipID] != channel {
+			t.Fatalf("topic %q lost its channel: want %q, got %q", relationshipID, channel, topics[relationshipID])
+		}
+	}
+}
+
+// A planned change is a proposal: it shows up under activeChanges and leaves the
+// applied model untouched until it is applied.
+func TestPlannedChangeIsAProposalAndDoesNotTouchTheAppliedModel(t *testing.T) {
+	h := newHarness(t)
+	run := h.run("visualise-ai", "run-2026-08-04-0001")
+	run.startRoot("orchestrator-root", "Extract VAT handling.")
+	run.emitExample("architecture-snapshot.json")
+
+	beforeIDs := func() []string {
+		var architecture readapi.ArchitectureResponse
+		h.getJSON("/api/v1/projects/visualise-ai/architecture", &architecture)
+		return componentIDs(architecture.Components)
+	}()
+
+	run.emitExample("component-change-planned.json")
+
+	var planned readapi.ArchitectureResponse
+	h.getJSON("/api/v1/projects/visualise-ai/architecture", &planned)
+	if got := componentIDs(planned.Components); len(got) != len(beforeIDs) {
+		t.Fatalf("a planned change modified the applied model: %v -> %v", beforeIDs, got)
+	}
+	if contains(componentIDs(planned.Components), "shop-platform.orders.domain.tax") {
+		t.Fatalf("the planned component reached the applied model")
+	}
+	if len(planned.ActiveChanges) != 1 {
+		t.Fatalf("want exactly one pending change, got %+v", planned.ActiveChanges)
+	}
+	change := planned.ActiveChanges[0]
+	if change.State != store.ChangeStatePlanned || change.ChangeID != "change-2026-08-04-0007" {
+		t.Fatalf("unexpected pending change: %+v", change)
+	}
+	if change.TargetKind != store.ChangeTargetComponent || change.TargetID != "shop-platform.orders.domain.tax" {
+		t.Fatalf("the change does not name its target: %+v", change)
+	}
+	// The reported descriptor travels with the proposal, so the canvas can draw
+	// it next to the applied model without a second lookup.
+	if !strings.Contains(string(change.Snapshot), `"Tax Calculation"`) {
+		t.Fatalf("the proposal lost its descriptor: %s", change.Snapshot)
+	}
+
+	run.emitExample("component-change-applied.json")
+
+	var applied readapi.ArchitectureResponse
+	h.getJSON("/api/v1/projects/visualise-ai/architecture", &applied)
+	if !contains(componentIDs(applied.Components), "shop-platform.orders.domain.tax") {
+		t.Fatalf("the applied change did not reach the model: %v", componentIDs(applied.Components))
+	}
+	// Applied is no longer pending: it has become the model.
+	if len(applied.ActiveChanges) != 0 {
+		t.Fatalf("an applied change is not an active change any more: %+v", applied.ActiveChanges)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Plans
+// ---------------------------------------------------------------------------
+
+// Plan revisions are append-only. A newer revision must not rewrite an older
+// one, and a step update must only reach the revision that was current when it
+// was reported.
+func TestPlanRevisionsAreAppendOnlyAndComplete(t *testing.T) {
+	h := newHarness(t)
+	run := h.run("visualise-ai", "run-2026-08-04-0001")
+	run.startRoot("orchestrator-root", "Deliver the cockpit.")
+
+	run.emit("orchestrator-root", nil, store.TypePlanPublished, `{
+		"planId": "plan-2026-08-04-0001",
+		"revision": 1,
+		"steps": [
+			{"stepId": "step-contract", "order": 0, "title": "Define the contract", "state": "pending"},
+			{"stepId": "step-store", "order": 1, "title": "Build the event store", "state": "pending"}
+		]
+	}`)
+	run.emit("orchestrator-root", nil, store.TypePlanStepUpdated,
+		`{"planId":"plan-2026-08-04-0001","stepId":"step-contract","state":"done"}`)
+
+	run.emit("orchestrator-root", nil, store.TypePlanPublished, `{
+		"planId": "plan-2026-08-04-0001",
+		"revision": 2,
+		"steps": [
+			{"stepId": "step-contract", "order": 0, "title": "Define the contract", "state": "done"},
+			{"stepId": "step-store", "order": 1, "title": "Build the event store", "state": "in_progress"},
+			{"stepId": "step-readapi", "order": 2, "title": "Build the read API", "state": "pending"}
+		]
+	}`)
+	run.emit("orchestrator-root", nil, store.TypePlanStepUpdated,
+		`{"planId":"plan-2026-08-04-0001","stepId":"step-store","state":"done"}`)
+
+	var plans readapi.PlansResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs/current/plans", &plans)
+	if len(plans.Plans) != 1 {
+		t.Fatalf("want one plan, got %+v", plans.Plans)
+	}
+	plan := plans.Plans[0]
+	if plan.CurrentRevision != 2 {
+		t.Fatalf("want revision 2 to be current, got %d", plan.CurrentRevision)
+	}
+	if len(plan.Revisions) != 2 {
+		t.Fatalf("want both revisions, got %d", len(plan.Revisions))
+	}
+	if plan.Revisions[0].Revision != 1 || plan.Revisions[1].Revision != 2 {
+		t.Fatalf("revisions are not ascending: %+v", plan.Revisions)
+	}
+	if plan.Revisions[0].IsCurrent || !plan.Revisions[1].IsCurrent {
+		t.Fatalf("the current revision is marked wrong: %+v", plan.Revisions)
+	}
+
+	first := plan.Revisions[0]
+	if len(first.Steps) != 2 {
+		t.Fatalf("revision 1 must keep exactly the two steps it was published with: %+v", first.Steps)
+	}
+	if first.Steps[0].StepID != "step-contract" || first.Steps[1].StepID != "step-store" {
+		t.Fatalf("revision 1 lost its step order: %+v", first.Steps)
+	}
+	// The first update landed on revision 1 while it was current; the second one
+	// went to revision 2 and must not have reached back.
+	if first.Steps[0].State != "done" {
+		t.Fatalf("revision 1 lost the update it received while current: %+v", first.Steps[0])
+	}
+	if first.Steps[1].State != "pending" {
+		t.Fatalf("an update of a later revision rewrote revision 1: %+v", first.Steps[1])
+	}
+
+	second := plan.Revisions[1]
+	if len(second.Steps) != 3 {
+		t.Fatalf("revision 2 must carry all three steps: %+v", second.Steps)
+	}
+	if second.Steps[1].State != "done" {
+		t.Fatalf("revision 2 did not receive its own update: %+v", second.Steps[1])
+	}
+	if second.Steps[2].State != "pending" {
+		t.Fatalf("an unrelated step of revision 2 changed: %+v", second.Steps[2])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Component inspector
+// ---------------------------------------------------------------------------
+
+// The inspector shows every kind of evidence of its own component and nothing of
+// its neighbour, even when both were reported by the same agent in the same run.
+func TestComponentInspectorCarriesOnlyItsOwnEvidence(t *testing.T) {
+	h := newHarness(t)
+	const (
+		mine    = "shop-platform.orders.domain.pricing"
+		theirs  = "shop-platform.orders.domain.tax"
+		project = "visualise-ai"
+	)
+
+	run := h.run(project, "run-2026-08-04-0001")
+	run.startRoot("orchestrator-root", "Extract VAT handling.")
+	run.startSub("subagent-implementer", "orchestrator-root", "Change the pricing module.")
+	run.emitExample("architecture-snapshot.json")
+
+	run.emit("subagent-implementer", nil, store.TypeWorkStepStarted, fmt.Sprintf(
+		`{"workStepId":"work-pricing","title":"Rework Total()","componentIds":[%q]}`, mine))
+	run.emit("subagent-implementer", nil, store.TypeFeedbackPublished, feedbackPayload("feedback-mine", mine, "Mine"))
+	run.emit("subagent-implementer", nil, store.TypeDiffReported, diffPayload("diff-mine", mine, "internal/pricing.go"))
+	run.emit("subagent-implementer", nil, store.TypeRiskReported, fmt.Sprintf(
+		`{"riskId":"risk-mine","componentIds":[%q],"title":"Rounding is undefined","severity":"medium"}`, mine))
+	run.emit("subagent-implementer", nil, store.TypeProblemReported, fmt.Sprintf(
+		`{"problemId":"problem-mine","componentIds":[%q],"title":"Test fixture missing"}`, mine))
+	run.emit("subagent-implementer", nil, store.TypeComponentChangePlanned, fmt.Sprintf(`{
+		"changeId": "change-mine",
+		"operation": "modify",
+		"component": {"componentId": %q, "name": "Pricing", "kind": "module",
+			"parentComponentId": "shop-platform.orders.domain"},
+		"rationale": "Split VAT out."
+	}`, mine))
+
+	// The same agent reports the same kinds of evidence for the neighbour.
+	run.emit("subagent-implementer", nil, store.TypeFeedbackPublished, feedbackPayload("feedback-theirs", theirs, "Theirs"))
+	run.emit("subagent-implementer", nil, store.TypeDiffReported, diffPayload("diff-theirs", theirs, "internal/tax.go"))
+	run.emit("subagent-implementer", nil, store.TypeRiskReported, fmt.Sprintf(
+		`{"riskId":"risk-theirs","componentIds":[%q],"title":"Unmapped country","severity":"high"}`, theirs))
+	run.emit("subagent-implementer", nil, store.TypeProblemReported, fmt.Sprintf(
+		`{"problemId":"problem-theirs","componentIds":[%q],"title":"Rate table stale"}`, theirs))
+
+	var inspector readapi.ComponentResponse
+	h.getJSON("/api/v1/projects/"+project+"/components/"+mine, &inspector)
+
+	if inspector.Component == nil || inspector.Component.ComponentID != mine {
+		t.Fatalf("want the applied component, got %+v", inspector.Component)
+	}
+	if inspector.CurrentWorkStep == nil || inspector.CurrentWorkStep.WorkStepID != "work-pricing" {
+		t.Fatalf("want the open work step, got %+v", inspector.CurrentWorkStep)
+	}
+	if inspector.CurrentWorkStep.CompletedAt != nil {
+		t.Fatalf("the work step was never completed: %+v", inspector.CurrentWorkStep)
+	}
+	if inspector.ResponsibleAgent == nil || inspector.ResponsibleAgent.AgentID != "subagent-implementer" {
+		t.Fatalf("want the agent of the work step, got %+v", inspector.ResponsibleAgent)
+	}
+	if parent := inspector.ResponsibleAgent.ParentAgentID; parent == nil || *parent != "orchestrator-root" {
+		t.Fatalf("the responsible agent lost its place in the tree: %v", parent)
+	}
+
+	assertOnlyOwn := func(kind string, ids []string) {
+		t.Helper()
+		if len(ids) != 1 || !strings.HasSuffix(ids[0], "-mine") {
+			t.Fatalf("%s: want exactly the own evidence, got %v", kind, ids)
+		}
+	}
+	assertOnlyOwn("feedback", mapIDs(len(inspector.Feedback), func(i int) string { return inspector.Feedback[i].FeedbackID }))
+	assertOnlyOwn("diffs", mapIDs(len(inspector.Diffs), func(i int) string { return inspector.Diffs[i].DiffID }))
+	assertOnlyOwn("risks", mapIDs(len(inspector.Risks), func(i int) string { return inspector.Risks[i].RiskID }))
+	assertOnlyOwn("problems", mapIDs(len(inspector.Problems), func(i int) string { return inspector.Problems[i].ProblemID }))
+	assertOnlyOwn("activeChanges", mapIDs(len(inspector.ActiveChanges), func(i int) string {
+		return inspector.ActiveChanges[i].ChangeID
+	}))
+
+	if inspector.Feedback[0].Body == "" || inspector.Diffs[0].UnifiedDiff == "" {
+		t.Fatalf("the inspector must carry the reported bodies verbatim: %+v", inspector.Feedback[0])
+	}
+
+	// The neighbour sees its own evidence, and only its own.
+	var neighbour readapi.ComponentResponse
+	h.getJSON("/api/v1/projects/"+project+"/components/"+theirs, &neighbour)
+	if len(neighbour.Feedback) != 1 || neighbour.Feedback[0].FeedbackID != "feedback-theirs" {
+		t.Fatalf("the neighbour inspector is wrong: %+v", neighbour.Feedback)
+	}
+	if neighbour.CurrentWorkStep != nil {
+		t.Fatalf("no work step named the neighbour, so none may be shown: %+v", neighbour.CurrentWorkStep)
+	}
+}
+
+// A component that a snapshot removed keeps its history and stays inspectable;
+// only the applied descriptor is gone.
+func TestRemovedComponentKeepsItsHistory(t *testing.T) {
+	h := newHarness(t)
+	const componentID = "shop-platform.legacy"
+	run := h.run("visualise-ai", "run-2026-08-04-0001")
+	run.startRoot("orchestrator-root", "Retire the legacy module.")
+	run.emit("orchestrator-root", nil, store.TypeArchitectureSnapshotPublished, fmt.Sprintf(`{
+		"snapshotId": "snapshot-1",
+		"components": [{"componentId": %q, "name": "Legacy", "kind": "module", "parentComponentId": null}],
+		"relationships": []
+	}`, componentID))
+	run.emit("orchestrator-root", nil, store.TypeFeedbackPublished, feedbackPayload("feedback-legacy", componentID, "Retire it"))
+	// A second snapshot without the component removes it from the applied model.
+	run.emit("orchestrator-root", nil, store.TypeArchitectureSnapshotPublished,
+		`{"snapshotId":"snapshot-2","components":[],"relationships":[]}`)
+
+	var inspector readapi.ComponentResponse
+	h.getJSON("/api/v1/projects/visualise-ai/components/"+componentID, &inspector)
+	if inspector.Component != nil {
+		t.Fatalf("the component left the applied model, so it must be null: %+v", inspector.Component)
+	}
+	if len(inspector.Feedback) != 1 {
+		t.Fatalf("the evidence must survive the removal: %+v", inspector.Feedback)
+	}
+
+	// The removing snapshot names no component at all, so it links to none: the
+	// history holds the two events that actually mentioned this component.
+	var history readapi.HistoryResponse
+	h.getJSON("/api/v1/projects/visualise-ai/components/"+componentID+"/history", &history)
+	if len(history.Entries) != 2 {
+		t.Fatalf("want the first snapshot and the feedback, got %d: %+v", len(history.Entries), history.Entries)
+	}
+	if history.Entries[1].Type != store.TypeArchitectureSnapshotPublished {
+		t.Fatalf("the oldest entry must be the snapshot that introduced the component: %+v", history.Entries)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+// Paging through the run list must visit every run exactly once.
+func TestRunPaginationIsGapFreeAndDuplicateFree(t *testing.T) {
+	h := newHarness(t)
+
+	const total = 7
+	want := make(map[string]bool, total)
+	for i := 1; i <= total; i++ {
+		runID := fmt.Sprintf("run-2026-08-04-%04d", i)
+		want[runID] = false
+		h.run("visualise-ai", runID).startRoot("orchestrator-root", "Run "+runID)
+	}
+
+	path := "/api/v1/projects/visualise-ai/runs?limit=3"
+	pages := 0
+	seen := 0
+	var previous *readapi.RunSummary
+	for {
+		pages++
+		if pages > total+1 {
+			t.Fatalf("pagination does not terminate")
+		}
+		var page readapi.RunsResponse
+		h.getJSON(path, &page)
+		for i := range page.Runs {
+			run := page.Runs[i]
+			already, known := want[run.RunID]
+			if !known {
+				t.Fatalf("unknown run %q in a page", run.RunID)
+			}
+			if already {
+				t.Fatalf("run %q was returned twice", run.RunID)
+			}
+			want[run.RunID] = true
+			seen++
+			// The ordering must hold across the page boundary as well.
+			if previous != nil && !previous.StartedAt.After(run.StartedAt) {
+				t.Fatalf("ordering broke at %q -> %q", previous.RunID, run.RunID)
+			}
+			previous = &run
+		}
+		if page.NextCursor == nil {
+			break
+		}
+		path = "/api/v1/projects/visualise-ai/runs?limit=3&cursor=" + *page.NextCursor
+	}
+	if seen != total {
+		t.Fatalf("want %d runs across the pages, got %d", total, seen)
+	}
+	if pages != 3 {
+		t.Fatalf("want three pages of 3+3+1, got %d", pages)
+	}
+}
+
+// The same for the component history, whose cursor is a project position.
+func TestHistoryPaginationIsGapFreeAndDuplicateFree(t *testing.T) {
+	h := newHarness(t)
+	const componentID = "shop-platform.orders"
+	run := h.run("visualise-ai", "run-2026-08-04-0001")
+	run.startRoot("orchestrator-root", "Report a lot.")
+
+	const total = 5
+	for i := 1; i <= total; i++ {
+		run.emit("orchestrator-root", nil, store.TypeFeedbackPublished,
+			feedbackPayload(fmt.Sprintf("feedback-%02d", i), componentID, fmt.Sprintf("Review %d", i)))
+	}
+
+	path := "/api/v1/projects/visualise-ai/components/" + componentID + "/history?limit=2"
+	var positions []int64
+	for {
+		var page readapi.HistoryResponse
+		h.getJSON(path, &page)
+		for _, entry := range page.Entries {
+			positions = append(positions, entry.Position)
+		}
+		if page.NextCursor == nil {
+			break
+		}
+		path = "/api/v1/projects/visualise-ai/components/" + componentID +
+			"/history?limit=2&cursor=" + *page.NextCursor
+	}
+
+	if len(positions) != total {
+		t.Fatalf("want %d history entries, got %d: %v", total, len(positions), positions)
+	}
+	for i := 1; i < len(positions); i++ {
+		if positions[i] >= positions[i-1] {
+			t.Fatalf("history positions are not strictly descending: %v", positions)
+		}
+	}
+}
+
+// The inspector pages its diffs, because one component can accumulate more
+// unified diffs than a single response should carry.
+func TestInspectorPagesItsDiffs(t *testing.T) {
+	h := newHarness(t)
+	const componentID = "shop-platform.orders"
+	run := h.run("visualise-ai", "run-2026-08-04-0001")
+	run.startRoot("orchestrator-root", "Change many files.")
+
+	const total = 5
+	for i := 1; i <= total; i++ {
+		run.emit("orchestrator-root", nil, store.TypeDiffReported, diffPayload(
+			fmt.Sprintf("diff-%02d", i), componentID, fmt.Sprintf("internal/orders/file%02d.go", i)))
+	}
+
+	path := "/api/v1/projects/visualise-ai/components/" + componentID + "?diffLimit=2"
+	seen := map[string]bool{}
+	for {
+		var page readapi.ComponentResponse
+		h.getJSON(path, &page)
+		for _, diff := range page.Diffs {
+			if seen[diff.DiffID] {
+				t.Fatalf("diff %q was returned twice", diff.DiffID)
+			}
+			seen[diff.DiffID] = true
+		}
+		if page.NextDiffCursor == nil {
+			break
+		}
+		path = "/api/v1/projects/visualise-ai/components/" + componentID +
+			"?diffLimit=2&diffCursor=" + *page.NextDiffCursor
+	}
+	if len(seen) != total {
+		t.Fatalf("want %d diffs across the pages, got %d", total, len(seen))
+	}
+}
+
+// A limit outside the documented range is a client error, not a silently
+// clamped page: a UI must not believe it received everything.
+func TestInvalidPaginationParametersAreRejected(t *testing.T) {
+	h := newHarness(t)
+	h.run("visualise-ai", "run-2026-08-04-0001").startRoot("orchestrator-root", "Deliver.")
+
+	cases := []struct {
+		path      string
+		wantField string
+	}{
+		{"/api/v1/projects/visualise-ai/runs?limit=0", "/limit"},
+		{"/api/v1/projects/visualise-ai/runs?limit=201", "/limit"},
+		{"/api/v1/projects/visualise-ai/runs?limit=-1", "/limit"},
+		{"/api/v1/projects/visualise-ai/runs?limit=many", "/limit"},
+		{"/api/v1/projects/visualise-ai/runs?cursor=not-a-cursor", "/cursor"},
+	}
+	for _, testCase := range cases {
+		problem := h.getProblem(testCase.path, http.StatusBadRequest)
+		if problem.Code != "invalid_query_parameter" {
+			t.Fatalf("GET %s: want invalid_query_parameter, got %q", testCase.path, problem.Code)
+		}
+		if len(problem.Errors) != 1 || problem.Errors[0].Field != testCase.wantField {
+			t.Fatalf("GET %s: want a field error on %s, got %+v", testCase.path, testCase.wantField, problem.Errors)
+		}
+	}
+
+	// The upper bound itself is still accepted.
+	var runs readapi.RunsResponse
+	h.getJSON("/api/v1/projects/visualise-ai/runs?limit=200", &runs)
+	if len(runs.Runs) != 1 {
+		t.Fatalf("the maximum limit must be accepted, got %+v", runs.Runs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// projectPosition
+// ---------------------------------------------------------------------------
+
+// Every project scoped response repeats projects.last_position, which is what
+// makes an HTTP snapshot and the SSE stream comparable.
+func TestEveryResponseRepeatsTheProjectPosition(t *testing.T) {
+	h := newHarness(t)
+	const componentID = "shop-platform.orders"
+	run := h.run("visualise-ai", "run-2026-08-04-0001")
+	run.startRoot("orchestrator-root", "Deliver.")
+	run.emit("orchestrator-root", nil, store.TypeArchitectureSnapshotPublished, fmt.Sprintf(`{
+		"snapshotId": "snapshot-1",
+		"components": [{"componentId": %q, "name": "Orders", "kind": "service", "parentComponentId": null}],
+		"relationships": []
+	}`, componentID))
+	run.emit("orchestrator-root", nil, store.TypePlanPublished, `{
+		"planId": "plan-1", "revision": 1,
+		"steps": [{"stepId":"step-1","order":0,"title":"Start","state":"pending"}]
+	}`)
+
+	assertPositions := func(want int64) {
+		t.Helper()
+		type positioned struct {
+			ProjectPosition int64 `json:"projectPosition"`
+		}
+		paths := []string{
+			"/api/v1/projects",
+			"/api/v1/projects/visualise-ai",
+			"/api/v1/projects/visualise-ai/architecture",
+			"/api/v1/projects/visualise-ai/runs",
+			"/api/v1/projects/visualise-ai/runs/current",
+			"/api/v1/projects/visualise-ai/runs/current/agents",
+			"/api/v1/projects/visualise-ai/runs/current/plans",
+			"/api/v1/projects/visualise-ai/components/" + componentID,
+			"/api/v1/projects/visualise-ai/components/" + componentID + "/history",
+		}
+		for _, path := range paths {
+			var body positioned
+			h.getJSON(path, &body)
+			if body.ProjectPosition != want {
+				t.Fatalf("GET %s: want projectPosition %d, got %d", path, want, body.ProjectPosition)
+			}
+		}
+	}
+
+	assertPositions(h.lastPosition("visualise-ai"))
+
+	// One more event moves the position of every response together.
+	result := run.emit("orchestrator-root", nil, store.TypeAgentStatusReported, `{"status":"working"}`)
+	if result.Position != h.lastPosition("visualise-ai") {
+		t.Fatalf("the store and the projection disagree on the position")
+	}
+	assertPositions(result.Position)
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance: a UI rebuilds the whole v0 state from the read endpoints alone
+// ---------------------------------------------------------------------------
+
+// This is the acceptance criterion of the issue: after a realistic event
+// sequence, architecture, runs, the agent tree, the plans and the component
+// evidence are reconstructed exclusively through the read endpoints — no query
+// touches the event log, and none of them needs a second round trip per row.
+func TestUIRebuildsTheFullV0StateFromReadEndpointsOnly(t *testing.T) {
+	h := newHarness(t)
+	const project = "visualise-ai"
+
+	// A finished run from yesterday, so the reconstruction has to separate
+	// current work from history.
+	past := h.run(project, "run-2026-08-03-0001")
+	past.startRoot("orchestrator-root", "Yesterday's run.")
+	past.emit("orchestrator-root", nil, store.TypeFeedbackPublished, feedbackPayload(
+		"feedback-yesterday", "shop-platform.orders.domain.pricing", "Yesterday"))
+	past.emit("orchestrator-root", nil, store.TypeRunFinished, `{"outcome":"completed","summary":"Done."}`)
+
+	run := h.run(project, "run-2026-08-04-0001")
+	run.startRoot("orchestrator-root", "Extract VAT handling out of pricing.")
+	run.emitExample("subagent-started.json")
+	run.startSub("subagent-architecture-mapper", "orchestrator-root", "Map the architecture.")
+	run.startSub("subagent-implementer", "orchestrator-root", "Implement the extraction.")
+	run.startSub("subagent-reviewer", "subagent-implementer", "Review the extraction.")
+
+	run.emit("orchestrator-root", nil, store.TypePlanPublished, `{
+		"planId": "plan-2026-08-04-0001",
+		"revision": 1,
+		"steps": [
+			{"stepId":"step-map","order":0,"title":"Map the architecture","state":"pending",
+			 "componentIds":["shop-platform.orders.domain"]},
+			{"stepId":"step-extract","order":1,"title":"Extract the tax module","state":"pending",
+			 "componentIds":["shop-platform.orders.domain.pricing"]}
+		]
+	}`)
+	run.emitExample("architecture-snapshot.json")
+	run.emit("orchestrator-root", nil, store.TypePlanStepUpdated,
+		`{"planId":"plan-2026-08-04-0001","stepId":"step-map","state":"done"}`)
+
+	run.emitExample("component-change-planned.json")
+	run.emit("subagent-implementer", nil, store.TypeWorkStepStarted, `{
+		"workStepId": "work-extract-tax",
+		"title": "Move VAT handling into its own module",
+		"componentIds": ["shop-platform.orders.domain.pricing"],
+		"planStepId": "step-extract"
+	}`)
+	run.emitExample("diff-reported.json")
+	run.emitExample("component-change-applied.json")
+	run.emitExample("feedback-published.json")
+	run.emit("subagent-implementer", nil, store.TypeAgentProgressReported,
+		`{"percent":80,"scope":"own_task","basis":"completed_steps"}`)
+	// A pending proposal that is deliberately left open.
+	run.emit("subagent-architecture-mapper", nil, store.TypeRelationshipChangePlanned, `{
+		"changeId": "change-pricing-tax-dependency",
+		"operation": "add",
+		"relationship": {
+			"relationshipId": "rel-pricing-tax",
+			"sourceComponentId": "shop-platform.orders.domain.pricing",
+			"targetComponentId": "shop-platform.orders.domain.tax",
+			"kind": "dependency",
+			"label": "Delegates VAT"
+		},
+		"rationale": "Pricing will call into the new tax module."
+	}`)
+
+	position := h.lastPosition(project)
+
+	// 1. The project list and the project itself.
+	var projects readapi.ProjectsResponse
+	h.getJSON("/api/v1/projects", &projects)
+	if len(projects.Projects) != 1 || projects.Projects[0].CurrentRunID == nil ||
+		*projects.Projects[0].CurrentRunID != "run-2026-08-04-0001" {
+		t.Fatalf("the project list does not point at the current run: %+v", projects.Projects)
+	}
+
+	var detail readapi.ProjectResponse
+	h.getJSON("/api/v1/projects/"+project, &detail)
+	if detail.Project.Counts.Runs != 2 || detail.Project.Counts.OpenRuns != 1 {
+		t.Fatalf("want two runs, one open, got %+v", detail.Project.Counts)
+	}
+
+	// 2. The architecture, including the applied change and the open proposal.
+	var architecture readapi.ArchitectureResponse
+	h.getJSON("/api/v1/projects/"+project+"/architecture", &architecture)
+	ids := componentIDs(architecture.Components)
+	if !contains(ids, "shop-platform.orders.domain.tax") {
+		t.Fatalf("the applied change is missing from the model: %v", ids)
+	}
+	if len(architecture.Relationships) != 8 {
+		t.Fatalf("want the eight applied relationships, got %d", len(architecture.Relationships))
+	}
+	if len(architecture.ActiveChanges) != 1 ||
+		architecture.ActiveChanges[0].ChangeID != "change-pricing-tax-dependency" {
+		t.Fatalf("want exactly the open proposal, got %+v", architecture.ActiveChanges)
+	}
+	// The proposal must not have reached the applied edges.
+	for _, relationship := range architecture.Relationships {
+		if relationship.RelationshipID == "rel-pricing-tax" {
+			t.Fatalf("a planned relationship reached the applied model")
+		}
+	}
+
+	// 3. Runs: the current one and the history, cleanly separated.
+	var runs readapi.RunsResponse
+	h.getJSON("/api/v1/projects/"+project+"/runs", &runs)
+	if len(runs.Runs) != 2 || !runs.Runs[0].IsCurrent || runs.Runs[1].IsOpen {
+		t.Fatalf("runs are not separated into current and history: %+v", runs.Runs)
+	}
+
+	// 4. The agent tree of the current run.
+	var agents readapi.AgentsResponse
+	h.getJSON("/api/v1/projects/"+project+"/runs/current/agents", &agents)
+	if len(agents.Agents) != 5 {
+		t.Fatalf("want the root and its four subagents, got %d: %+v", len(agents.Agents), agents.Agents)
+	}
+	children := map[string]int{}
+	for _, agent := range agents.Agents {
+		if agent.ParentAgentID != nil {
+			children[*agent.ParentAgentID]++
+		}
+	}
+	if children["orchestrator-root"] != 3 || children["subagent-implementer"] != 1 {
+		t.Fatalf("the spawn hierarchy is wrong: %v", children)
+	}
+
+	// 5. The plans with their revisions and steps.
+	var plans readapi.PlansResponse
+	h.getJSON("/api/v1/projects/"+project+"/runs/current/plans", &plans)
+	if len(plans.Plans) != 1 || len(plans.Plans[0].Revisions) != 1 {
+		t.Fatalf("want one plan with one revision, got %+v", plans.Plans)
+	}
+	steps := plans.Plans[0].Revisions[0].Steps
+	if len(steps) != 2 || steps[0].State != "done" || steps[1].State != "pending" {
+		t.Fatalf("the plan steps were not reconstructed: %+v", steps)
+	}
+
+	// 6. The component inspector of the current run.
+	var inspector readapi.ComponentResponse
+	h.getJSON("/api/v1/projects/"+project+"/components/shop-platform.orders.domain.pricing", &inspector)
+	if inspector.ProjectPosition != position {
+		t.Fatalf("want projectPosition %d, got %d", position, inspector.ProjectPosition)
+	}
+	if inspector.Component == nil || inspector.Component.Name != "Pricing" {
+		t.Fatalf("the inspector lost its component: %+v", inspector.Component)
+	}
+	if inspector.CurrentWorkStep == nil || inspector.CurrentWorkStep.WorkStepID != "work-extract-tax" {
+		t.Fatalf("want the open work step, got %+v", inspector.CurrentWorkStep)
+	}
+	if step := inspector.CurrentWorkStep.PlanStepID; step == nil || *step != "step-extract" {
+		t.Fatalf("the work step lost its link into the plan: %v", step)
+	}
+	if inspector.ResponsibleAgent == nil || inspector.ResponsibleAgent.AgentID != "subagent-implementer" {
+		t.Fatalf("want the implementing subagent, got %+v", inspector.ResponsibleAgent)
+	}
+	if len(inspector.Diffs) != 1 || inspector.Diffs[0].DiffID != "diff-2026-08-04-0011" {
+		t.Fatalf("want the reported diff of this run, got %+v", inspector.Diffs)
+	}
+	if !strings.Contains(inspector.Diffs[0].UnifiedDiff, "@@") {
+		t.Fatalf("the unified diff was not handed through verbatim")
+	}
+	if len(inspector.Feedback) != 1 || inspector.Feedback[0].FeedbackID != "feedback-2026-08-04-0003" {
+		t.Fatalf("want the review of this run, got %+v", inspector.Feedback)
+	}
+	// Yesterday's feedback belongs to the history, not to the current inspector.
+	for _, entry := range inspector.Feedback {
+		if entry.FeedbackID == "feedback-yesterday" {
+			t.Fatalf("the inspector mixed in evidence of a historical run")
+		}
+	}
+
+	// 7. The run spanning history of the same component.
+	var history readapi.HistoryResponse
+	h.getJSON("/api/v1/projects/"+project+"/components/shop-platform.orders.domain.pricing/history", &history)
+	types := map[string]int{}
+	runsSeen := map[string]bool{}
+	for _, entry := range history.Entries {
+		types[entry.Type]++
+		runsSeen[entry.RunID] = true
+	}
+	if !runsSeen["run-2026-08-03-0001"] || !runsSeen["run-2026-08-04-0001"] {
+		t.Fatalf("the history does not span both runs: %v", runsSeen)
+	}
+	for _, wanted := range []string{
+		store.TypeArchitectureSnapshotPublished,
+		store.TypeWorkStepStarted,
+		store.TypeDiffReported,
+		store.TypeFeedbackPublished,
+		store.TypePlanPublished,
+	} {
+		if types[wanted] == 0 {
+			t.Fatalf("the history is missing %s: %v", wanted, types)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Payload helpers
+// ---------------------------------------------------------------------------
+
+func feedbackPayload(feedbackID, componentID, title string) string {
+	return fmt.Sprintf(`{
+		"feedbackId": %q,
+		"componentIds": [%q],
+		"format": "markdown",
+		"title": %q,
+		"body": "## %s\n\nReported observation."
+	}`, feedbackID, componentID, title, title)
+}
+
+func diffPayload(diffID, componentID, filePath string) string {
+	return fmt.Sprintf(`{
+		"diffId": %q,
+		"componentIds": [%q],
+		"filePath": %q,
+		"unifiedDiff": "--- a/%s\n+++ b/%s\n@@ -1,2 +1,2 @@\n-old\n+new\n"
+	}`, diffID, componentID, filePath, filePath, filePath)
+}
+
+func mapIDs(count int, at func(int) string) []string {
+	out := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, at(i))
+	}
+	return out
+}

--- a/backend/internal/readapi/runs.go
+++ b/backend/internal/readapi/runs.go
@@ -1,0 +1,281 @@
+package readapi
+
+import (
+	"context"
+	"time"
+
+	"github.com/risqyy/visualise-ai/backend/internal/store"
+)
+
+// Runs lists current and historical runs of a project, newest start first.
+//
+// Two statements: the project head row and one page of runs. The page is read
+// with limit+1 rows so the presence of a next page is known without a count.
+func (s *Service) Runs(ctx context.Context, projectID, rawLimit, rawCursor string) (RunsResponse, error) {
+	project, err := s.project(ctx, projectID)
+	if err != nil {
+		return RunsResponse{}, err
+	}
+	page, invalid := parsePage("limit", "cursor", rawLimit, rawCursor)
+	if invalid != nil {
+		return RunsResponse{}, invalid
+	}
+
+	query := s.db.WithContext(ctx).
+		Model(&store.Run{}).
+		Where("project_id = ?", projectID)
+	if page.Cursor != "" {
+		nanos, runID, ok := parseRunCursor(page.Cursor)
+		if !ok {
+			return RunsResponse{}, &ValidationError{Errors: []FieldError{{
+				Field:   "/cursor",
+				Code:    codeInvalid,
+				Message: "cursor does not belong to the run collection",
+			}}}
+		}
+		// Strictly after the cursor row in the very ordering below, so a page
+		// boundary neither repeats nor skips a run.
+		startedAt := time.Unix(0, nanos).UTC()
+		query = query.Where("(started_at, run_id) < (?, ?)", startedAt, runID)
+	}
+
+	var rows []store.Run
+	if err := query.
+		Order("started_at DESC, run_id DESC").
+		Limit(page.Limit + 1).
+		Find(&rows).Error; err != nil {
+		return RunsResponse{}, err
+	}
+
+	response := RunsResponse{ProjectPosition: project.LastPosition}
+	if len(rows) > page.Limit {
+		last := rows[page.Limit-1]
+		cursor := runCursor(last.StartedAt.UTC().UnixNano(), last.RunID)
+		response.NextCursor = &cursor
+		rows = rows[:page.Limit]
+	}
+
+	response.Runs = make([]RunSummary, 0, len(rows))
+	for _, row := range rows {
+		response.Runs = append(response.Runs, runSummary(row, project.CurrentRunID))
+	}
+	return response, nil
+}
+
+// Run returns one run of a project. The literal `current` resolves to
+// `projects.current_run_id`.
+//
+// Three statements: the project head row, the run row and one row of scalar
+// subqueries for the counts.
+func (s *Service) Run(ctx context.Context, projectID, runID string) (RunResponse, error) {
+	project, err := s.project(ctx, projectID)
+	if err != nil {
+		return RunResponse{}, err
+	}
+	run, err := s.resolveRun(ctx, project, runID)
+	if err != nil {
+		return RunResponse{}, err
+	}
+
+	var counts RunCounts
+	if err := s.db.WithContext(ctx).Raw(`
+		SELECT
+			(SELECT count(*) FROM agents     WHERE project_id = ? AND run_id = ?) AS agents,
+			(SELECT count(*) FROM plans      WHERE project_id = ? AND run_id = ?) AS plans,
+			(SELECT count(*) FROM work_steps WHERE project_id = ? AND run_id = ?) AS work_steps`,
+		projectID, run.RunID, projectID, run.RunID, projectID, run.RunID,
+	).Scan(&counts).Error; err != nil {
+		return RunResponse{}, err
+	}
+
+	return RunResponse{
+		ProjectPosition: project.LastPosition,
+		Run: RunDetail{
+			RunSummary: runSummary(run, project.CurrentRunID),
+			Counts:     counts,
+		},
+	}, nil
+}
+
+// Agents returns the agent tree of one run as a flat list.
+//
+// Three statements: project, run and the agents. The list is ordered by start
+// time so a parent is emitted before the subagents it spawned, which lets a
+// consumer build the tree in a single pass.
+func (s *Service) Agents(ctx context.Context, projectID, runID string) (AgentsResponse, error) {
+	project, err := s.project(ctx, projectID)
+	if err != nil {
+		return AgentsResponse{}, err
+	}
+	run, err := s.resolveRun(ctx, project, runID)
+	if err != nil {
+		return AgentsResponse{}, err
+	}
+
+	var rows []store.Agent
+	if err := s.db.WithContext(ctx).
+		Model(&store.Agent{}).
+		Where("project_id = ? AND run_id = ?", projectID, run.RunID).
+		Order("started_at ASC, agent_id ASC").
+		Find(&rows).Error; err != nil {
+		return AgentsResponse{}, err
+	}
+
+	response := AgentsResponse{
+		ProjectPosition: project.LastPosition,
+		Agents:          make([]Agent, 0, len(rows)),
+	}
+	for _, row := range rows {
+		response.Agents = append(response.Agents, agentOf(row))
+	}
+	return response, nil
+}
+
+// Plans returns every plan of one run with all of its revisions and steps.
+//
+// Five statements regardless of how many plans, revisions or steps exist:
+// project, run, plans, then the revisions and the steps of exactly those plans.
+// Grouping happens in memory, so no query runs per plan or per revision.
+func (s *Service) Plans(ctx context.Context, projectID, runID string) (PlansResponse, error) {
+	project, err := s.project(ctx, projectID)
+	if err != nil {
+		return PlansResponse{}, err
+	}
+	run, err := s.resolveRun(ctx, project, runID)
+	if err != nil {
+		return PlansResponse{}, err
+	}
+
+	var planRows []store.Plan
+	if err := s.db.WithContext(ctx).
+		Model(&store.Plan{}).
+		Where("project_id = ? AND run_id = ?", projectID, run.RunID).
+		Order("plan_id ASC").
+		Find(&planRows).Error; err != nil {
+		return PlansResponse{}, err
+	}
+
+	response := PlansResponse{
+		ProjectPosition: project.LastPosition,
+		Plans:           make([]Plan, 0, len(planRows)),
+	}
+	if len(planRows) == 0 {
+		return response, nil
+	}
+
+	planIDs := make([]string, 0, len(planRows))
+	for _, row := range planRows {
+		planIDs = append(planIDs, row.PlanID)
+	}
+
+	// plan_revisions and plan_steps are keyed by (project, plan, revision) and
+	// carry no run column: a plan id belongs to exactly one run, so narrowing by
+	// the plan ids of this run is the run filter.
+	var revisionRows []store.PlanRevision
+	if err := s.db.WithContext(ctx).
+		Model(&store.PlanRevision{}).
+		Where("project_id = ? AND plan_id IN ?", projectID, planIDs).
+		Order("plan_id ASC, revision ASC").
+		Find(&revisionRows).Error; err != nil {
+		return PlansResponse{}, err
+	}
+
+	var stepRows []store.PlanStep
+	if err := s.db.WithContext(ctx).
+		Model(&store.PlanStep{}).
+		Where("project_id = ? AND plan_id IN ?", projectID, planIDs).
+		Order("plan_id ASC, revision ASC, step_order ASC, step_id ASC").
+		Find(&stepRows).Error; err != nil {
+		return PlansResponse{}, err
+	}
+
+	type revisionKey struct {
+		planID   string
+		revision int
+	}
+	stepsByRevision := make(map[revisionKey][]PlanStep, len(revisionRows))
+	for _, row := range stepRows {
+		key := revisionKey{planID: row.PlanID, revision: row.Revision}
+		stepsByRevision[key] = append(stepsByRevision[key], PlanStep{
+			StepID:   row.StepID,
+			Order:    row.StepOrder,
+			Title:    row.Title,
+			State:    row.State,
+			Position: row.LastAppliedProjectPosition,
+		})
+	}
+
+	revisionsByPlan := make(map[string][]PlanRevision, len(planRows))
+	for _, row := range revisionRows {
+		steps := stepsByRevision[revisionKey{planID: row.PlanID, revision: row.Revision}]
+		if steps == nil {
+			steps = []PlanStep{}
+		}
+		revisionsByPlan[row.PlanID] = append(revisionsByPlan[row.PlanID], PlanRevision{
+			Revision:         row.Revision,
+			CreatedAt:        utc(row.CreatedAt),
+			CreatedByAgentID: row.CreatedByAgentID,
+			Steps:            steps,
+			Position:         row.LastAppliedProjectPosition,
+		})
+	}
+
+	for _, row := range planRows {
+		revisions := revisionsByPlan[row.PlanID]
+		if revisions == nil {
+			revisions = []PlanRevision{}
+		}
+		for i := range revisions {
+			revisions[i].IsCurrent = revisions[i].Revision == row.CurrentRevision
+		}
+		response.Plans = append(response.Plans, Plan{
+			PlanID:          row.PlanID,
+			RunID:           row.RunID,
+			AgentID:         row.AgentID,
+			CurrentRevision: row.CurrentRevision,
+			Revisions:       revisions,
+			Position:        row.LastAppliedProjectPosition,
+		})
+	}
+	return response, nil
+}
+
+func runSummary(row store.Run, currentRunID string) RunSummary {
+	return RunSummary{
+		RunID:       row.RunID,
+		RootAgentID: nonEmpty(row.RootAgentID),
+		StartedAt:   utc(row.StartedAt),
+		FinishedAt:  utcPtr(row.FinishedAt),
+		Outcome:     row.Outcome,
+		IsOpen:      row.IsOpen,
+		IsCurrent:   currentRunID != "" && row.RunID == currentRunID,
+		Position:    row.LastAppliedProjectPosition,
+	}
+}
+
+func agentOf(row store.Agent) Agent {
+	agent := Agent{
+		AgentID:         row.AgentID,
+		RunID:           row.RunID,
+		ParentAgentID:   row.ParentAgentID,
+		Role:            row.Role,
+		DisplayName:     row.DisplayName,
+		AssignedTask:    row.AssignedTask,
+		Status:          row.Status,
+		StatusNote:      row.StatusNote,
+		FinishedOutcome: row.FinishedOutcome,
+		StartedAt:       utc(row.StartedAt),
+		LastEventAt:     utc(row.LastEventAt),
+		Position:        row.LastAppliedProjectPosition,
+	}
+	// Progress stays null until the agent reported a number itself; a zero
+	// percent that was never reported would read as "nothing done yet".
+	if row.ProgressPercent != nil {
+		agent.Progress = &AgentProgress{
+			Percent: *row.ProgressPercent,
+			Scope:   row.ProgressScope,
+			Basis:   row.ProgressBasis,
+		}
+	}
+	return agent
+}

--- a/backend/internal/readapi/testsupport_test.go
+++ b/backend/internal/readapi/testsupport_test.go
@@ -1,0 +1,320 @@
+package readapi_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"gorm.io/gorm"
+
+	"github.com/risqyy/visualise-ai/backend/internal/database"
+	"github.com/risqyy/visualise-ai/backend/internal/health"
+	"github.com/risqyy/visualise-ai/backend/internal/httpapi"
+	"github.com/risqyy/visualise-ai/backend/internal/readapi"
+	"github.com/risqyy/visualise-ai/backend/internal/store"
+)
+
+// The read API is tested against a real PostgreSQL instance and against the
+// real event store: the fixtures are built by appending events through
+// store.Append, never by writing into the projection tables. Only that exercises
+// the chain the cockpit actually depends on — contract payload, projection,
+// query, handler.
+//
+//	docker run -d --name vai-test-pg-8 -e POSTGRES_PASSWORD=test \
+//	  -e POSTGRES_USER=test -e POSTGRES_DB=test -p 55435:5432 postgres:17-alpine
+//	TEST_DATABASE_URL='postgres://test:test@127.0.0.1:55435/test?sslmode=disable' \
+//	  go test ./internal/readapi/...
+//
+// Without TEST_DATABASE_URL every test here skips, so `go test ./...` stays
+// green on a machine without a database.
+const testDatabaseURLEnv = "TEST_DATABASE_URL"
+
+// testSchema keeps these tests in a PostgreSQL schema of their own.
+//
+// `go test ./...` runs packages in parallel, and every test here truncates the
+// whole schema before it seeds. Without the separation the store tests and
+// these would wipe each other's fixtures on a shared TEST_DATABASE_URL.
+const testSchema = "readapi_test"
+
+var (
+	migrateOnce sync.Once
+	migrateErr  error
+)
+
+// baseTime anchors the reported timestamps so ordering assertions are exact.
+var baseTime = time.Date(2026, 8, 4, 9, 0, 0, 0, time.UTC)
+
+// harness owns the database, the read service and the fully wired HTTP router
+// of one test.
+type harness struct {
+	t       *testing.T
+	db      *gorm.DB
+	store   *store.Store
+	service *readapi.Service
+	handler http.Handler
+	seq     int
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+
+	dsn := strings.TrimSpace(os.Getenv(testDatabaseURLEnv))
+	if dsn == "" {
+		t.Skipf("%s is not set: skipping the PostgreSQL backed read API tests", testDatabaseURLEnv)
+	}
+
+	db, err := database.Open(context.Background(), withSearchPath(dsn, testSchema), 30*time.Second, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("opening the test database: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := database.Close(db); closeErr != nil {
+			t.Errorf("closing the test database: %v", closeErr)
+		}
+	})
+
+	migrateOnce.Do(func() {
+		if migrateErr = db.Exec(`CREATE SCHEMA IF NOT EXISTS "` + testSchema + `"`).Error; migrateErr != nil {
+			return
+		}
+		migrateErr = store.Migrate(db)
+	})
+	if migrateErr != nil {
+		t.Fatalf("migrating the test schema: %v", migrateErr)
+	}
+	truncateAll(t, db)
+
+	service := readapi.New(db)
+	checker := health.NewChecker(func(context.Context) error { return nil })
+	checker.MarkBootstrapped()
+
+	return &harness{
+		t:       t,
+		db:      db,
+		store:   store.New(db),
+		service: service,
+		handler: httpapi.New(httpapi.Options{
+			Logger:  zerolog.New(io.Discard),
+			Health:  checker,
+			Version: "test",
+			Read:    service,
+		}),
+	}
+}
+
+// withSearchPath pins the connection to one schema. `search_path` is not a
+// libpq keyword but a server runtime parameter, and both supported DSN forms
+// pass unknown keys straight through to the server.
+func withSearchPath(dsn, schema string) string {
+	if parsed, err := url.Parse(dsn); err == nil && parsed.Scheme != "" {
+		query := parsed.Query()
+		query.Set("search_path", schema)
+		parsed.RawQuery = query.Encode()
+		return parsed.String()
+	}
+	return dsn + " search_path=" + schema
+}
+
+// truncateAll empties every table so each test starts from a known state.
+func truncateAll(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	names := make([]string, 0, len(store.Models()))
+	for _, model := range store.Models() {
+		named, ok := model.(interface{ TableName() string })
+		if !ok {
+			t.Fatalf("model %T does not pin its table name", model)
+		}
+		names = append(names, `"`+named.TableName()+`"`)
+	}
+	if err := db.Exec("TRUNCATE " + strings.Join(names, ", ") + " RESTART IDENTITY CASCADE").Error; err != nil {
+		t.Fatalf("truncating the test schema: %v", err)
+	}
+}
+
+// nextTime keeps every reported timestamp of a test strictly increasing, which
+// makes "newest first" orderings deterministic.
+func (h *harness) nextTime() time.Time {
+	h.seq++
+	return baseTime.Add(time.Duration(h.seq) * time.Second)
+}
+
+// runContext appends events for one (project, run) pair.
+type runContext struct {
+	h         *harness
+	projectID string
+	runID     string
+}
+
+func (h *harness) run(projectID, runID string) *runContext {
+	return &runContext{h: h, projectID: projectID, runID: runID}
+}
+
+// emit appends one event through the real store, so every projection this test
+// later reads was written by the production projector.
+func (r *runContext) emit(agentID string, parent *string, evType, payload string) store.Result {
+	r.h.t.Helper()
+	result, err := r.h.store.Append(context.Background(), store.Envelope{
+		ProjectID:     r.projectID,
+		ClientEventID: uuid.NewString(),
+		RunID:         r.runID,
+		AgentID:       agentID,
+		ParentAgentID: parent,
+		Type:          evType,
+		SchemaVersion: "1.0",
+		OccurredAt:    r.h.nextTime(),
+		Payload:       json.RawMessage(payload),
+	})
+	if err != nil {
+		r.h.t.Fatalf("appending %s to %s/%s: %v", evType, r.projectID, r.runID, err)
+	}
+	return result
+}
+
+// startRoot opens the run with a root orchestrator, which is what makes it the
+// current run of the project.
+func (r *runContext) startRoot(agentID, task string) store.Result {
+	r.h.t.Helper()
+	return r.emit(agentID, nil, store.TypeAgentStarted, fmt.Sprintf(`{
+		"role": "orchestrator",
+		"displayName": %q,
+		"assignedTask": %q
+	}`, agentID, task))
+}
+
+// startSub spawns a subagent below parentID.
+func (r *runContext) startSub(agentID, parentID, task string) store.Result {
+	r.h.t.Helper()
+	parent := parentID
+	return r.emit(agentID, &parent, store.TypeAgentStarted, fmt.Sprintf(`{
+		"role": "subagent",
+		"displayName": %q,
+		"assignedTask": %q
+	}`, agentID, task))
+}
+
+// emitExample replays one of the contract examples from api/examples, rebound to
+// this run. Contract and read API are exercised against the very same documents.
+func (r *runContext) emitExample(name string) store.Result {
+	r.h.t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "api", "examples", name))
+	if err != nil {
+		r.h.t.Fatalf("reading example %s: %v", name, err)
+	}
+	var example struct {
+		AgentID       string          `json:"agentId"`
+		ParentAgentID *string         `json:"parentAgentId"`
+		Type          string          `json:"type"`
+		Payload       json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(raw, &example); err != nil {
+		r.h.t.Fatalf("decoding example %s: %v", name, err)
+	}
+	return r.emit(example.AgentID, example.ParentAgentID, example.Type, string(example.Payload))
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+func (h *harness) request(path string) *httptest.ResponseRecorder {
+	h.t.Helper()
+	recorder := httptest.NewRecorder()
+	h.handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+	return recorder
+}
+
+// getJSON performs one request, insists on 200 and decodes the body into target.
+func (h *harness) getJSON(path string, target any) {
+	h.t.Helper()
+	recorder := h.request(path)
+	if recorder.Code != http.StatusOK {
+		h.t.Fatalf("GET %s: want 200, got %d: %s", path, recorder.Code, recorder.Body.String())
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), target); err != nil {
+		h.t.Fatalf("GET %s: decoding body: %v: %s", path, err, recorder.Body.String())
+	}
+}
+
+// problemBody is the RFC 9457 document the read endpoints serve on failure.
+type problemBody struct {
+	Type   string `json:"type"`
+	Title  string `json:"title"`
+	Status int    `json:"status"`
+	Detail string `json:"detail"`
+	Code   string `json:"code"`
+	Errors []struct {
+		Field   string `json:"field"`
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// getProblem performs one request, insists on the given status and decodes the
+// problem document, including its media type.
+func (h *harness) getProblem(path string, wantStatus int) problemBody {
+	h.t.Helper()
+	recorder := h.request(path)
+	if recorder.Code != wantStatus {
+		h.t.Fatalf("GET %s: want %d, got %d: %s", path, wantStatus, recorder.Code, recorder.Body.String())
+	}
+	if contentType := recorder.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "application/problem+json") {
+		h.t.Fatalf("GET %s: want an RFC 9457 media type, got %q", path, contentType)
+	}
+	var problem problemBody
+	if err := json.Unmarshal(recorder.Body.Bytes(), &problem); err != nil {
+		h.t.Fatalf("GET %s: decoding problem: %v: %s", path, err, recorder.Body.String())
+	}
+	if problem.Status != wantStatus {
+		h.t.Fatalf("GET %s: problem repeats status %d, want %d", path, problem.Status, wantStatus)
+	}
+	if problem.Code == "" {
+		h.t.Fatalf("GET %s: problem carries no machine readable code", path)
+	}
+	return problem
+}
+
+// ---------------------------------------------------------------------------
+// Assertions
+// ---------------------------------------------------------------------------
+
+// lastPosition reads projects.last_position straight from the projection, which
+// is what every response must repeat as projectPosition.
+func (h *harness) lastPosition(projectID string) int64 {
+	h.t.Helper()
+	var project store.Project
+	if err := h.db.Where("project_id = ?", projectID).Take(&project).Error; err != nil {
+		h.t.Fatalf("loading project %q: %v", projectID, err)
+	}
+	return project.LastPosition
+}
+
+func componentIDs(components []readapi.Component) []string {
+	out := make([]string, 0, len(components))
+	for _, component := range components {
+		out = append(out, component.ComponentID)
+	}
+	return out
+}
+
+func contains(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/decisions/0005-read-api-shape-and-run-scoping.md
+++ b/docs/decisions/0005-read-api-shape-and-run-scoping.md
@@ -1,0 +1,71 @@
+# 5. Read API shape, run scoping and cursor pagination
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #8 (part of the v0 epic #1)
+- **Builds on:** [0002 — Event log with synchronous projections](./0002-event-log-with-synchronous-projections.md),
+  [0003 — Frontend state split](./0003-frontend-state-split-and-live-updates.md)
+
+## Context
+
+The UI must be able to build the complete v0 state without ever querying the
+event log, and it must be able to reconcile an HTTP snapshot against a live SSE
+stream that keeps moving underneath it. Histories grow without bound, and a
+single component can accumulate many diffs.
+
+## Decision
+
+**Every response carries `projectPosition`.** It is `projects.last_position` at
+the time of the answer. The UI compares it against the SSE cursor and knows
+exactly whether a snapshot is behind, level with, or ahead of the stream. This
+is what makes the two transports reconcilable instead of merely coexisting.
+
+**Read models only.** Every endpoint reads projections. The one exception is
+component history, which reads the purpose-built `event_components` join table
+rather than scanning `events` payloads — that table exists precisely so the
+history is an index lookup.
+
+**Current run and history are different endpoints, not a flag.** `runs/current`
+resolves via `projects.current_run_id`. The component inspector answers for
+exactly one run and never mixes evidence from another; the separate `/history`
+endpoint is the cross-run view, ordered by descending project position with the
+`runId` on every entry. Conflating them would make it impossible to tell whether
+a diff belongs to what the agent is doing now or to something it did yesterday.
+
+**`activeChanges` means planned, not "everything in flight".** A change that has
+been applied is visible in the applied model itself; leaving it in the active
+list too would double-count it. Planned changes never appear in `components` or
+`relationships` — that separation is what the live overlays in #10 depend on.
+
+**Cursors are opaque and versioned.** Base64url over a `v1|…` sort key. History
+and diffs encode the project position. Runs order by `startedAt`, which is not
+unique, so their cursor encodes the pair `(startedAt, runId)` and is compared
+with a row-value predicate. Two runs starting in the same millisecond therefore
+still page without a gap or a duplicate.
+
+**Diffs paginate; the other collections do not.** Diffs are the one component
+scoped collection that can grow without bound, so the inspector exposes
+`diffLimit`/`diffCursor` and returns `nextDiffCursor`. Feedback, risks, problems
+and active changes are bounded per component and run and come complete. A
+separate diff endpoint was rejected because it would split the normal inspector
+open into two round trips.
+
+**Query count is fixed per request**, not proportional to the result: inspector
+≤ 10, plans 5, architecture 4, runs 2. Component-scoped collections are loaded
+through their join tables as subqueries, one statement per collection.
+
+## Consequences
+
+- Adding a projection means adding an endpoint or a field; the UI never gets to
+  fall back on the event log, which keeps the log free to stay an audit source
+  rather than a query surface.
+- A run literally named `current` is unreachable through the alias. Accepted:
+  run ids are agent-generated and the alias is worth more than that edge.
+- Relationship proposals appear on the architecture endpoint but not in the
+  component inspector, because filtering them per component would require
+  searching the JSONB snapshot — exactly what the join tables exist to avoid.
+- Timestamps are normalised to UTC in the API layer. Without it the rendered
+  time zone depended on the server's, which is invisible until it is wrong.
+- The contract gained `run_already_started` as the documented counterpart of
+  `run_not_started`, so the ingestion layer's 422 vocabulary and the published
+  contract agree.


### PR DESCRIPTION
## Ziel

Stabile, UI-orientierte Read Models bereitstellen, aus denen eine UI den vollständigen v0-Zustand aufbauen kann, **ohne** das Event-Log abzufragen.

## Endpunkte

| Endpunkt | Antwort |
| --- | --- |
| `GET /api/v1/projects` | `{ projectPosition, projects: ProjectSummary[] }` |
| `GET /api/v1/projects/{projectId}` | `{ projectPosition, project: ProjectDetail }` (`currentRunId: string\|null`, plus `counts`) |
| `GET /api/v1/projects/{projectId}/architecture` | `{ projectPosition, components[], relationships[], activeChanges[] }` |
| `GET /api/v1/projects/{projectId}/runs?limit&cursor` | `{ projectPosition, runs: RunSummary[], nextCursor: string\|null }` |
| `GET /api/v1/projects/{projectId}/runs/{runId}` | `{ projectPosition, run: RunDetail }`, `runId=current` löst auf `projects.current_run_id` auf |
| `GET /api/v1/projects/{projectId}/runs/{runId}/agents` | `{ projectPosition, agents: Agent[] }` — flach, jeweils mit `parentAgentId` |
| `GET /api/v1/projects/{projectId}/runs/{runId}/plans` | `{ projectPosition, plans: Plan[] }` — je Plan alle `revisions[]` mit `steps[]` |
| `GET /api/v1/projects/{projectId}/components/{componentId}?runId&diffLimit&diffCursor` | `{ projectPosition, runId, component, responsibleAgent, currentWorkStep, feedback[], diffs[], nextDiffCursor, risks[], problems[], activeChanges[] }` |
| `GET /api/v1/projects/{projectId}/components/{componentId}/history?limit&cursor` | `{ projectPosition, entries: HistoryEntry[], nextCursor: string\|null }` |

Der zugesagte Vertrag ist unverändert eingehalten. Additiv hinzugekommen sind nur `nextDiffCursor` (Diff-Pagination, siehe unten) und `counts` auf `ProjectDetail`/`RunDetail`.

## Kernentscheidungen

**Projektisolation ist strukturell, nicht konventionell.** Jedes Statement filtert auf `project_id`. Ein expliziter Test legt zwei Projekte mit *identischen* Run-, Agent- und Komponenten-IDs an und prüft jeden Endpunkt beider Seiten.

**`projectPosition`** ist `projects.last_position`. Zusätzlich trägt jede Zeile als `position` die Projektposition des Events, das sie zuletzt geschrieben hat — damit kann die UI bei einem Live-Event einen einzelnen Knoten abgleichen statt den ganzen Snapshot neu zu holen. Für die Projektliste (nicht projektbezogen) ist `projectPosition` das Maximum über die gelisteten Projekte; die projektbezogene Zahl steht als `lastPosition` an jedem Eintrag.

**Aktueller Run und Historie sind getrennt.** Der Inspektor liefert Belege **genau eines** Runs (`?runId=…`, sonst der aktuelle). Ein unbekannter `runId` ist ein `404` und *kein* stiller Fallback auf den aktuellen Run. `/history` ist der runübergreifende, paginierte Weg. `runs/current` liefert `404` mit dem eigenen Code `current_run_not_found`, wenn nie ein Root-Orchestrator einen Run eröffnet hat — bewusst unterscheidbar von `run_not_found`.

**`activeChanges` heißt „ausstehend".** Nur `state: planned`. Ein angewandter Change *ist* das Modell, ein zurückgezogener wurde widerrufen — beides ist nicht mehr aktiv.

**Diff-Pagination statt undokumentierter Kappung.** Feedback, Risiken, Probleme und Proposals sind pro Komponente und Run klein und kommen vollständig. Unified Diffs können beliebig wachsen (ein Event pro Datei), deshalb bekommen sie im Inspektor einen echten Cursor: `diffLimit`/`diffCursor` rein, `nextDiffCursor` raus. Ein separater Diff-Endpunkt wurde verworfen — er hätte den Inspektor in zwei Round-Trips zerlegt, obwohl der Normalfall auf eine Seite passt.

**Cursor-Format.** Base64url über einen versionierten internen Sortierschlüssel (`v1|…`), für den Client undurchsichtig. History und Diffs kodieren die Projektposition. Runs ordnen nach gemeldetem Start, was keine Position und nicht eindeutig ist — dort kodiert der Cursor das Paar `(startedAt, runId)` und die Query vergleicht per Row-Value `(started_at, run_id) < (?, ?)`. Dadurch ist Blättern lückenlos und duplikatfrei, auch bei gleichen Startzeitpunkten.

**Zeitstempel werden auf UTC normalisiert**, damit die gerenderte Zone nicht von der Server-Zeitzone abhängt.

**`component: null` statt `404`**, wenn eine Komponente das angewandte Modell verlassen hat, aber noch Historie besitzt. Ein `404` gibt es nur, wenn das Projekt die Komponente nie gemeldet hat.

## Query-Anzahl (kein N+1)

Fix pro Request, unabhängig von der Datenmenge:

| Endpunkt | Statements |
| --- | --- |
| `projects` | 1 |
| `projects/{id}` | 2 (Kopfzeile + eine Zeile Skalar-Subqueries) |
| `architecture` | 4 |
| `runs` | 2 (Seite mit `limit+1`, kein `COUNT`) |
| `runs/{id}` | 3 |
| `…/agents` | 3 |
| `…/plans` | 5 (Pläne, dann Revisionen und Steps *aller* Pläne des Runs, Gruppierung im Speicher) |
| Inspector | ≤ 10 |
| `…/history` | 3 |

Komponentenbezogene Belege laufen über die vorhandenen Join-Tabellen (`feedback_components`, `diff_components`, `risk_components`, `problem_components`, `work_step_components`) als Subquery — ein Statement je Collection. Die Historie nutzt `event_components`; es gibt keinen JSONB-Scan über `events`.

## Konfliktvermeidung

`internal/httpapi/router.go` ändert sich um genau **eine** Aufrufzeile plus ein additives `Options`-Feld; die gesamte Registrierung liegt in der neuen Datei `internal/httpapi/read.go`. Ein `nil`-Service lässt die Routen ungemountet, damit der Probe-only-Router in Tests weiter funktioniert.

## Tests

19 Tests gegen echtes PostgreSQL. Die Fixtures werden **ausschließlich über `store.Append`** eingespielt, nie durch direktes Schreiben in Projektionstabellen — getestet wird also die reale Kette Contract-Payload → Projektor → Query → Handler. Wo möglich werden die Dokumente aus `api/examples/` verwendet. Ohne `TEST_DATABASE_URL` skippen alle Tests.

Die Read-API-Tests laufen in einem eigenen PostgreSQL-Schema (`readapi_test`), weil `go test ./...` Pakete parallel ausführt und sowohl Store- als auch Read-API-Tests vor jedem Test truncaten.

```
$ docker run -d --name vai-test-pg-8 -e POSTGRES_PASSWORD=test -e POSTGRES_USER=test \
    -e POSTGRES_DB=test -p 55435:5432 postgres:17-alpine

$ TEST_DATABASE_URL='postgres://test:test@127.0.0.1:55435/test?sslmode=disable' \
    go test -count=1 -v ./internal/readapi/...
--- PASS: TestEmptyProjectAnswersEveryEndpointWithEmptyCollections (0.47s)
--- PASS: TestProjectListIsEmptyBeforeTheFirstEvent (0.04s)
--- PASS: TestUnknownProjectIsAlways404 (0.06s)
--- PASS: TestActiveRunReturnsTheCompleteNestedAgentTree (0.11s)
--- PASS: TestFinishedRunStaysListedWhileCurrentResolvesToTheOpenRun (0.07s)
--- PASS: TestCurrentRunIsItsOwnErrorCodeWhenNoRunWasOpened (0.06s)
--- PASS: TestInspectorIsRunScopedWhileHistorySpansRuns (0.14s)
--- PASS: TestProjectsWithIdenticalIdentifiersStayIsolated (0.17s)
--- PASS: TestArchitectureReadModelReturnsTheFullContractSnapshot (0.09s)
--- PASS: TestPlannedChangeIsAProposalAndDoesNotTouchTheAppliedModel (0.10s)
--- PASS: TestPlanRevisionsAreAppendOnlyAndComplete (0.09s)
--- PASS: TestComponentInspectorCarriesOnlyItsOwnEvidence (0.18s)
--- PASS: TestRemovedComponentKeepsItsHistory (0.09s)
--- PASS: TestRunPaginationIsGapFreeAndDuplicateFree (0.09s)
--- PASS: TestHistoryPaginationIsGapFreeAndDuplicateFree (0.09s)
--- PASS: TestInspectorPagesItsDiffs (0.11s)
--- PASS: TestInvalidPaginationParametersAreRejected (0.06s)
--- PASS: TestEveryResponseRepeatsTheProjectPosition (0.13s)
--- PASS: TestUIRebuildsTheFullV0StateFromReadEndpointsOnly (0.22s)
ok  	github.com/risqyy/visualise-ai/backend/internal/readapi	5.688s

$ TEST_DATABASE_URL=... go test -count=1 ./...
ok  	github.com/risqyy/visualise-ai/backend/internal/config	0.788s
ok  	github.com/risqyy/visualise-ai/backend/internal/health	0.775s
ok  	github.com/risqyy/visualise-ai/backend/internal/httpapi	3.514s
ok  	github.com/risqyy/visualise-ai/backend/internal/readapi	5.841s
ok  	github.com/risqyy/visualise-ai/backend/internal/store	4.665s

$ gofmt -l .        # leer
$ go vet ./...      # sauber
$ go build ./...    # sauber
```

`TestUIRebuildsTheFullV0StateFromReadEndpointsOnly` ist das Abnahmekriterium: eine realistische Eventsequenz (historischer Run + aktueller Run, Snapshot, Plan, geplante und angewandte Änderungen, Work Step, Diff, Feedback) wird eingespielt und danach ausschließlich über die Read-Endpunkte zu Architektur, Runs, Agentbaum, Plänen und Komponentenbelegen rekonstruiert.

## OpenAPI

```
$ cd api && npm test
✓ redocly lint openapi.yaml — valid (3 problems explicitly ignored)
✓ redocly bundle -o dist/openapi.bundled.yaml
✓ architecture-read-model.json -> ArchitectureResponse
✓ component-inspector.json -> ComponentInspectorResponse
All 14 examples match the contract.
All 5 rejection fixtures were refused by the contract.
```

* `info.version` → `1.1.0`; der Satz „Die Read API ist separat spezifiziert" ist ersetzt.
* Neue Beispiele `api/examples/architecture-read-model.json` (vier Hierarchieebenen, alle Beziehungstypen, drei separate `nats_topic`-Kanten, zwei ausstehende Proposals) und `api/examples/component-inspector.json` — **aus den echten Endpunkten generiert**, damit sie nicht vom Verhalten abdriften können, und in `EXPECTED_SCHEMA` eingetragen.
* Read Models bekommen eigene Schemas (`AppliedComponent`, `AppliedRelationship`, …) statt der gemeldeten Descriptor-Schemas: ein `Component` in einem Event ist eine Behauptung eines Agenten, ein `AppliedComponent` ist der Modellstand.
* Zusätzlich zu `npm test` wurden alle Inline-Beispiele des Dokuments einmalig mit Ajv gegen ihr Response-Schema geprüft (12/12 gültig).
* `.redocly.lint-ignore.yaml` bekommt einen dritten, begründeten Eintrag: `GET /api/v1/projects` hat weder Pfad- noch Query-Parameter noch Body, jede deklarierte 4xx wäre erfunden. `operation-4xx-response` bleibt für alle anderen Read-Operationen aktiv.

## Offene Punkte / Risiken

* **Route-Parametername.** Die parallele Ingestion (#5) registriert `GET /api/v1/projects/{projectId}/stream`. Gin verlangt, dass sich Wildcards an derselben Stelle gleich heißen — dort muss ebenfalls `:projectId` verwendet werden, sonst paniert der Router beim Start. Sollte beim Merge geprüft werden.
* **Alias `current`.** Ein Run, der wirklich `current` heißt, ist über den Alias nicht erreichbar. Bewusst so: die Standardansicht darf nicht davon abhängen, wie ein Agent seinen Run benannt hat.
* **Relationship-Proposals im Inspektor.** `activeChanges` des Inspektors listet nur Proposals mit `targetKind: component` für diese Komponente. Beziehungs-Proposals nach Endpunkt zu filtern hieße, den JSONB-Snapshot zu durchsuchen — genau das, was hier vermieden werden soll. Sie stehen vollständig am Architektur-Endpunkt.
* **Kein ADR** unter `docs/decisions/` angelegt, weil der Auftrag den Änderungsumfang explizit auf `backend/**` und `api/**` begrenzt hat.

Closes #8
