### PR TITLE
[v0] Deterministischen Agent-Event-Simulator bereitstellen

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ right or wrong.
 | `backend/`        | Go module: Gin HTTP surface, zerolog, GORM/PostgreSQL       |
 | `frontend/`       | React + TypeScript application, built by Vite               |
 | `frontend/nginx/` | Nginx site config — the only external entry point           |
+| `simulator/`      | Node/TypeScript event simulator — the deterministic demo client |
 | `docker-compose.yml` | `frontend`, `backend` and `postgres` services           |
 | `docs/decisions/` | Architecture decision records                               |
 
@@ -30,6 +31,18 @@ docker compose up --build
 ```
 
 Then open <http://localhost:8080>.
+
+A fresh database is empty, so the cockpit has nothing to show until an agent
+reports something. The bundled simulator fills it deterministically through the
+public route:
+
+```bash
+cd simulator
+npm install
+npm run simulate                # or: npm run simulate -- --base http://localhost:8091
+```
+
+See [`simulator/README.md`](simulator/README.md) for the scenarios and flags.
 
 The full operations and agent-integration guide is delivered separately; this
 file covers the scaffold only.
@@ -91,6 +104,11 @@ go build ./... && go vet ./... && go test ./...
 cd frontend
 npm ci
 npm run lint && npm run typecheck && npm run test && npm run build
+
+# Simulator
+cd simulator
+npm ci
+npm run lint && npm run typecheck && npm test
 ```
 
 `npm run dev` starts Vite on port 5173 and proxies `/api`, `/healthz` and

--- a/docs/decisions/0007-deterministic-event-simulator.md
+++ b/docs/decisions/0007-deterministic-event-simulator.md
@@ -1,0 +1,113 @@
+# 7. Deterministic event simulator as a contract-validating Node client
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #13 (part of the v0 epic #1)
+- **Builds on:** [0004 — Contract-driven ingestion validation](./0004-contract-driven-ingestion-validation.md),
+  [0005 — Read API shape and run scoping](./0005-read-api-shape-and-run-scoping.md)
+
+## Context
+
+v0 has no repository access and no live agent. Everything the cockpit shows has
+to arrive through `POST /api/v1/events`, so without a producer there is nothing
+to look at, nothing to demo and nothing for the mandatory Playwright acceptance
+run (#14) to assert against.
+
+That producer has to satisfy three things at once: it must be reproducible
+enough that an end-to-end test can assert on exact content, rich enough that
+every v0 UI state is reachable, and honest enough that it cannot demonstrate
+anything the published contract does not allow.
+
+## Decision
+
+**Node and TypeScript, in its own `simulator/` package.** The backend is Go, so
+Go would have been the obvious neighbour. It was rejected because the consumer
+is the Playwright suite of #14, which is Node: a Node simulator can be imported
+and started directly from a test, with no compiled binary and no container in
+between. The package carries its own `package.json`, `tsconfig.json` and ESLint
+config; it depends on nothing inside `backend/` or `frontend/` and touches
+neither.
+
+**Determinism is enforced by the linter, not by discipline.** `Math.random`,
+`Date.now` and `crypto.randomUUID` are banned through `no-restricted-properties`
+with a message naming the seeded replacement. Client event ids are drawn as
+UUIDv4-shaped values from a seeded mulberry32 stream, and `occurredAt` comes
+from a virtual clock anchored to the date the contract's examples use. Ids,
+pacing and the clock are three *separate* streams, so adding a pause cannot
+shift an id and re-timing a phase cannot change an event's identity.
+
+The property this buys is the one the acceptance criteria ask for: a repeated
+run against an empty database produces the same events, therefore the same
+positions, therefore the same read models. It also makes the idempotency
+scenario meaningful — a retry can only be byte-identical if the generator is.
+
+**The simulator validates every event against `api/openapi.yaml` before it sends
+it.** Same approach as `api/scripts/validate-examples.mjs`: parse the contract,
+register the component schemas under their canonical `$ref` and compile with Ajv
+2020 with format assertions on. An event that violates the contract aborts the
+process; it never reaches the network.
+
+This is deliberate and not redundant with the server-side validation. It fixes
+the meaning of a failure: if the simulator runs, whatever it sent was contract
+legal, so a rejection is a statement about the *server*. Without it, a red run
+would first have to be triaged into "the simulator invented a field" versus "the
+backend is wrong". The union is a 20-branch `oneOf`, so — exactly as ADR 0004
+found for the backend — the contract's own `discriminator.mapping` selects the
+single branch first and only then the union gates it, otherwise a single bad
+field reports the failures of 19 branches nobody meant.
+
+The check is symmetric: every acknowledgement is validated against
+`EventAccepted`, and an unexpected status, `duplicate` flag or re-allocated
+position aborts the run with the event, the code and the detail printed.
+
+**No bundling step.** `api/openapi.yaml` has no external `$ref`, so the document
+is loaded directly instead of depending on `api/dist/openapi.bundled.yaml`, which
+is generated and git-ignored. The simulator therefore has no build-order
+dependency on the `api/` package. The contract is located by walking up from the
+module, so it works from `src/`, from a test runner and from a future build
+output alike.
+
+**The run stays open unless `--finish true` is given.** `run.finished` is
+optional by contract and no terminal state is derived from silence, which is a
+product boundary rather than an implementation detail. Leaving the run open is
+the state that demonstrates it: an abandoned run keeps `isOpen: true` and its
+last reported values, and the cockpit invents nothing. It is also the more
+interesting thing to look at. `--finish true` restores the terminal event, and a
+test asserts that `run.finished` is the *only* event type the default run omits.
+
+**The probes report into their own projects.** `full` writes to `visualise-ai`,
+`retry` to `visualise-ai-retry` and `conflict` to `visualise-ai-conflict`. Per
+ADR 0005 `runs/current` resolves to the run a root orchestrator opened last, so a
+probe sent into the demo project afterwards would silently become the current run
+and empty every default component inspector. Each id is fixed, so a repeated run
+always lands in the same project; `--project` overrides all three.
+
+**The scenario is a document, not a recording of the examples.**
+`api/examples/` are standalone illustrations and are not a runnable order: the
+lifecycle guard of ADR 0004 rejects any event whose agent never reported
+`agent.started`. The sequence is therefore built to satisfy those rules, and
+tests assert the preconditions — one root orchestrator, every agent started
+before its first other event, every `parentAgentId` and every correction target
+already sent — on the generated sequence rather than discovering them as a wall
+of `422`s.
+
+## Consequences
+
+- Adding an event type to the contract turns the catalogue test red until the
+  scenario reports it. That is the same intended friction ADR 0004 describes for
+  the backend: the catalogue is closed and the demonstration of it should be
+  complete.
+- The scenario is a fixture in code. It is long and it is meant to be — the tests
+  that guard it (agent depth, hierarchy depth, all six relationship kinds, two
+  NATS topics with a fan-out, four grouped diffs, planned/applied/removed/
+  retracted/pending) encode what #14 has to be able to see.
+- The simulated data is invented and says so. v0 has no repository access, and
+  the contract states that `unifiedDiff` is taken as reported; the diffs are
+  plausible Go, not extracted from anything.
+- `--speed` is a pause *multiplier*, not a rate: `1` is the normal watchable
+  pace, `0` removes every pause for CI, `2` doubles them. A rate would have made
+  `0` mean "divide by zero".
+- The determinism claim is only true on an empty database. A second run against a
+  populated one legitimately answers `200 duplicate` throughout, which is correct
+  behaviour but not what the scenarios assert; `docker compose down -v` is part
+  of the procedure.

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -1,0 +1,71 @@
+# Event simulator
+
+A deterministic developer and test client for the cockpit. It reports a complete,
+representative agent run through the published contract, so the UI has something
+to show and the end-to-end acceptance test has something to assert on.
+
+It talks to **one** URL: `<base>/api/v1/events`, the public Nginx route. It knows
+nothing about internal ports and nothing about the database.
+
+## Usage
+
+```bash
+cd simulator
+npm install
+
+npm run simulate                            # full run against http://localhost:8080
+npm run simulate -- --base http://localhost:8091
+npm run simulate -- --speed 0               # no pauses, for CI and E2E
+npm run simulate -- --scenario retry        # idempotent redelivery
+npm run simulate -- --scenario conflict     # reused client event id
+npm run simulate -- --help
+```
+
+| Flag | Meaning | Default |
+| --- | --- | --- |
+| `--base <url>` | Public entry point, scheme and host only | `http://localhost:8080` |
+| `--project <id>` | Project to report under | the scenario's own project |
+| `--run <id>` | Run id | the scenario's own run id |
+| `--speed <factor>` | Pause multiplier: `1` normal, `0` none, `2` twice as slow | `1` |
+| `--scenario <name>` | `full`, `retry` or `conflict` | `full` |
+| `--seed <n>` | Seed of the id, pause and clock streams | `20260804` |
+| `--finish <bool>` | Whether the full run sends `run.finished` | `false` |
+| `--json` | Machine-readable summary on stdout, narrative on stderr | off |
+
+## Scenarios
+
+| Scenario | Project | Run | What it demonstrates |
+| --- | --- | --- | --- |
+| `full` | `visualise-ai` | `run-2026-08-04-0001` | The representative run: 62 events, every event type except the optional `run.finished` |
+| `retry` | `visualise-ai-retry` | `run-2026-08-04-0002` | `201`, then a byte-identical redelivery answering `200 duplicate: true` with the **same** position |
+| `conflict` | `visualise-ai-conflict` | `run-2026-08-04-0003` | The same `clientEventId` with different content answering `409 client_event_id_conflict` |
+
+Each scenario opens its own run with its own root orchestrator and writes into
+its own project, so none of them turns another one's run into the cockpit's
+current run. All three expect an empty database: against a populated one the
+first delivery is legitimately a duplicate, which is correct but not what the
+probes assert.
+
+The `full` run leaves the run **open** by default. `run.finished` is optional by
+contract and no state is derived from silence, so an unterminated run is the more
+honest — and more interesting — cockpit state. `--finish true` closes it.
+
+## Determinism
+
+Every client event id, every pause and every `occurredAt` is drawn from a seeded
+generator. `Math.random`, `Date.now` and `crypto.randomUUID` are refused by the
+ESLint config. Two runs with the same seed against empty databases produce the
+same events, the same positions and therefore the same read models.
+
+## Development
+
+```bash
+npm run lint
+npm run typecheck
+npm test
+```
+
+The tests cover determinism, conformance of every generated event to
+`IngestEventRequest`, the lifecycle preconditions the backend enforces, coverage
+of the closed event catalogue, and the structural cases the end-to-end acceptance
+test depends on.

--- a/simulator/eslint.config.js
+++ b/simulator/eslint.config.js
@@ -1,0 +1,39 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  { ignores: ['node_modules'] },
+  {
+    files: ['**/*.ts'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2023,
+      globals: globals.node,
+    },
+    rules: {
+      // The simulator must be reproducible. These three are the only sources of
+      // non-determinism a scenario could reach for, so they are banned outright
+      // rather than merely discouraged; every id, timestamp and choice is
+      // derived from `--seed` instead.
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'Math',
+          property: 'random',
+          message: 'Non-deterministic. Use the seeded PRNG from src/prng.ts.',
+        },
+        {
+          object: 'Date',
+          property: 'now',
+          message: 'Non-deterministic. Use the seeded clock from src/clock.ts.',
+        },
+        {
+          object: 'crypto',
+          property: 'randomUUID',
+          message: 'Non-deterministic. Use uuidFrom() in src/prng.ts.',
+        },
+      ],
+    },
+  },
+)

--- a/simulator/package-lock.json
+++ b/simulator/package-lock.json
@@ -1,0 +1,3205 @@
+{
+  "name": "visualise-ai-simulator",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "visualise-ai-simulator",
+      "version": "0.0.0",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "yaml": "^2.8.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.0",
+        "@types/node": "^24.10.0",
+        "eslint": "^9.39.0",
+        "globals": "^16.5.0",
+        "tsx": "^4.20.0",
+        "typescript": "~5.9.0",
+        "typescript-eslint": "^8.46.0",
+        "vitest": "^3.2.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.66.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.66.0",
+        "@typescript-eslint/parser": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/simulator/package.json
+++ b/simulator/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "visualise-ai-simulator",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Deterministic agent event simulator for the Visualise AI cockpit",
+  "scripts": {
+    "simulate": "tsx src/cli.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.0",
+    "@types/node": "^24.10.0",
+    "eslint": "^9.39.0",
+    "globals": "^16.5.0",
+    "tsx": "^4.20.0",
+    "typescript": "~5.9.0",
+    "typescript-eslint": "^8.46.0",
+    "vitest": "^3.2.0"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "yaml": "^2.8.0"
+  }
+}

--- a/simulator/src/cli.ts
+++ b/simulator/src/cli.ts
@@ -1,0 +1,55 @@
+/**
+ * Entry point.
+ *
+ * `npm run simulate -- --help` prints the option list; every other invocation
+ * builds a scenario, validates it against the contract and sends it to
+ * `<base>/api/v1/events`.
+ */
+import { ContractViolationError, loadContract } from './contract.js'
+import { OptionsError, parseOptions, USAGE } from './options.js'
+import { buildScenario } from './scenarios/index.js'
+import { RunAbortedError, runScenario } from './runner.js'
+
+async function main(): Promise<number> {
+  let options
+  try {
+    options = parseOptions(process.argv.slice(2))
+  } catch (error) {
+    if (error instanceof OptionsError) {
+      process.stderr.write(`${error.message}\n\n${USAGE}\n`)
+      return 2
+    }
+    throw error
+  }
+
+  if (options === null) {
+    process.stdout.write(`${USAGE}\n`)
+    return 0
+  }
+
+  const contract = loadContract()
+  const scenario = buildScenario(options)
+
+  const summary = await runScenario(scenario, contract, {
+    baseUrl: options.baseUrl,
+    speed: options.speed,
+    quietStdout: options.json,
+  })
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`)
+  }
+
+  return 0
+}
+
+try {
+  process.exitCode = await main()
+} catch (error) {
+  if (error instanceof ContractViolationError || error instanceof RunAbortedError) {
+    process.stderr.write(`\nsimulator aborted: ${error.message}\n`)
+    process.exitCode = 1
+  } else {
+    throw error
+  }
+}

--- a/simulator/src/clock.ts
+++ b/simulator/src/clock.ts
@@ -1,0 +1,41 @@
+/**
+ * The virtual clock the scenarios report `occurredAt` from.
+ *
+ * `occurredAt` is what the agent observed, not what the server received, so the
+ * simulator is free to pick it — and it must, because the wall clock would make
+ * every run a different document and destroy the idempotency and comparison
+ * properties the acceptance criteria are written against.
+ *
+ * The base instant is the date the whole v0 contract and its examples are dated
+ * to, so a simulated run reads consistently next to `api/examples/`.
+ */
+export const BASE_INSTANT_MS = Date.UTC(2026, 7, 4, 9, 0, 0)
+
+export interface VirtualClock {
+  /** Current instant as an RFC 3339 UTC timestamp. */
+  now(): string
+  /** Advances the clock by `ms` and returns the new instant. */
+  advance(ms: number): string
+}
+
+/**
+ * Creates a clock that starts at {@link BASE_INSTANT_MS}. It only ever moves
+ * forward and only when a scenario says so, which keeps the reported timeline
+ * strictly increasing without tying it to how fast the process happens to run.
+ */
+export function createClock(startMs: number = BASE_INSTANT_MS): VirtualClock {
+  let current = startMs
+
+  const format = (ms: number): string => new Date(ms).toISOString().replace(/\.\d{3}Z$/, 'Z')
+
+  return {
+    now: () => format(current),
+    advance(ms: number): string {
+      if (ms < 0) {
+        throw new Error(`clock: cannot advance by a negative amount (${ms} ms)`)
+      }
+      current += ms
+      return format(current)
+    },
+  }
+}

--- a/simulator/src/contract.ts
+++ b/simulator/src/contract.ts
@@ -1,0 +1,173 @@
+/**
+ * Validation against the published contract.
+ *
+ * The simulator is the reference client of `api/openapi.yaml`, so it must not be
+ * able to demonstrate anything the contract does not allow. Every envelope is
+ * checked here *before* it reaches the network: a violation aborts the run
+ * instead of being answered with a `400` the simulator would then have to
+ * explain.
+ *
+ * The approach mirrors `api/scripts/validate-examples.mjs`: parse the contract,
+ * register every component schema under its canonical `$ref` and compile it with
+ * Ajv 2020 (OpenAPI 3.1 schemas are JSON Schema 2020-12). No bundling step is
+ * needed because `api/openapi.yaml` contains no external `$ref`.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import Ajv2020, { type ValidateFunction } from 'ajv/dist/2020.js'
+import addFormats from 'ajv-formats'
+import { parse as parseYaml } from 'yaml'
+
+import type { EventEnvelope } from './types.js'
+
+/** Relative path of the contract inside the repository. */
+export const CONTRACT_RELATIVE_PATH = 'api/openapi.yaml'
+
+/**
+ * Walks up from this module until it finds the contract. Resolving upwards
+ * rather than hard-coding `../../api` keeps the lookup correct no matter whether
+ * the simulator runs from `src/`, from a build output or from a test runner's
+ * working directory.
+ */
+export function locateContract(startDir: string = dirname(fileURLToPath(import.meta.url))): string {
+  let dir = startDir
+  for (;;) {
+    const candidate = join(dir, CONTRACT_RELATIVE_PATH)
+    try {
+      readFileSync(candidate, 'utf8')
+      return candidate
+    } catch {
+      const parent = dirname(dir)
+      if (parent === dir) {
+        throw new Error(
+          `could not find ${CONTRACT_RELATIVE_PATH} in any parent directory of ${startDir}`,
+        )
+      }
+      dir = parent
+    }
+  }
+}
+
+export class ContractViolationError extends Error {
+  constructor(
+    readonly eventType: string,
+    readonly clientEventId: string,
+    readonly violations: string[],
+  ) {
+    super(
+      `event ${clientEventId} of type ${eventType} violates ${CONTRACT_RELATIVE_PATH}:\n` +
+        violations.map((v) => `    ${v}`).join('\n'),
+    )
+    this.name = 'ContractViolationError'
+  }
+}
+
+export interface Contract {
+  /** `info.version` of the contract the simulator validated against. */
+  readonly documentVersion: string
+  /** The closed v0 event catalogue, in the order the contract lists it. */
+  readonly eventTypes: readonly string[]
+  /** Absolute path of the contract document that was loaded. */
+  readonly path: string
+  /** Throws {@link ContractViolationError} when the envelope is not ingestible. */
+  assertIngestible(event: EventEnvelope): void
+  /** Validates a response body against a named component schema. */
+  validateResponse(schemaName: string, body: unknown): string[]
+}
+
+interface OpenApiDocument {
+  info?: { version?: string }
+  components?: { schemas?: Record<string, Record<string, unknown>> }
+}
+
+/** Loads and compiles `api/openapi.yaml`. */
+export function loadContract(contractPath: string = locateContract()): Contract {
+  const spec = parseYaml(readFileSync(contractPath, 'utf8')) as OpenApiDocument
+  const schemas = spec.components?.schemas
+  if (!schemas) {
+    throw new Error(`no component schemas found in ${contractPath}`)
+  }
+
+  const ajv = new Ajv2020({ strict: false, allErrors: true })
+  // Format assertions are advisory in JSON Schema 2020-12. ADR 0004 records that
+  // leaving them off silently accepted `"clientEventId": "not-a-uuid"` in the
+  // backend; the simulator turns them on for the same reason.
+  addFormats(ajv)
+  for (const [name, schema] of Object.entries(schemas)) {
+    ajv.addSchema(schema, `#/components/schemas/${name}`)
+  }
+
+  const compile = (name: string): ValidateFunction => {
+    const validate = ajv.getSchema(`#/components/schemas/${name}`)
+    if (!validate) {
+      throw new Error(`schema ${name} does not exist in ${contractPath}`)
+    }
+    return validate
+  }
+
+  const ingest = schemas.IngestEventRequest
+  const mapping = (ingest?.discriminator as { mapping?: Record<string, string> } | undefined)
+    ?.mapping
+  if (!mapping) {
+    throw new Error(`IngestEventRequest in ${contractPath} has no discriminator mapping`)
+  }
+
+  const validateUnion = compile('IngestEventRequest')
+  const branchCache = new Map<string, ValidateFunction>()
+
+  const eventTypes = (schemas.EventType?.enum as string[] | undefined) ?? []
+  if (eventTypes.length === 0) {
+    throw new Error(`EventType in ${contractPath} has no enumeration`)
+  }
+
+  const describe = (validate: ValidateFunction): string[] =>
+    (validate.errors ?? []).map((error) => `${error.instancePath || '/'} ${error.message ?? ''}`)
+
+  return {
+    documentVersion: spec.info?.version ?? 'unknown',
+    eventTypes,
+    path: contractPath,
+
+    assertIngestible(event: EventEnvelope): void {
+      // Validating straight against the 20-branch `oneOf` reports the failures
+      // of the 19 branches the event never meant — ADR 0004 measured ~80 errors
+      // for a single bad field. The contract's own discriminator mapping selects
+      // the branch first, so the message names the real problem; the union is
+      // still the authoritative gate afterwards.
+      const ref = mapping[event.type]
+      if (ref) {
+        let branch = branchCache.get(ref)
+        if (!branch) {
+          const compiled = ajv.getSchema(ref)
+          if (!compiled) {
+            throw new Error(`discriminator maps ${event.type} to ${ref}, which does not exist`)
+          }
+          branch = compiled
+          branchCache.set(ref, branch)
+        }
+        // Ajv types its validators as type guards over `unknown`, which would
+        // narrow `event` to `never` in the failure branch. The explicit boolean
+        // keeps the envelope typed while the check stays the same.
+        const branchOk: boolean = branch(event)
+        if (!branchOk) {
+          throw new ContractViolationError(event.type, event.clientEventId, describe(branch))
+        }
+      }
+
+      const unionOk: boolean = validateUnion(event)
+      if (!unionOk) {
+        throw new ContractViolationError(event.type, event.clientEventId, [
+          `type ${event.type} matches no branch of IngestEventRequest`,
+          ...describe(validateUnion),
+        ])
+      }
+    },
+
+    validateResponse(schemaName: string, body: unknown): string[] {
+      const validate = compile(schemaName)
+      return validate(body) ? [] : describe(validate)
+    },
+  }
+}

--- a/simulator/src/options.ts
+++ b/simulator/src/options.ts
@@ -1,0 +1,158 @@
+/** Command line surface of the simulator. */
+import { SCENARIO_NAMES, type ScenarioName } from './types.js'
+
+export interface Options {
+  /** Public entry point. The simulator only ever appends paths to this. */
+  baseUrl: string
+  /** Explicit project id, or `null` to use the scenario's own default. */
+  projectId: string | null
+  /** Explicit run id, or `null` to use the scenario's own default. */
+  runId: string | null
+  /** Pause multiplier: 1 = normal, 0 = no pauses, 2 = twice as long. */
+  speed: number
+  scenario: ScenarioName
+  seed: number
+  /** Whether the `full` scenario closes the run with `run.finished`. */
+  finish: boolean
+  /** Emit a machine-readable summary on stdout and narrate on stderr. */
+  json: boolean
+}
+
+export const DEFAULT_OPTIONS: Options = {
+  baseUrl: 'http://localhost:8080',
+  projectId: null,
+  runId: null,
+  speed: 1,
+  scenario: 'full',
+  // The date the contract, its examples and the simulated timeline are set on.
+  // Any integer works; this one just makes the default run recognisable.
+  seed: 20260804,
+  // A run without a terminal event is the more interesting cockpit state and
+  // the one that proves no status is derived from silence, so it is the default.
+  finish: false,
+  json: false,
+}
+
+export const USAGE = `visualise-ai event simulator
+
+  npm run simulate -- [options]
+
+Options
+  --base <url>        Public Nginx entry point. Default: ${DEFAULT_OPTIONS.baseUrl}
+  --project <id>      Project id. Default: the scenario's own project id.
+  --run <id>          Run id. Default: the scenario's own run id.
+  --speed <factor>    Pause multiplier. 1 = normal pauses, 0 = none (CI/E2E),
+                      2 = twice as slow. Default: ${DEFAULT_OPTIONS.speed}
+  --scenario <name>   ${SCENARIO_NAMES.join(' | ')}. Default: ${DEFAULT_OPTIONS.scenario}
+  --seed <n>          Seed of the deterministic id and pause generator.
+                      Default: ${DEFAULT_OPTIONS.seed}
+  --finish <bool>     Whether the full scenario sends run.finished.
+                      Default: ${DEFAULT_OPTIONS.finish}
+  --json              Print a machine-readable summary on stdout.
+  --help              Show this text.
+
+Every scenario talks to <base>/api/v1/events only. The simulator has no
+knowledge of internal ports or of the database.`
+
+export class OptionsError extends Error {}
+
+const BOOLEAN_FLAGS = new Set(['--json', '--help', '-h'])
+
+function requireValue(flag: string, value: string | undefined): string {
+  if (value === undefined || value.startsWith('--')) {
+    throw new OptionsError(`${flag} requires a value`)
+  }
+  return value
+}
+
+function parseBoolean(flag: string, value: string): boolean {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  throw new OptionsError(`${flag} expects true or false, got ${JSON.stringify(value)}`)
+}
+
+/**
+ * Parses `argv` (without the node and script entries).
+ *
+ * Returns `null` when the caller asked for `--help`, so the CLI can print the
+ * usage and exit `0` rather than treating it as a failure.
+ */
+export function parseOptions(argv: readonly string[]): Options | null {
+  const options: Options = { ...DEFAULT_OPTIONS }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i] as string
+    const next = argv[i + 1]
+    const consume = (): string => {
+      const value = requireValue(flag, next)
+      i += 1
+      return value
+    }
+
+    switch (flag) {
+      case '--help':
+      case '-h':
+        return null
+      case '--json':
+        options.json = true
+        break
+      case '--base':
+        options.baseUrl = consume().replace(/\/+$/, '')
+        break
+      case '--project':
+        options.projectId = consume()
+        break
+      case '--run':
+        options.runId = consume()
+        break
+      case '--speed': {
+        const raw = consume()
+        const speed = Number(raw)
+        if (!Number.isFinite(speed) || speed < 0) {
+          throw new OptionsError(`--speed expects a number >= 0, got ${JSON.stringify(raw)}`)
+        }
+        options.speed = speed
+        break
+      }
+      case '--scenario': {
+        const raw = consume()
+        if (!(SCENARIO_NAMES as readonly string[]).includes(raw)) {
+          throw new OptionsError(
+            `--scenario expects one of ${SCENARIO_NAMES.join(', ')}, got ${JSON.stringify(raw)}`,
+          )
+        }
+        options.scenario = raw as ScenarioName
+        break
+      }
+      case '--seed': {
+        const raw = consume()
+        const seed = Number(raw)
+        if (!Number.isInteger(seed)) {
+          throw new OptionsError(`--seed expects an integer, got ${JSON.stringify(raw)}`)
+        }
+        options.seed = seed
+        break
+      }
+      case '--finish':
+        // `--finish` on its own means `--finish true`; the explicit form is what
+        // the acceptance criteria ask for.
+        if (next === undefined || next.startsWith('--')) {
+          options.finish = true
+        } else {
+          options.finish = parseBoolean(flag, consume())
+        }
+        break
+      default:
+        if (BOOLEAN_FLAGS.has(flag)) break
+        throw new OptionsError(`unknown option ${JSON.stringify(flag)}`)
+    }
+  }
+
+  if (!/^https?:\/\/[^/]+$/.test(options.baseUrl)) {
+    throw new OptionsError(
+      `--base must be a scheme and host only, for example http://localhost:8091, got ${JSON.stringify(options.baseUrl)}`,
+    )
+  }
+
+  return options
+}

--- a/simulator/src/prng.ts
+++ b/simulator/src/prng.ts
@@ -1,0 +1,96 @@
+/**
+ * Seeded pseudo-random number generation.
+ *
+ * Everything the simulator "invents" — client event ids and the length of the
+ * pauses between phases — comes from here. `Math.random`, `Date.now` and
+ * `crypto.randomUUID` are banned by the ESLint config, so a scenario has no
+ * other source of entropy and two runs with the same seed are byte-identical.
+ */
+
+/** A 32-bit integer stream. Small, fast and, above all, reproducible. */
+export interface Prng {
+  /** Next unsigned 32-bit integer. */
+  nextUint32(): number
+  /** Next integer in `[min, max]`, both inclusive. */
+  nextInt(min: number, max: number): number
+}
+
+/**
+ * mulberry32 — a 32-bit state generator. It is not cryptographically strong and
+ * does not need to be: its only job is to be identical on every machine and in
+ * every Node version, which a hand-rolled integer recurrence guarantees and a
+ * platform RNG does not.
+ */
+export function createPrng(seed: number): Prng {
+  let state = seed >>> 0
+
+  const nextUint32 = (): number => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return (t ^ (t >>> 14)) >>> 0
+  }
+
+  return {
+    nextUint32,
+    nextInt(min: number, max: number): number {
+      if (max < min) {
+        throw new Error(`nextInt: max (${max}) must not be below min (${min})`)
+      }
+      return min + (nextUint32() % (max - min + 1))
+    },
+  }
+}
+
+/**
+ * Mixes a string into a seed, so scenarios that share a `--seed` still get
+ * disjoint client event ids. Without it, `full` and `retry` would collide on the
+ * same project and the retry scenario would see a duplicate where it expects a
+ * first delivery.
+ *
+ * FNV-1a, 32 bit.
+ */
+export function mixSeed(seed: number, label: string): number {
+  let hash = (seed >>> 0) ^ 0x811c9dc5
+  for (let i = 0; i < label.length; i += 1) {
+    hash ^= label.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash >>> 0
+}
+
+const HEX = '0123456789abcdef'
+
+/**
+ * Draws a UUIDv4-shaped identifier from the stream.
+ *
+ * The contract types `clientEventId` as `format: uuid`, so the value has to
+ * carry the version and variant nibbles of a real RFC 4122 v4 UUID even though
+ * its randomness is seeded. Only the 6 fixed bits differ from a genuine v4;
+ * everything else comes from the generator.
+ */
+export function uuidFrom(prng: Prng): string {
+  const bytes = new Uint8Array(16)
+  for (let i = 0; i < 16; i += 4) {
+    const word = prng.nextUint32()
+    bytes[i] = (word >>> 24) & 0xff
+    bytes[i + 1] = (word >>> 16) & 0xff
+    bytes[i + 2] = (word >>> 8) & 0xff
+    bytes[i + 3] = word & 0xff
+  }
+  // Version 4 and RFC 4122 variant.
+  bytes[6] = ((bytes[6] as number) & 0x0f) | 0x40
+  bytes[8] = ((bytes[8] as number) & 0x3f) | 0x80
+
+  let out = ''
+  for (let i = 0; i < 16; i += 1) {
+    const byte = bytes[i] as number
+    out += HEX[byte >>> 4]
+    out += HEX[byte & 0x0f]
+    if (i === 3 || i === 5 || i === 7 || i === 9) {
+      out += '-'
+    }
+  }
+  return out
+}

--- a/simulator/src/report.ts
+++ b/simulator/src/report.ts
@@ -1,0 +1,94 @@
+/** Console rendering of a run. */
+import type { EventEnvelope } from './types.js'
+
+export interface Reporter {
+  phase(name: string): void
+  step(line: string): void
+  note(line: string): void
+  blank(): void
+}
+
+/**
+ * Writes the narrative. With `--json` it goes to stderr so stdout carries
+ * nothing but the machine-readable summary and stays pipeable.
+ */
+export function createReporter(toStderr: boolean): Reporter {
+  const write = (line: string): void => {
+    const stream = toStderr ? process.stderr : process.stdout
+    stream.write(line + '\n')
+  }
+  return {
+    phase: (name) => write(`\n── ${name} ${'─'.repeat(Math.max(0, 58 - name.length))}`),
+    step: write,
+    note: write,
+    blank: () => write(''),
+  }
+}
+
+const MAX_COMPONENTS = 3
+
+/**
+ * Summarises which architecture components an event talks about, so the console
+ * shows what moved rather than only that something did.
+ */
+export function affectedComponents(event: EventEnvelope): string[] {
+  const payload = event.payload as Record<string, unknown>
+  const ids = new Set<string>()
+
+  const addAll = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (typeof entry === 'string') ids.add(entry)
+      }
+    }
+  }
+
+  addAll(payload.componentIds)
+
+  const component = payload.component as { componentId?: unknown } | undefined
+  if (component && typeof component.componentId === 'string') ids.add(component.componentId)
+
+  const relationship = payload.relationship as
+    | { sourceComponentId?: unknown; targetComponentId?: unknown }
+    | undefined
+  if (relationship) {
+    if (typeof relationship.sourceComponentId === 'string') ids.add(relationship.sourceComponentId)
+    if (typeof relationship.targetComponentId === 'string') ids.add(relationship.targetComponentId)
+  }
+
+  const components = payload.components
+  if (Array.isArray(components)) {
+    for (const entry of components) {
+      const id = (entry as { componentId?: unknown }).componentId
+      if (typeof id === 'string') ids.add(id)
+    }
+  }
+
+  const steps = payload.steps
+  if (Array.isArray(steps)) {
+    for (const entry of steps) {
+      addAll((entry as { componentIds?: unknown }).componentIds)
+    }
+  }
+
+  const corrected = payload.correctedPayload as { componentIds?: unknown } | undefined
+  if (corrected) addAll(corrected.componentIds)
+
+  return [...ids]
+}
+
+/** Renders the component list of an event, abbreviated when it is long. */
+export function formatComponents(event: EventEnvelope): string {
+  const ids = affectedComponents(event)
+  if (ids.length === 0) return '—'
+  if (ids.length <= MAX_COMPONENTS) return ids.join(', ')
+  return `${ids.slice(0, MAX_COMPONENTS).join(', ')} +${ids.length - MAX_COMPONENTS} more`
+}
+
+export function pad(value: string, width: number): string {
+  return value.length >= width ? value : value + ' '.repeat(width - value.length)
+}
+
+export function padStart(value: string, width: number): string {
+  return value.length >= width ? value : ' '.repeat(width - value.length) + value
+}

--- a/simulator/src/runner.ts
+++ b/simulator/src/runner.ts
@@ -1,0 +1,269 @@
+/**
+ * Sends a scenario to a running cockpit and checks every answer.
+ *
+ * Two rules the runner never relaxes:
+ *
+ * 1. **Nothing is sent that the contract would refuse.** Every envelope is
+ *    validated against `api/openapi.yaml` first; a violation aborts before the
+ *    request is made, so a failing simulator run always means the *server*
+ *    disagreed, never that the simulator invented a field.
+ * 2. **Every response is checked.** An unexpected status, a duplicate flag that
+ *    does not match or a re-allocated position stops the run with the event, the
+ *    status, the problem `code` and the `detail` printed.
+ */
+import { setTimeout as delay } from 'node:timers/promises'
+
+import type { Contract } from './contract.js'
+import { createReporter, formatComponents, pad, padStart, type Reporter } from './report.js'
+import type { EventAccepted, ProblemDocument, Scenario, ScenarioStep } from './types.js'
+
+export const EVENTS_PATH = '/api/v1/events'
+
+export class RunAbortedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RunAbortedError'
+  }
+}
+
+export interface RunnerOptions {
+  baseUrl: string
+  /** Pause multiplier. 0 disables every pause. */
+  speed: number
+  /** Narrate on stderr instead of stdout, so stdout can carry JSON only. */
+  quietStdout: boolean
+  /** Injectable for tests. Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch
+  /** Injectable for tests. Defaults to a real sleep. */
+  sleep?: (ms: number) => Promise<void>
+  /** Suppresses the narrative entirely. Used by the tests. */
+  silent?: boolean
+}
+
+export interface RunSummary {
+  scenario: string
+  projectId: string
+  runId: string
+  baseUrl: string
+  eventsSent: number
+  created: number
+  duplicates: number
+  conflicts: number
+  /** Highest position the server assigned during this run, or 0 when none. */
+  endPosition: number
+  /** Position, type and agent of every accepted event, in order. */
+  events: { position: number | null; type: string; agentId: string; status: number }[]
+  projectUrl: string
+}
+
+interface Answer {
+  status: number
+  body: unknown
+}
+
+async function post(
+  fetchImpl: typeof fetch,
+  url: string,
+  event: unknown,
+): Promise<Answer> {
+  let response: Response
+  try {
+    response = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(event),
+    })
+  } catch (cause) {
+    throw new RunAbortedError(
+      `POST ${url} failed: ${cause instanceof Error ? cause.message : String(cause)}\n` +
+        '  Is the compose stack up and is --base pointing at the published Nginx port?',
+    )
+  }
+
+  const text = await response.text()
+  let body: unknown = text
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      // Leave the raw text in place; the mismatch report prints it verbatim.
+    }
+  }
+  return { status: response.status, body }
+}
+
+function describeProblem(status: number, body: unknown): string {
+  if (body && typeof body === 'object') {
+    const problem = body as ProblemDocument
+    const parts = [`status ${status}`]
+    if (problem.code) parts.push(`code ${problem.code}`)
+    if (problem.detail) parts.push(`detail ${problem.detail}`)
+    const errors = problem.errors ?? []
+    for (const error of errors) {
+      parts.push(`${error.field ?? '/'} ${error.code ?? ''} ${error.message ?? ''}`.trim())
+    }
+    return parts.join('\n      ')
+  }
+  return `status ${status}, body ${JSON.stringify(body)}`
+}
+
+/** Sends `scenario` and returns its summary. Throws on the first mismatch. */
+export async function runScenario(
+  scenario: Scenario,
+  contract: Contract,
+  options: RunnerOptions,
+): Promise<RunSummary> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const sleep = options.sleep ?? ((ms: number) => delay(ms))
+  const reporter: Reporter = options.silent
+    ? { phase: () => {}, step: () => {}, note: () => {}, blank: () => {} }
+    : createReporter(options.quietStdout)
+  const url = `${options.baseUrl}${EVENTS_PATH}`
+
+  reporter.step(
+    `simulator: scenario ${scenario.name}, project ${scenario.projectId}, run ${scenario.runId}`,
+  )
+  reporter.step(`           target ${url}`)
+  reporter.step(
+    `           contract ${contract.path} (v${contract.documentVersion}), ${scenario.steps.length} events`,
+  )
+
+  const summary: RunSummary = {
+    scenario: scenario.name,
+    projectId: scenario.projectId,
+    runId: scenario.runId,
+    baseUrl: options.baseUrl,
+    eventsSent: 0,
+    created: 0,
+    duplicates: 0,
+    conflicts: 0,
+    endPosition: 0,
+    events: [],
+    projectUrl: `${options.baseUrl}/projects/${scenario.projectId}`,
+  }
+
+  /** Position assigned to each client event id, for the retry assertion. */
+  const positions = new Map<string, number>()
+  let phase = ''
+
+  for (const step of scenario.steps) {
+    if (step.phase !== phase) {
+      phase = step.phase
+      reporter.phase(phase)
+    }
+
+    // Contract first: an event that violates the published schema never leaves
+    // the process.
+    contract.assertIngestible(step.event)
+
+    const pause = Math.round(step.pauseMs * options.speed)
+    if (pause > 0) await sleep(pause)
+
+    const answer = await post(fetchImpl, url, step.event)
+    summary.eventsSent += 1
+
+    assertStatus(step, answer)
+
+    let position: number | null = null
+    if (answer.status === 200 || answer.status === 201) {
+      const violations = contract.validateResponse('EventAccepted', answer.body)
+      if (violations.length > 0) {
+        throw new RunAbortedError(
+          `the ${answer.status} answer to ${step.event.type} does not match EventAccepted:\n` +
+            violations.map((v) => `      ${v}`).join('\n'),
+        )
+      }
+      const accepted = answer.body as EventAccepted
+      position = accepted.position
+      assertIdempotency(step, accepted, positions)
+      positions.set(accepted.clientEventId, accepted.position)
+      summary.endPosition = Math.max(summary.endPosition, accepted.position)
+      if (accepted.duplicate) summary.duplicates += 1
+      else summary.created += 1
+    } else {
+      summary.conflicts += 1
+    }
+
+    summary.events.push({
+      position,
+      type: step.event.type,
+      agentId: step.event.agentId,
+      status: answer.status,
+    })
+
+    reporter.step(
+      `  ${padStart(position === null ? '—' : String(position), 4)}  ${answer.status}  ` +
+        `${pad(step.event.type, 32)}${pad(step.event.agentId, 30)}${formatComponents(step.event)}`,
+    )
+  }
+
+  reporter.blank()
+  reporter.note('Summary')
+  for (const [label, value] of [
+    ['scenario', summary.scenario],
+    ['project', summary.projectId],
+    ['run', summary.runId],
+    ['events sent', String(summary.eventsSent)],
+    ['created (201)', String(summary.created)],
+    ['duplicate (200)', String(summary.duplicates)],
+    ['conflict (409)', String(summary.conflicts)],
+    ['end position', String(summary.endPosition)],
+    ['open', summary.projectUrl],
+  ]) {
+    reporter.note(`  ${pad(label as string, 16)}${value}`)
+  }
+
+  return summary
+}
+
+function assertStatus(step: ScenarioStep, answer: Answer): void {
+  if (answer.status === step.expect.status) {
+    if (step.expect.code) {
+      const code = (answer.body as ProblemDocument | undefined)?.code
+      if (code !== step.expect.code) {
+        throw new RunAbortedError(
+          `${step.event.type} (${step.event.clientEventId}) was refused with the expected ` +
+            `status ${answer.status} but code ${JSON.stringify(code)} instead of ` +
+            `${JSON.stringify(step.expect.code)}\n      ${describeProblem(answer.status, answer.body)}`,
+        )
+      }
+    }
+    return
+  }
+
+  throw new RunAbortedError(
+    `${step.event.type} (${step.event.clientEventId}) by ${step.event.agentId}\n` +
+      `      expected HTTP ${step.expect.status}, got:\n      ${describeProblem(answer.status, answer.body)}`,
+  )
+}
+
+function assertIdempotency(
+  step: ScenarioStep,
+  accepted: EventAccepted,
+  positions: Map<string, number>,
+): void {
+  const { expect } = step
+
+  if (expect.duplicate !== undefined && accepted.duplicate !== expect.duplicate) {
+    throw new RunAbortedError(
+      `${step.event.type} (${step.event.clientEventId}) answered duplicate: ${accepted.duplicate}, ` +
+        `expected ${expect.duplicate}`,
+    )
+  }
+
+  if (expect.samePositionAs) {
+    const original = positions.get(expect.samePositionAs)
+    if (original === undefined) {
+      throw new RunAbortedError(
+        `internal: no position recorded for ${expect.samePositionAs}, cannot check the retry`,
+      )
+    }
+    if (accepted.position !== original) {
+      throw new RunAbortedError(
+        `the byte-identical retry of ${expect.samePositionAs} was assigned position ` +
+          `${accepted.position}, but the first delivery got ${original}. An idempotent retry ` +
+          'must repeat the original position and must not append.',
+      )
+    }
+  }
+}

--- a/simulator/src/scenarios/architecture.ts
+++ b/simulator/src/scenarios/architecture.ts
@@ -1,0 +1,391 @@
+/**
+ * The architecture model the `full` scenario publishes.
+ *
+ * It is written to exercise every structural feature the cockpit has to render:
+ *
+ * * four hierarchy levels — `shop-platform` -> `orders` -> `domain` -> `pricing`
+ *   — so nesting is more than a single fold,
+ * * all six relationship kinds,
+ * * two separate NATS topics, each with its own relationship per participant,
+ *   and one of them (`orders.order.created`) fanned out to **two** consumers as
+ *   two distinct relationships sharing a `channel`, which is what proves the
+ *   backend never aggregates topic edges,
+ * * one component and one relationship that exist only so a later `remove` has
+ *   something real to take away.
+ */
+
+export interface Technology {
+  language?: string
+  framework?: string
+  runtime?: string
+  version?: string
+}
+
+export interface Component {
+  componentId: string
+  name: string
+  kind:
+    | 'system'
+    | 'service'
+    | 'module'
+    | 'datastore'
+    | 'queue'
+    | 'topic'
+    | 'ui'
+    | 'external'
+    | 'library'
+  parentComponentId: string | null
+  description?: string
+  technology?: Technology
+  tags?: string[]
+}
+
+export interface Relationship {
+  relationshipId: string
+  sourceComponentId: string
+  targetComponentId: string
+  kind: 'http' | 'grpc' | 'data' | 'async' | 'nats_topic' | 'dependency'
+  label?: string
+  protocol?: string
+  operation?: string
+  channel?: string
+}
+
+export const TOPIC_ORDER_CREATED = 'orders.order.created'
+export const TOPIC_INVENTORY_RESERVED = 'inventory.item.reserved'
+
+export const COMPONENT_IDS = {
+  system: 'shop-platform',
+  storefront: 'shop-platform.storefront',
+  gateway: 'shop-platform.api-gateway',
+  orders: 'shop-platform.orders',
+  ordersApi: 'shop-platform.orders.api',
+  ordersDomain: 'shop-platform.orders.domain',
+  pricing: 'shop-platform.orders.domain.pricing',
+  legacyTaxRates: 'shop-platform.orders.domain.legacy-tax-rates',
+  tax: 'shop-platform.orders.domain.tax',
+  rounding: 'shop-platform.orders.domain.rounding',
+  ordersPersistence: 'shop-platform.orders.persistence',
+  inventory: 'shop-platform.inventory',
+  notifications: 'shop-platform.notifications',
+  ordersDb: 'shop-platform.orders-db',
+  events: 'shop-platform.events',
+  topicOrderCreated: 'shop-platform.events.order-created',
+  topicInventoryReserved: 'shop-platform.events.inventory-reserved',
+  sharedMoney: 'shop-platform.shared-money',
+  paymentProvider: 'payment-provider',
+} as const
+
+const C = COMPONENT_IDS
+
+/** The components of the initial snapshot, ordered parent before child. */
+export const SNAPSHOT_COMPONENTS: Component[] = [
+  {
+    componentId: C.system,
+    name: 'Shop Platform',
+    kind: 'system',
+    parentComponentId: null,
+    description: 'The observed application. Root of the component hierarchy.',
+  },
+  {
+    componentId: C.storefront,
+    name: 'Storefront',
+    kind: 'ui',
+    parentComponentId: C.system,
+    description: 'Customer-facing single page application.',
+    technology: { language: 'TypeScript', framework: 'React', runtime: 'Browser', version: '19' },
+    tags: ['frontend', 'public'],
+  },
+  {
+    componentId: C.gateway,
+    name: 'API Gateway',
+    kind: 'service',
+    parentComponentId: C.system,
+    description: 'Single external entry point, terminates TLS and fans out to the services.',
+    technology: { language: 'Go', framework: 'chi', runtime: 'Go', version: '1.24' },
+  },
+  {
+    componentId: C.orders,
+    name: 'Orders Service',
+    kind: 'service',
+    parentComponentId: C.system,
+    description: 'Owns the order lifecycle.',
+    technology: { language: 'Go', runtime: 'Go', version: '1.24' },
+    tags: ['core-domain'],
+  },
+  {
+    componentId: C.ordersApi,
+    name: 'Orders API Layer',
+    kind: 'module',
+    parentComponentId: C.orders,
+    description: 'gRPC handlers and request mapping.',
+  },
+  {
+    componentId: C.ordersDomain,
+    name: 'Orders Domain Layer',
+    kind: 'module',
+    parentComponentId: C.orders,
+    description: 'Order aggregate, invariants and state machine.',
+  },
+  {
+    componentId: C.pricing,
+    name: 'Pricing',
+    kind: 'module',
+    parentComponentId: C.ordersDomain,
+    description: 'Fourth hierarchy level: discount and tax calculation inside the domain layer.',
+    tags: ['pricing'],
+  },
+  {
+    componentId: C.legacyTaxRates,
+    name: 'Legacy Tax Rates',
+    kind: 'module',
+    parentComponentId: C.ordersDomain,
+    description: 'Hard-coded VAT table kept alive for the German rate only.',
+    tags: ['pricing', 'legacy'],
+  },
+  {
+    componentId: C.ordersPersistence,
+    name: 'Orders Persistence Layer',
+    kind: 'module',
+    parentComponentId: C.orders,
+    description: 'Repository implementations and SQL migrations.',
+  },
+  {
+    componentId: C.inventory,
+    name: 'Inventory Service',
+    kind: 'service',
+    parentComponentId: C.system,
+    description: 'Reserves and releases stock.',
+    technology: { language: 'Go', runtime: 'Go', version: '1.24' },
+  },
+  {
+    componentId: C.notifications,
+    name: 'Notification Service',
+    kind: 'service',
+    parentComponentId: C.system,
+    description: 'Sends order and shipment mails. Second consumer of the order topic.',
+    technology: { language: 'Go', runtime: 'Go', version: '1.24' },
+  },
+  {
+    componentId: C.ordersDb,
+    name: 'Orders Database',
+    kind: 'datastore',
+    parentComponentId: C.system,
+    description: 'Relational store owned exclusively by the orders service.',
+    technology: { runtime: 'PostgreSQL', version: '17' },
+  },
+  {
+    componentId: C.events,
+    name: 'Event Bus',
+    kind: 'queue',
+    parentComponentId: C.system,
+    description: 'NATS cluster. Each topic below is modelled as its own component.',
+    technology: { runtime: 'NATS', version: '2.10' },
+  },
+  {
+    componentId: C.topicOrderCreated,
+    name: TOPIC_ORDER_CREATED,
+    kind: 'topic',
+    parentComponentId: C.events,
+    description: 'Published once per accepted order, consumed by inventory and notifications.',
+  },
+  {
+    componentId: C.topicInventoryReserved,
+    name: TOPIC_INVENTORY_RESERVED,
+    kind: 'topic',
+    parentComponentId: C.events,
+    description: 'Published once per successful stock reservation.',
+  },
+  {
+    componentId: C.sharedMoney,
+    name: 'Shared Money Library',
+    kind: 'library',
+    parentComponentId: C.system,
+    description: 'Currency and amount value objects shared across services.',
+    technology: { language: 'Go' },
+  },
+  {
+    componentId: C.paymentProvider,
+    name: 'Payment Provider',
+    kind: 'external',
+    parentComponentId: null,
+    description: 'Third-party payment system outside the system boundary.',
+  },
+]
+
+export const RELATIONSHIP_IDS = {
+  storefrontGateway: 'rel-storefront-gateway-http',
+  gatewayOrders: 'rel-gateway-orders-grpc',
+  ordersDb: 'rel-orders-persistence-data',
+  ordersPayment: 'rel-orders-payment-async',
+  ordersPublishesOrderCreated: 'rel-orders-publishes-order-created',
+  inventoryConsumesOrderCreated: 'rel-inventory-consumes-order-created',
+  notificationsConsumesOrderCreated: 'rel-notifications-consumes-order-created',
+  inventoryPublishesReserved: 'rel-inventory-publishes-inventory-reserved',
+  notificationsConsumesReserved: 'rel-notifications-consumes-inventory-reserved',
+  pricingSharedMoney: 'rel-pricing-shared-money-dependency',
+  pricingLegacyTaxRates: 'rel-pricing-legacy-tax-rates-dependency',
+  pricingTax: 'rel-pricing-tax-dependency',
+  notificationsOrdersHttp: 'rel-notifications-orders-http',
+  taxRounding: 'rel-tax-rounding-dependency',
+} as const
+
+const R = RELATIONSHIP_IDS
+
+/** The relationships of the initial snapshot. */
+export const SNAPSHOT_RELATIONSHIPS: Relationship[] = [
+  {
+    relationshipId: R.storefrontGateway,
+    sourceComponentId: C.storefront,
+    targetComponentId: C.gateway,
+    kind: 'http',
+    label: 'Browse and place orders',
+    protocol: 'HTTPS',
+    operation: 'GET /orders',
+  },
+  {
+    relationshipId: R.gatewayOrders,
+    sourceComponentId: C.gateway,
+    targetComponentId: C.ordersApi,
+    kind: 'grpc',
+    label: 'Place order',
+    protocol: 'gRPC/HTTP2',
+    operation: 'orders.v1.OrderService/PlaceOrder',
+  },
+  {
+    relationshipId: R.ordersDb,
+    sourceComponentId: C.ordersPersistence,
+    targetComponentId: C.ordersDb,
+    kind: 'data',
+    label: 'Order aggregate storage',
+    protocol: 'postgresql',
+    operation: 'SELECT/INSERT/UPDATE orders',
+  },
+  {
+    relationshipId: R.ordersPayment,
+    sourceComponentId: C.orders,
+    targetComponentId: C.paymentProvider,
+    kind: 'async',
+    label: 'Payment settlement callbacks',
+    protocol: 'webhook',
+    operation: 'POST /callbacks/payment',
+  },
+  {
+    relationshipId: R.ordersPublishesOrderCreated,
+    sourceComponentId: C.orders,
+    targetComponentId: C.topicOrderCreated,
+    kind: 'nats_topic',
+    label: 'publishes',
+    protocol: 'NATS',
+    channel: TOPIC_ORDER_CREATED,
+  },
+  {
+    relationshipId: R.inventoryConsumesOrderCreated,
+    sourceComponentId: C.topicOrderCreated,
+    targetComponentId: C.inventory,
+    kind: 'nats_topic',
+    label: 'consumes',
+    protocol: 'NATS',
+    channel: TOPIC_ORDER_CREATED,
+  },
+  {
+    // Second consumer of the same topic. Two relationships, one channel — the
+    // cockpit must show both edges rather than one merged "messaging" edge.
+    relationshipId: R.notificationsConsumesOrderCreated,
+    sourceComponentId: C.topicOrderCreated,
+    targetComponentId: C.notifications,
+    kind: 'nats_topic',
+    label: 'consumes',
+    protocol: 'NATS',
+    channel: TOPIC_ORDER_CREATED,
+  },
+  {
+    relationshipId: R.inventoryPublishesReserved,
+    sourceComponentId: C.inventory,
+    targetComponentId: C.topicInventoryReserved,
+    kind: 'nats_topic',
+    label: 'publishes',
+    protocol: 'NATS',
+    channel: TOPIC_INVENTORY_RESERVED,
+  },
+  {
+    relationshipId: R.notificationsConsumesReserved,
+    sourceComponentId: C.topicInventoryReserved,
+    targetComponentId: C.notifications,
+    kind: 'nats_topic',
+    label: 'consumes',
+    protocol: 'NATS',
+    channel: TOPIC_INVENTORY_RESERVED,
+  },
+  {
+    relationshipId: R.pricingSharedMoney,
+    sourceComponentId: C.pricing,
+    targetComponentId: C.sharedMoney,
+    kind: 'dependency',
+    label: 'Money value objects',
+  },
+  {
+    relationshipId: R.pricingLegacyTaxRates,
+    sourceComponentId: C.pricing,
+    targetComponentId: C.legacyTaxRates,
+    kind: 'dependency',
+    label: 'Hard-coded VAT table',
+  },
+]
+
+/** The component the scenario adds through a planned and then applied change. */
+export const TAX_COMPONENT: Component = {
+  componentId: C.tax,
+  name: 'Tax Calculation',
+  kind: 'module',
+  parentComponentId: C.ordersDomain,
+  description: 'VAT rules per delivery country, extracted from the pricing module.',
+  technology: { language: 'Go', runtime: 'Go', version: '1.24' },
+  tags: ['pricing', 'tax'],
+}
+
+/** The relationship the scenario adds alongside {@link TAX_COMPONENT}. */
+export const PRICING_TAX_RELATIONSHIP: Relationship = {
+  relationshipId: R.pricingTax,
+  sourceComponentId: C.pricing,
+  targetComponentId: C.tax,
+  kind: 'dependency',
+  label: 'Delegates VAT calculation',
+}
+
+/**
+ * The component the scenario proposes and deliberately leaves pending, so the
+ * run ends with a change in state `planned` for the cockpit to render.
+ */
+export const ROUNDING_COMPONENT: Component = {
+  componentId: C.rounding,
+  name: 'Rounding',
+  kind: 'module',
+  parentComponentId: C.ordersDomain,
+  description: 'Proposed: one place for the half-up rounding rule the tax module applies today.',
+  technology: { language: 'Go' },
+  tags: ['pricing', 'proposed'],
+}
+
+/** The relationship that would accompany {@link ROUNDING_COMPONENT}. Also pending. */
+export const TAX_ROUNDING_RELATIONSHIP: Relationship = {
+  relationshipId: R.taxRounding,
+  sourceComponentId: C.tax,
+  targetComponentId: C.rounding,
+  kind: 'dependency',
+  label: 'Delegates the rounding rule',
+}
+
+/**
+ * The relationship the scenario plans and then withdraws again, so the cockpit
+ * has a retracted proposal to render.
+ */
+export const NOTIFICATIONS_ORDERS_RELATIONSHIP: Relationship = {
+  relationshipId: R.notificationsOrdersHttp,
+  sourceComponentId: C.notifications,
+  targetComponentId: C.ordersApi,
+  kind: 'http',
+  label: 'Read order details for the mail body',
+  protocol: 'HTTPS',
+  operation: 'GET /orders/{id}',
+}

--- a/simulator/src/scenarios/conflict.ts
+++ b/simulator/src/scenarios/conflict.ts
@@ -1,0 +1,57 @@
+/**
+ * The `conflict` scenario: the same `clientEventId` with different content.
+ *
+ * Idempotency is content based (ADR 0002), so reusing the key for a different
+ * document is not a retry but a bug in the reporting agent. The contract answers
+ * `409` with code `client_event_id_conflict`; the runner aborts if it sees
+ * anything else, including a silently accepted second event.
+ *
+ * Like `retry`, this scenario expects an empty project.
+ */
+import { SequenceBuilder, type Agent } from '../sequence.js'
+import type { Scenario } from '../types.js'
+
+export const CONFLICT_RUN_ID = 'run-2026-08-04-0003'
+
+const ORCHESTRATOR: Agent = { agentId: 'orchestrator-conflict', parentAgentId: null }
+
+export interface ConflictScenarioOptions {
+  projectId: string
+  runId: string
+  seed: number
+}
+
+export function buildConflictScenario(options: ConflictScenarioOptions): Scenario {
+  const b = new SequenceBuilder({
+    projectId: options.projectId,
+    runId: options.runId,
+    seed: options.seed,
+    scenarioLabel: 'conflict',
+  })
+
+  b.beginPhase('Run start')
+  b.emit(ORCHESTRATOR, 'agent.started', {
+    role: 'orchestrator',
+    displayName: 'Conflict Probe',
+    assignedTask: 'Demonstrate that a reused client event id with different content is refused.',
+  })
+
+  b.beginPhase('First delivery')
+  const target = b.emit(ORCHESTRATOR, 'agent.status_reported', {
+    status: 'working',
+    note: 'Original content.',
+  })
+
+  b.beginPhase('Same id, different payload')
+  b.emitConflictWith(target, ORCHESTRATOR, 'agent.status_reported', {
+    status: 'blocked',
+    note: 'Different content under the same client event id.',
+  })
+
+  return {
+    name: 'conflict',
+    projectId: options.projectId,
+    runId: options.runId,
+    steps: b.build(),
+  }
+}

--- a/simulator/src/scenarios/diffs.ts
+++ b/simulator/src/scenarios/diffs.ts
@@ -1,0 +1,206 @@
+/**
+ * The unified diffs the `full` scenario reports.
+ *
+ * One `diff.reported` event carries exactly one repository file, so a change
+ * that touches four files produces four events sharing a `changeId`. Three of
+ * the five below share `change-2026-08-04-0007`, which is what the component
+ * inspector groups on.
+ *
+ * The diffs are plausible but invented: v0 has no repository access, and the
+ * contract states explicitly that `unifiedDiff` is taken as reported.
+ */
+
+export interface DiffFile {
+  diffId: string
+  /** Omitted for a change the agent made without planning it first. */
+  changeId?: string
+  componentIds: string[]
+  filePath: string
+  unifiedDiff: string
+}
+
+export const CHANGE_IDS = {
+  addTax: 'change-2026-08-04-0007',
+  linkPricingToTax: 'change-2026-08-04-0008',
+  dropLegacyTaxRates: 'change-2026-08-04-0009',
+  dropLegacyTaxDependency: 'change-2026-08-04-0010',
+  notificationsReadsOrders: 'change-2026-08-04-0011',
+  addRounding: 'change-2026-08-04-0012',
+  linkTaxToRounding: 'change-2026-08-04-0013',
+} as const
+
+export const PRICING_DIFF: DiffFile = {
+  diffId: 'diff-2026-08-04-0011',
+  changeId: CHANGE_IDS.addTax,
+  componentIds: ['shop-platform.orders.domain.pricing'],
+  filePath: 'internal/orders/domain/pricing/pricing.go',
+  unifiedDiff: [
+    '--- a/internal/orders/domain/pricing/pricing.go',
+    '+++ b/internal/orders/domain/pricing/pricing.go',
+    '@@ -1,8 +1,9 @@',
+    ' package pricing',
+    ' ',
+    ' import (',
+    '-\t"shop-platform/internal/orders/domain/legacy"',
+    '+\t"shop-platform/internal/orders/domain/tax"',
+    ' \t"shop-platform/internal/shared/money"',
+    ' )',
+    ' ',
+    ' // Pricing turns an order into the amount the customer owes.',
+    '@@ -18,11 +19,10 @@ func (p *Pricing) Total(order Order) money.Amount {',
+    ' \tsum := money.Zero(order.Currency)',
+    ' \tfor _, line := range order.Lines {',
+    ' \t\tsum = sum.Add(line.Net)',
+    ' \t}',
+    '-',
+    '-\tvat := sum.MultiplyFloat(legacy.RateDE)',
+    '-\tsum = sum.Add(vat)',
+    '-',
+    '-\treturn sum.Sub(p.discountFor(order))',
+    '+\tdiscounted := sum.Sub(p.discountFor(order))',
+    '+\tvat := tax.For(order.DeliveryCountry).Apply(discounted)',
+    '+',
+    '+\treturn discounted.Add(vat)',
+    ' }',
+    '',
+  ].join('\n'),
+}
+
+export const TAX_DIFF: DiffFile = {
+  diffId: 'diff-2026-08-04-0012',
+  changeId: CHANGE_IDS.addTax,
+  componentIds: ['shop-platform.orders.domain.tax'],
+  filePath: 'internal/orders/domain/tax/tax.go',
+  unifiedDiff: [
+    '--- /dev/null',
+    '+++ b/internal/orders/domain/tax/tax.go',
+    '@@ -0,0 +1,32 @@',
+    '+// Package tax owns the VAT rules that used to sit inside pricing.',
+    '+package tax',
+    '+',
+    '+import "shop-platform/internal/shared/money"',
+    '+',
+    '+// Rate is the VAT rate of exactly one delivery country.',
+    '+type Rate struct {',
+    '+\tCountry string',
+    '+\tPercent float64',
+    '+}',
+    '+',
+    '+var rates = map[string]Rate{',
+    '+\t"DE": {Country: "DE", Percent: 19},',
+    '+\t"AT": {Country: "AT", Percent: 20},',
+    '+\t"CH": {Country: "CH", Percent: 8.1},',
+    '+}',
+    '+',
+    '+// fallback keeps an unknown country explicit instead of silently untaxed.',
+    '+var fallback = Rate{Country: "", Percent: 19}',
+    '+',
+    '+// For returns the rate of a delivery country.',
+    '+func For(country string) Rate {',
+    '+\tif rate, ok := rates[country]; ok {',
+    '+\t\treturn rate',
+    '+\t}',
+    '+\treturn fallback',
+    '+}',
+    '+',
+    '+// Apply returns the VAT owed on a net amount, rounded once, per order.',
+    '+func (r Rate) Apply(net money.Amount) money.Amount {',
+    '+\treturn net.MultiplyFloat(r.Percent / 100).RoundHalfUp()',
+    '+}',
+    '',
+  ].join('\n'),
+}
+
+export const TAX_TEST_DIFF: DiffFile = {
+  diffId: 'diff-2026-08-04-0013',
+  changeId: CHANGE_IDS.addTax,
+  componentIds: ['shop-platform.orders.domain.tax'],
+  filePath: 'internal/orders/domain/tax/tax_test.go',
+  unifiedDiff: [
+    '--- /dev/null',
+    '+++ b/internal/orders/domain/tax/tax_test.go',
+    '@@ -0,0 +1,24 @@',
+    '+package tax_test',
+    '+',
+    '+import (',
+    '+\t"testing"',
+    '+',
+    '+\t"shop-platform/internal/orders/domain/tax"',
+    '+\t"shop-platform/internal/shared/money"',
+    '+)',
+    '+',
+    '+func TestApplyRoundsOncePerOrder(t *testing.T) {',
+    '+\tcases := map[string]string{',
+    '+\t\t"DE": "19.00",',
+    '+\t\t"AT": "20.00",',
+    '+\t\t"CH": "8.10",',
+    '+\t\t"XX": "19.00",',
+    '+\t}',
+    '+\tfor country, want := range cases {',
+    '+\t\tgot := tax.For(country).Apply(money.MustParse("EUR", "100.00"))',
+    '+\t\tif got.String() != want {',
+    '+\t\t\tt.Fatalf("%s: got %s, want %s", country, got, want)',
+    '+\t\t}',
+    '+\t}',
+    '+}',
+    '',
+  ].join('\n'),
+}
+
+export const LEGACY_REMOVAL_DIFF: DiffFile = {
+  diffId: 'diff-2026-08-04-0014',
+  changeId: CHANGE_IDS.dropLegacyTaxRates,
+  componentIds: ['shop-platform.orders.domain.legacy-tax-rates'],
+  filePath: 'internal/orders/domain/legacy/tax_rates.go',
+  unifiedDiff: [
+    '--- a/internal/orders/domain/legacy/tax_rates.go',
+    '+++ /dev/null',
+    '@@ -1,12 +0,0 @@',
+    '-// Package legacy holds the hard-coded VAT table.',
+    '-//',
+    '-// Deprecated: superseded by internal/orders/domain/tax.',
+    '-package legacy',
+    '-',
+    '-// RateDE is the German VAT rate as a multiplier.',
+    '-const RateDE = 0.19',
+    '-',
+    '-// RateFor is the single-country stand-in the pricing module used to call.',
+    '-func RateFor(string) float64 {',
+    '-\treturn RateDE',
+    '-}',
+    '',
+  ].join('\n'),
+}
+
+export const NOTIFICATIONS_DIFF: DiffFile = {
+  diffId: 'diff-2026-08-04-0015',
+  // No changeId: an unplanned fix the implementer made while reading the topic
+  // wiring. The inspector must show it ungrouped next to the grouped ones.
+  componentIds: ['shop-platform.notifications'],
+  filePath: 'internal/notifications/consumer.go',
+  unifiedDiff: [
+    '--- a/internal/notifications/consumer.go',
+    '+++ b/internal/notifications/consumer.go',
+    '@@ -27,7 +27,11 @@ func (c *Consumer) Start(ctx context.Context) error {',
+    ' \t\treturn fmt.Errorf("subscribe %s: %w", topicOrderCreated, err)',
+    ' \t}',
+    ' ',
+    '-\tc.total = c.total.Add(msg.Order.Gross)',
+    '+\t// The gross total moved behind the tax module, so the mail template has',
+    '+\t// to read the field the order actually publishes now.',
+    '+\tc.total = c.total.Add(msg.Order.Total)',
+    '+\tc.vat = c.vat.Add(msg.Order.Vat)',
+    '+',
+    ' \treturn nil',
+    ' }',
+    '',
+  ].join('\n'),
+}
+
+export const ALL_DIFFS: DiffFile[] = [
+  PRICING_DIFF,
+  TAX_DIFF,
+  TAX_TEST_DIFF,
+  LEGACY_REMOVAL_DIFF,
+  NOTIFICATIONS_DIFF,
+]

--- a/simulator/src/scenarios/feedback.ts
+++ b/simulator/src/scenarios/feedback.ts
@@ -1,0 +1,68 @@
+/**
+ * The markdown bodies the reviewer publishes.
+ *
+ * Real markdown, not a placeholder string: headings, ordered and unordered
+ * lists, inline code and a fenced code block, so the inspector's renderer is
+ * actually exercised. Both bodies are agent statements — the cockpit never
+ * judges the work itself.
+ */
+
+const FENCE = '```'
+
+export const PRICING_TAX_FEEDBACK = [
+  '## What I looked at',
+  '',
+  'The extraction of VAT handling out of `pricing` into the new `tax` module,',
+  'including `Pricing.Total` and the new `tax.Rate.Apply`.',
+  '',
+  '## What stands out',
+  '',
+  '1. **The order of operations changed.** The old code added VAT to the net sum',
+  '   and subtracted the discount afterwards. The new code discounts first and',
+  '   taxes the discounted amount. For percentage discounts both are defensible,',
+  '   but they are not the same number.',
+  '2. **Rounding is now stated once.** `Apply` calls `RoundHalfUp()` on the whole',
+  '   order rather than per line. That is the behaviour the test pins down.',
+  '3. **The fallback rate is silent.** An unknown delivery country falls back to',
+  '   19 %, which is correct for Germany and wrong everywhere else.',
+  '',
+  '## Suggestion',
+  '',
+  'Make the sequence explicit at the call site and keep the table test next to it:',
+  '',
+  FENCE + 'go',
+  'net := order.NetTotal()',
+  'discounted := net.Sub(p.discountFor(order))',
+  'total := discounted.Add(tax.For(order.DeliveryCountry).Apply(discounted))',
+  FENCE,
+  '',
+  '- [x] rounding rule documented',
+  '- [ ] fallback country decided',
+  '',
+  'This is a reported observation, not a measured defect.',
+  '',
+].join('\n')
+
+export const NOTIFICATIONS_FEEDBACK = [
+  '## Second consumer of `orders.order.created`',
+  '',
+  'The notification service subscribes to the same topic as inventory. Both edges',
+  'are modelled separately on purpose — they fail independently.',
+  '',
+  '### What changed',
+  '',
+  '- `msg.Order.Gross` no longer exists; the consumer reads `Total` and `Vat`.',
+  '- The mail template still prints a single amount, so the split is invisible to',
+  '  the customer for now.',
+  '',
+  '### What to watch',
+  '',
+  '| Field | Before | After |',
+  '| --- | --- | --- |',
+  '| `Total` | net + VAT | discounted + VAT |',
+  '| `Vat` | not published | published per order |',
+  '',
+  'Replaying an event from before the change through the new consumer would read',
+  'a zero `Vat`. Nothing in this run verified that path.',
+  '',
+].join('\n')

--- a/simulator/src/scenarios/full.ts
+++ b/simulator/src/scenarios/full.ts
@@ -1,0 +1,550 @@
+/**
+ * The representative `full` run.
+ *
+ * The sequence is built to satisfy the lifecycle rules the backend enforces
+ * (ADR 0004), which the standalone examples in `api/examples/` deliberately do
+ * not: a run is opened by exactly one root orchestrator, every agent reports
+ * `agent.started` before its first other event, and every `parentAgentId` names
+ * an agent that already started. The examples are illustrations; this is a
+ * runnable order.
+ */
+import { SequenceBuilder, type Agent } from '../sequence.js'
+import type { Scenario } from '../types.js'
+import {
+  COMPONENT_IDS as C,
+  NOTIFICATIONS_ORDERS_RELATIONSHIP,
+  PRICING_TAX_RELATIONSHIP,
+  RELATIONSHIP_IDS as R,
+  ROUNDING_COMPONENT,
+  SNAPSHOT_COMPONENTS,
+  SNAPSHOT_RELATIONSHIPS,
+  TAX_COMPONENT,
+  TAX_ROUNDING_RELATIONSHIP,
+} from './architecture.js'
+import {
+  CHANGE_IDS,
+  LEGACY_REMOVAL_DIFF,
+  NOTIFICATIONS_DIFF,
+  PRICING_DIFF,
+  TAX_DIFF,
+  TAX_TEST_DIFF,
+  type DiffFile,
+} from './diffs.js'
+import { NOTIFICATIONS_FEEDBACK, PRICING_TAX_FEEDBACK } from './feedback.js'
+
+export const FULL_RUN_ID = 'run-2026-08-04-0001'
+
+/**
+ * The agent tree. Four subagents below one root, two of them delegated by
+ * another subagent — depth 3 including the root, with two branches running in
+ * parallel at the deepest level.
+ */
+const ORCHESTRATOR: Agent = { agentId: 'orchestrator-root', parentAgentId: null }
+const ARCHITECT: Agent = { agentId: 'subagent-architecture-mapper', parentAgentId: 'orchestrator-root' }
+const IMPLEMENTER: Agent = { agentId: 'subagent-implementer', parentAgentId: 'orchestrator-root' }
+const REVIEWER: Agent = { agentId: 'subagent-reviewer', parentAgentId: 'subagent-implementer' }
+const TESTER: Agent = { agentId: 'subagent-test-engineer', parentAgentId: 'subagent-implementer' }
+
+const PLAN_ID = 'plan-2026-08-04-0001'
+const SNAPSHOT_ID = 'snapshot-2026-08-04-0001'
+
+const STEP = {
+  map: 'step-map-architecture',
+  extract: 'step-extract-tax',
+  dropLegacy: 'step-drop-legacy-rates',
+  review: 'step-review-extraction',
+  cover: 'step-cover-with-tests',
+} as const
+
+const WORK = {
+  map: 'work-2026-08-04-0001',
+  extract: 'work-2026-08-04-0002',
+  review: 'work-2026-08-04-0003',
+  tests: 'work-2026-08-04-0004',
+} as const
+
+export interface FullScenarioOptions {
+  projectId: string
+  runId: string
+  seed: number
+  /**
+   * Whether the orchestrator closes the run. Off by default: a run without a
+   * terminal event is the state that proves the cockpit derives nothing from
+   * silence, and it is the more interesting thing to look at in the browser.
+   */
+  finish: boolean
+}
+
+/** Turns a diff file into a `diff.reported` payload. */
+function diffPayload(diff: DiffFile): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    diffId: diff.diffId,
+    componentIds: diff.componentIds,
+    filePath: diff.filePath,
+    unifiedDiff: diff.unifiedDiff,
+  }
+  if (diff.changeId !== undefined) {
+    payload.changeId = diff.changeId
+  }
+  return payload
+}
+
+export function buildFullScenario(options: FullScenarioOptions): Scenario {
+  const b = new SequenceBuilder({
+    projectId: options.projectId,
+    runId: options.runId,
+    seed: options.seed,
+    scenarioLabel: 'full',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Run start')
+  // -------------------------------------------------------------------------
+  b.emit(ORCHESTRATOR, 'agent.started', {
+    role: 'orchestrator',
+    displayName: 'Root Orchestrator',
+    assignedTask: 'Extract VAT handling out of the pricing module and keep the architecture model current.',
+    capabilities: ['planning', 'delegation', 'review'],
+  })
+  b.emit(ORCHESTRATOR, 'agent.status_reported', {
+    status: 'working',
+    note: 'Mapping the current architecture before delegating anything.',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Subagents spawn')
+  // -------------------------------------------------------------------------
+  b.emit(ARCHITECT, 'agent.started', {
+    role: 'subagent',
+    displayName: 'Architecture Mapper',
+    assignedTask: 'Publish the applied architecture model and keep it in sync with the change.',
+    capabilities: ['static-analysis', 'architecture'],
+  })
+  b.emit(IMPLEMENTER, 'agent.started', {
+    role: 'subagent',
+    displayName: 'Implementer',
+    assignedTask: 'Move VAT handling out of pricing into its own module.',
+    capabilities: ['go', 'refactoring'],
+  })
+  // Delegated by the implementer, not by the root: the tree is three levels deep.
+  b.emit(REVIEWER, 'agent.started', {
+    role: 'subagent',
+    displayName: 'Reviewer',
+    assignedTask: 'Review the extraction and report component-scoped feedback.',
+    capabilities: ['review', 'go'],
+  })
+  b.emit(TESTER, 'agent.started', {
+    role: 'subagent',
+    displayName: 'Test Engineer',
+    assignedTask: 'Cover the new tax module with table tests.',
+    capabilities: ['go', 'testing'],
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Architecture snapshot')
+  // -------------------------------------------------------------------------
+  b.emit(ARCHITECT, 'agent.status_reported', {
+    status: 'working',
+    note: 'Reading the module graph.',
+  })
+  b.emit(ARCHITECT, 'work.step_started', {
+    workStepId: WORK.map,
+    title: 'Map the applied architecture',
+    componentIds: [C.system, C.orders, C.ordersDomain, C.pricing, C.events],
+    planStepId: STEP.map,
+  })
+  b.emit(ARCHITECT, 'architecture.snapshot_published', {
+    snapshotId: SNAPSHOT_ID,
+    components: SNAPSHOT_COMPONENTS,
+    relationships: SNAPSHOT_RELATIONSHIPS,
+  })
+  b.emit(ARCHITECT, 'work.step_completed', {
+    workStepId: WORK.map,
+    summary: '17 components across four hierarchy levels, 11 relationships, two NATS topics.',
+  })
+  b.emit(ARCHITECT, 'agent.progress_reported', {
+    percent: 40,
+    scope: 'own_task',
+    basis: 'completed_steps',
+    note: 'Model published; the change itself is still open.',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Plan')
+  // -------------------------------------------------------------------------
+  b.emit(ORCHESTRATOR, 'plan.published', {
+    planId: PLAN_ID,
+    revision: 1,
+    steps: [
+      {
+        stepId: STEP.map,
+        order: 0,
+        title: 'Map the applied architecture',
+        state: 'done',
+        componentIds: [C.system],
+      },
+      {
+        stepId: STEP.extract,
+        order: 1,
+        title: 'Extract VAT handling into a tax module',
+        state: 'in_progress',
+        componentIds: [C.pricing, C.tax],
+      },
+      {
+        stepId: STEP.review,
+        order: 2,
+        title: 'Review the extraction',
+        state: 'pending',
+        componentIds: [C.pricing, C.tax],
+      },
+      {
+        stepId: STEP.cover,
+        order: 3,
+        title: 'Cover the tax module with table tests',
+        state: 'pending',
+        componentIds: [C.tax],
+      },
+    ],
+  })
+  // The orchestrator estimates the whole run; the subagents above and below
+  // report their own task. The two scopes must stay visibly different.
+  b.emit(ORCHESTRATOR, 'agent.progress_reported', {
+    percent: 20,
+    scope: 'overall_estimate',
+    basis: 'reported_estimate',
+    note: 'One of four planned steps done.',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Proposed changes')
+  // -------------------------------------------------------------------------
+  b.emit(ARCHITECT, 'component.change_planned', {
+    changeId: CHANGE_IDS.addTax,
+    operation: 'add',
+    component: TAX_COMPONENT,
+    rationale: 'Pricing mixes discount and VAT rules, which makes country-specific rates hard to test.',
+  })
+  b.emit(ARCHITECT, 'relationship.change_planned', {
+    changeId: CHANGE_IDS.linkPricingToTax,
+    operation: 'add',
+    relationship: PRICING_TAX_RELATIONSHIP,
+    rationale: 'Pricing will delegate the VAT calculation to the new module.',
+  })
+  b.emit(ARCHITECT, 'component.change_planned', {
+    changeId: CHANGE_IDS.dropLegacyTaxRates,
+    operation: 'remove',
+    component: {
+      componentId: C.legacyTaxRates,
+      name: 'Legacy Tax Rates',
+      kind: 'module',
+      parentComponentId: C.ordersDomain,
+      description: 'Superseded by the tax module.',
+    },
+    rationale: 'The hard-coded German rate has no callers once pricing delegates to tax.',
+  })
+  b.emit(ARCHITECT, 'relationship.change_planned', {
+    changeId: CHANGE_IDS.dropLegacyTaxDependency,
+    operation: 'remove',
+    relationship: {
+      relationshipId: R.pricingLegacyTaxRates,
+      sourceComponentId: C.pricing,
+      targetComponentId: C.legacyTaxRates,
+      kind: 'dependency',
+    },
+    rationale: 'Removed together with the component it points at.',
+  })
+  // Planned here and withdrawn again further down, so the cockpit has a
+  // retracted proposal to show.
+  const withdrawnPlan = b.emit(ARCHITECT, 'relationship.change_planned', {
+    changeId: CHANGE_IDS.notificationsReadsOrders,
+    operation: 'add',
+    relationship: NOTIFICATIONS_ORDERS_RELATIONSHIP,
+    rationale: 'The mail body needs order details the topic message does not carry.',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Implementation')
+  // -------------------------------------------------------------------------
+  b.emit(IMPLEMENTER, 'agent.status_reported', {
+    status: 'working',
+    note: 'Rewriting Total().',
+  })
+  b.emit(IMPLEMENTER, 'work.step_started', {
+    workStepId: WORK.extract,
+    title: 'Extract VAT handling into internal/orders/domain/tax',
+    componentIds: [C.pricing, C.tax, C.legacyTaxRates],
+    planStepId: STEP.extract,
+  })
+  const pricingDiff = b.emit(IMPLEMENTER, 'diff.reported', diffPayload(PRICING_DIFF))
+  b.emit(IMPLEMENTER, 'diff.reported', diffPayload(TAX_DIFF))
+  b.emit(IMPLEMENTER, 'diff.reported', diffPayload(TAX_TEST_DIFF))
+  b.emit(IMPLEMENTER, 'agent.progress_reported', {
+    percent: 65,
+    scope: 'own_task',
+    basis: 'completed_steps',
+    note: 'Tax module compiles; the legacy package is still referenced by tests.',
+  })
+  // The first diff named only the pricing module although it also introduces the
+  // tax import. The log is append-only, so the fix is a new event, not an edit.
+  b.emit(IMPLEMENTER, 'correction.issued', {
+    correctsClientEventId: pricingDiff,
+    reason: 'The diff was attributed to the pricing module only; it also introduces the tax dependency.',
+    correctedType: 'diff.reported',
+    correctedPayload: {
+      ...diffPayload(PRICING_DIFF),
+      componentIds: [C.pricing, C.tax],
+    },
+  })
+  b.emit(IMPLEMENTER, 'diff.reported', diffPayload(LEGACY_REMOVAL_DIFF))
+  b.emit(IMPLEMENTER, 'diff.reported', diffPayload(NOTIFICATIONS_DIFF))
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Applied changes')
+  // -------------------------------------------------------------------------
+  b.emit(ARCHITECT, 'component.change_applied', {
+    changeId: CHANGE_IDS.addTax,
+    operation: 'add',
+    component: TAX_COMPONENT,
+  })
+  b.emit(ARCHITECT, 'relationship.change_applied', {
+    changeId: CHANGE_IDS.linkPricingToTax,
+    operation: 'add',
+    relationship: PRICING_TAX_RELATIONSHIP,
+  })
+  b.emit(ARCHITECT, 'relationship.change_applied', {
+    changeId: CHANGE_IDS.dropLegacyTaxDependency,
+    operation: 'remove',
+    relationship: {
+      relationshipId: R.pricingLegacyTaxRates,
+      sourceComponentId: C.pricing,
+      targetComponentId: C.legacyTaxRates,
+      kind: 'dependency',
+    },
+  })
+  b.emit(ARCHITECT, 'component.change_applied', {
+    changeId: CHANGE_IDS.dropLegacyTaxRates,
+    operation: 'remove',
+    component: {
+      componentId: C.legacyTaxRates,
+      name: 'Legacy Tax Rates',
+      kind: 'module',
+      parentComponentId: C.ordersDomain,
+    },
+  })
+  b.emit(ARCHITECT, 'retraction.issued', {
+    retractsClientEventId: withdrawnPlan,
+    reason: 'The topic message will carry the missing fields instead, so no HTTP edge is needed.',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Review')
+  // -------------------------------------------------------------------------
+  b.emit(REVIEWER, 'agent.status_reported', { status: 'working', note: 'Reading the extraction.' })
+  b.emit(REVIEWER, 'work.step_started', {
+    workStepId: WORK.review,
+    title: 'Review the VAT extraction',
+    componentIds: [C.pricing, C.tax],
+    planStepId: STEP.review,
+  })
+  b.emit(REVIEWER, 'feedback.published', {
+    feedbackId: 'feedback-2026-08-04-0001',
+    componentIds: [C.pricing, C.tax],
+    format: 'markdown',
+    title: 'VAT extraction changes the discount order',
+    body: PRICING_TAX_FEEDBACK,
+  })
+  b.emit(REVIEWER, 'feedback.published', {
+    feedbackId: 'feedback-2026-08-04-0002',
+    componentIds: [C.notifications, C.topicOrderCreated],
+    format: 'markdown',
+    title: 'Notification consumer follows the renamed amount fields',
+    body: NOTIFICATIONS_FEEDBACK,
+  })
+  b.emit(REVIEWER, 'risk.reported', {
+    riskId: 'risk-2026-08-04-0001',
+    componentIds: [C.pricing, C.tax],
+    title: 'Discount and VAT order changed without a migration note',
+    detail:
+      'Orders priced before and after the change are not comparable. Nothing in this run checked historical orders.',
+    severity: 'medium',
+  })
+  b.emit(REVIEWER, 'problem.reported', {
+    problemId: 'problem-2026-08-04-0001',
+    componentIds: [C.notifications],
+    title: 'Mail template still prints a single amount',
+    detail:
+      'The consumer reads Total and Vat separately, but the template was not touched, so the VAT line is not shown.',
+  })
+  b.emit(REVIEWER, 'agent.progress_reported', {
+    percent: 80,
+    scope: 'own_task',
+    basis: 'completed_steps',
+  })
+  b.emit(REVIEWER, 'work.step_completed', {
+    workStepId: WORK.review,
+    summary: 'Two feedback items, one risk, one problem.',
+  })
+  b.emit(REVIEWER, 'agent.status_reported', {
+    status: 'blocked',
+    note: 'Waiting for a decision on the fallback VAT rate.',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Tests')
+  // -------------------------------------------------------------------------
+  b.emit(TESTER, 'agent.status_reported', { status: 'working', note: 'Writing the table test.' })
+  b.emit(TESTER, 'work.step_started', {
+    workStepId: WORK.tests,
+    title: 'Cover tax.Rate.Apply with a table test',
+    componentIds: [C.tax],
+    planStepId: STEP.cover,
+  })
+  b.emit(TESTER, 'agent.status_reported', {
+    status: 'waiting',
+    note: 'Waiting for the reviewer to settle the fallback rate before pinning it down.',
+  })
+  b.emit(TESTER, 'work.step_completed', {
+    workStepId: WORK.tests,
+    summary: 'Four countries covered, including the fallback.',
+  })
+  b.emit(TESTER, 'agent.progress_reported', {
+    percent: 100,
+    scope: 'own_task',
+    basis: 'completed_steps',
+  })
+  b.emit(TESTER, 'agent.status_reported', { status: 'done' })
+  b.emit(TESTER, 'agent.finished', {
+    outcome: 'completed',
+    summary: 'tax_test.go covers DE, AT, CH and the fallback country.',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Plan revision')
+  // -------------------------------------------------------------------------
+  // A revision is a full republish of the plan under the same planId. The
+  // earlier revision keeps the step states it was last seen with.
+  b.emit(ORCHESTRATOR, 'plan.published', {
+    planId: PLAN_ID,
+    revision: 2,
+    steps: [
+      {
+        stepId: STEP.map,
+        order: 0,
+        title: 'Map the applied architecture',
+        state: 'done',
+        componentIds: [C.system],
+      },
+      {
+        stepId: STEP.extract,
+        order: 1,
+        title: 'Extract VAT handling into a tax module',
+        state: 'done',
+        componentIds: [C.pricing, C.tax],
+      },
+      {
+        stepId: STEP.dropLegacy,
+        order: 2,
+        title: 'Remove the legacy VAT table',
+        state: 'in_progress',
+        componentIds: [C.legacyTaxRates],
+      },
+      {
+        stepId: STEP.review,
+        order: 3,
+        title: 'Review the extraction',
+        state: 'done',
+        componentIds: [C.pricing, C.tax],
+      },
+      {
+        stepId: STEP.cover,
+        order: 4,
+        title: 'Cover the tax module with table tests',
+        state: 'done',
+        componentIds: [C.tax],
+      },
+    ],
+  })
+  b.emit(ORCHESTRATOR, 'plan.step_updated', {
+    planId: PLAN_ID,
+    stepId: STEP.dropLegacy,
+    state: 'done',
+    note: 'Legacy package deleted and the dependency edge removed.',
+  })
+  b.emit(ORCHESTRATOR, 'plan.step_updated', {
+    planId: PLAN_ID,
+    stepId: STEP.review,
+    state: 'skipped',
+    note: 'Re-review of the fallback rate deferred to a follow-up run.',
+  })
+  b.emit(ORCHESTRATOR, 'agent.progress_reported', {
+    percent: 70,
+    scope: 'overall_estimate',
+    basis: 'reported_estimate',
+    note: 'Implementation done; the fallback rate decision is still open.',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Open proposals')
+  // -------------------------------------------------------------------------
+  // Planned and neither applied nor retracted, so the run ends with something in
+  // `activeChanges`. Without it the cockpit would have no pending proposal left
+  // to render once the run goes quiet, and the `planned` overlay state would only
+  // ever be visible while the simulator is mid-flight.
+  b.emit(ARCHITECT, 'component.change_planned', {
+    changeId: CHANGE_IDS.addRounding,
+    operation: 'add',
+    component: ROUNDING_COMPONENT,
+    rationale: 'Rounding is stated inside tax.Apply today; a shared module would keep it one rule.',
+  })
+  b.emit(ARCHITECT, 'relationship.change_planned', {
+    changeId: CHANGE_IDS.linkTaxToRounding,
+    operation: 'add',
+    relationship: TAX_ROUNDING_RELATIONSHIP,
+    rationale: 'The tax module would delegate the half-up rounding instead of implementing it.',
+  })
+
+  // -------------------------------------------------------------------------
+  b.beginPhase('Wind down')
+  // -------------------------------------------------------------------------
+  b.emit(REVIEWER, 'agent.status_reported', { status: 'done' })
+  b.emit(REVIEWER, 'agent.finished', {
+    outcome: 'completed',
+    summary: 'Extraction reviewed; the fallback rate stays an open question.',
+  })
+  b.emit(IMPLEMENTER, 'work.step_completed', {
+    workStepId: WORK.extract,
+    summary: 'Pricing delegates to tax; the legacy package is gone.',
+  })
+  b.emit(IMPLEMENTER, 'agent.status_reported', { status: 'done' })
+  b.emit(IMPLEMENTER, 'agent.finished', {
+    outcome: 'completed',
+    summary: 'VAT handling extracted, five files reported as unified diffs.',
+  })
+  b.emit(ARCHITECT, 'agent.status_reported', { status: 'done' })
+  b.emit(ARCHITECT, 'agent.finished', {
+    outcome: 'completed',
+    summary: 'Model updated: tax added, the legacy module and its edge removed.',
+  })
+  b.emit(ORCHESTRATOR, 'agent.status_reported', {
+    status: 'idle',
+    note: 'All subagents finished. The fallback rate decision is left to the human reviewer.',
+  })
+
+  if (options.finish) {
+    // -----------------------------------------------------------------------
+    b.beginPhase('Run finished')
+    // -----------------------------------------------------------------------
+    b.emit(ORCHESTRATOR, 'run.finished', {
+      outcome: 'completed',
+      summary:
+        'VAT handling extracted into its own module, the architecture model updated and the review reported.',
+    })
+  }
+
+  return {
+    name: 'full',
+    projectId: options.projectId,
+    runId: options.runId,
+    steps: b.build(),
+  }
+}

--- a/simulator/src/scenarios/index.ts
+++ b/simulator/src/scenarios/index.ts
@@ -1,0 +1,50 @@
+/** Scenario selection. */
+import type { Options } from '../options.js'
+import type { Scenario } from '../types.js'
+import { buildConflictScenario, CONFLICT_RUN_ID } from './conflict.js'
+import { buildFullScenario, FULL_RUN_ID } from './full.js'
+import { buildRetryScenario, RETRY_RUN_ID } from './retry.js'
+
+/**
+ * Each scenario has its own default run id, so none of them can be mistaken for
+ * another in the run list.
+ */
+export const DEFAULT_RUN_IDS = {
+  full: FULL_RUN_ID,
+  retry: RETRY_RUN_ID,
+  conflict: CONFLICT_RUN_ID,
+} as const
+
+/**
+ * The probes report into their own projects.
+ *
+ * `runs/current` resolves to the run a root orchestrator opened last (ADR 0005),
+ * so a probe sent into the demo project afterwards would silently become the
+ * cockpit's current run and empty every default component inspector. Keeping
+ * them apart also gives the project list more than one row to render.
+ *
+ * Each id is fixed, so repeating a scenario always lands in the same project;
+ * `--project` overrides all three.
+ */
+export const DEFAULT_PROJECT_IDS = {
+  full: 'visualise-ai',
+  retry: 'visualise-ai-retry',
+  conflict: 'visualise-ai-conflict',
+} as const
+
+export function buildScenario(options: Options): Scenario {
+  const runId = options.runId ?? DEFAULT_RUN_IDS[options.scenario]
+  const projectId = options.projectId ?? DEFAULT_PROJECT_IDS[options.scenario]
+  const common = { projectId, runId, seed: options.seed }
+
+  switch (options.scenario) {
+    case 'full':
+      return buildFullScenario({ ...common, finish: options.finish })
+    case 'retry':
+      return buildRetryScenario(common)
+    case 'conflict':
+      return buildConflictScenario(common)
+  }
+}
+
+export { buildConflictScenario, buildFullScenario, buildRetryScenario }

--- a/simulator/src/scenarios/retry.ts
+++ b/simulator/src/scenarios/retry.ts
@@ -1,0 +1,56 @@
+/**
+ * The `retry` scenario: idempotency on `clientEventId`.
+ *
+ * It opens its own run, sends one ordinary event and then the byte-identical
+ * document a second time. The contract promises `201` followed by `200` with
+ * `duplicate: true` and the **same** position; the runner asserts all three and
+ * aborts otherwise.
+ *
+ * The scenario expects an empty project — a second execution against the same
+ * database would legitimately answer `200` to the first delivery too, which is
+ * the correct behaviour but not what this scenario is trying to prove.
+ */
+import { SequenceBuilder, type Agent } from '../sequence.js'
+import type { Scenario } from '../types.js'
+
+export const RETRY_RUN_ID = 'run-2026-08-04-0002'
+
+const ORCHESTRATOR: Agent = { agentId: 'orchestrator-retry', parentAgentId: null }
+
+export interface RetryScenarioOptions {
+  projectId: string
+  runId: string
+  seed: number
+}
+
+export function buildRetryScenario(options: RetryScenarioOptions): Scenario {
+  const b = new SequenceBuilder({
+    projectId: options.projectId,
+    runId: options.runId,
+    seed: options.seed,
+    scenarioLabel: 'retry',
+  })
+
+  b.beginPhase('Run start')
+  b.emit(ORCHESTRATOR, 'agent.started', {
+    role: 'orchestrator',
+    displayName: 'Idempotency Probe',
+    assignedTask: 'Demonstrate that a byte-identical redelivery is not appended twice.',
+  })
+
+  b.beginPhase('First delivery')
+  const target = b.emit(ORCHESTRATOR, 'agent.status_reported', {
+    status: 'working',
+    note: 'This exact event is sent twice.',
+  })
+
+  b.beginPhase('Byte-identical redelivery')
+  b.emitRetryOf(target)
+
+  return {
+    name: 'retry',
+    projectId: options.projectId,
+    runId: options.runId,
+    steps: b.build(),
+  }
+}

--- a/simulator/src/sequence.ts
+++ b/simulator/src/sequence.ts
@@ -1,0 +1,146 @@
+/**
+ * The builder every scenario is written against.
+ *
+ * It owns the three things that must not be left to the scenario author:
+ * the client event ids, the reported timeline and the parent agent of an
+ * envelope. All three come from seeded streams, which is what makes a scenario
+ * a document rather than a recording.
+ */
+import type { VirtualClock } from './clock.js'
+import { createClock } from './clock.js'
+import { createPrng, mixSeed, uuidFrom, type Prng } from './prng.js'
+import type { EventEnvelope, EventPayload, ExpectedResponse, ScenarioStep } from './types.js'
+
+/** One agent of the simulated run. */
+export interface Agent {
+  agentId: string
+  /** `null` for the root orchestrator. */
+  parentAgentId: string | null
+}
+
+export interface SequenceOptions {
+  projectId: string
+  runId: string
+  seed: number
+  /** Mixed into the seed so scenarios sharing a `--seed` get disjoint ids. */
+  scenarioLabel: string
+}
+
+/**
+ * Three independent streams, so adding a pause never shifts a client event id
+ * and changing the pacing never changes the identity of an event.
+ */
+interface Streams {
+  ids: Prng
+  pauses: Prng
+  clock: Prng
+}
+
+export class SequenceBuilder {
+  private readonly steps: ScenarioStep[] = []
+  private readonly streams: Streams
+  private readonly clock: VirtualClock
+  private phase = 'start'
+  private nextPauseMs = 0
+
+  constructor(private readonly options: SequenceOptions) {
+    const base = mixSeed(options.seed, options.scenarioLabel)
+    this.streams = {
+      ids: createPrng(mixSeed(base, 'ids')),
+      pauses: createPrng(mixSeed(base, 'pauses')),
+      clock: createPrng(mixSeed(base, 'clock')),
+    }
+    this.clock = createClock()
+  }
+
+  /**
+   * Opens a narrated phase. The pause before the first event of a phase is the
+   * long one — that is the beat a human watching the browser needs to see the
+   * previous phase land.
+   */
+  beginPhase(name: string): this {
+    this.phase = name
+    this.nextPauseMs = this.streams.pauses.nextInt(900, 1800)
+    return this
+  }
+
+  /** Appends one event and returns its client event id. */
+  emit(
+    agent: Agent,
+    type: string,
+    payload: EventPayload,
+    expect: ExpectedResponse = { status: 201, duplicate: false },
+  ): string {
+    const event: EventEnvelope = {
+      schemaVersion: '1.0',
+      clientEventId: uuidFrom(this.streams.ids),
+      projectId: this.options.projectId,
+      runId: this.options.runId,
+      agentId: agent.agentId,
+      parentAgentId: agent.parentAgentId,
+      // Reported time moves in plausible steps of seconds; the pause the runner
+      // waits is unrelated and much shorter.
+      occurredAt: this.clock.advance(this.streams.clock.nextInt(7, 95) * 1000),
+      type,
+      payload,
+    }
+
+    const pauseMs = this.nextPauseMs
+    this.nextPauseMs = this.streams.pauses.nextInt(120, 420)
+    this.steps.push({ phase: this.phase, pauseMs, event, expect })
+    return event.clientEventId
+  }
+
+  /**
+   * Appends a byte-identical copy of an already emitted event. The copy shares
+   * its client event id, so the server must answer `200 duplicate: true` with
+   * the position it assigned the first time.
+   */
+  emitRetryOf(clientEventId: string): void {
+    const original = this.steps.find((step) => step.event.clientEventId === clientEventId)
+    if (!original) {
+      throw new Error(`emitRetryOf: no earlier step with clientEventId ${clientEventId}`)
+    }
+    this.steps.push({
+      phase: this.phase,
+      pauseMs: this.nextPauseMs,
+      // Structured clone keeps the retry byte-identical without sharing the
+      // object, so a later mutation of one cannot silently change the other.
+      event: structuredClone(original.event),
+      expect: { status: 200, duplicate: true, samePositionAs: clientEventId },
+    })
+    this.nextPauseMs = this.streams.pauses.nextInt(120, 420)
+  }
+
+  /**
+   * Appends an event that reuses an already emitted client event id with a
+   * different payload. The server must refuse it with `409`.
+   */
+  emitConflictWith(clientEventId: string, agent: Agent, type: string, payload: EventPayload): void {
+    const original = this.steps.find((step) => step.event.clientEventId === clientEventId)
+    if (!original) {
+      throw new Error(`emitConflictWith: no earlier step with clientEventId ${clientEventId}`)
+    }
+    this.steps.push({
+      phase: this.phase,
+      pauseMs: this.nextPauseMs,
+      event: {
+        schemaVersion: '1.0',
+        clientEventId,
+        projectId: this.options.projectId,
+        runId: this.options.runId,
+        agentId: agent.agentId,
+        parentAgentId: agent.parentAgentId,
+        occurredAt: this.clock.advance(this.streams.clock.nextInt(7, 95) * 1000),
+        type,
+        payload,
+      },
+      expect: { status: 409, code: 'client_event_id_conflict' },
+    })
+    this.nextPauseMs = this.streams.pauses.nextInt(120, 420)
+  }
+
+  build(): ScenarioStep[] {
+    return this.steps
+  }
+}

--- a/simulator/src/types.ts
+++ b/simulator/src/types.ts
@@ -1,0 +1,88 @@
+/**
+ * The shapes the simulator works with.
+ *
+ * These are deliberately loose about the payload: `api/openapi.yaml` is the
+ * authority on what a payload may contain, and every envelope is validated
+ * against it before it is sent (see `contract.ts`). Restating the 20 payload
+ * schemas in TypeScript would create a second, silently drifting contract —
+ * exactly what ADR 0004 rejects for the backend.
+ */
+
+export type EventPayload = Record<string, unknown>
+
+/** One event envelope as `POST /api/v1/events` accepts it. */
+export interface EventEnvelope {
+  schemaVersion: '1.0'
+  clientEventId: string
+  projectId: string
+  runId: string
+  agentId: string
+  parentAgentId: string | null
+  occurredAt: string
+  type: string
+  payload: EventPayload
+}
+
+/**
+ * One entry of a scenario: the envelope plus how the runner should narrate and
+ * pace it.
+ */
+export interface ScenarioStep {
+  /** Human-readable phase this step belongs to, printed as a section heading. */
+  phase: string
+  /** Base pause in milliseconds *before* this step, scaled by `--speed`. */
+  pauseMs: number
+  /** The envelope to send. */
+  event: EventEnvelope
+  /**
+   * What the runner expects back. `201` for a first delivery, `200` for a
+   * byte-identical retry, `409` for a deliberate conflict. Anything else aborts
+   * the run.
+   */
+  expect: ExpectedResponse
+}
+
+export interface ExpectedResponse {
+  status: number
+  /** Expected `duplicate` flag of an `EventAccepted` body, when the step asserts one. */
+  duplicate?: boolean
+  /** Expected RFC 9457 `code` of a problem body, when the step expects a failure. */
+  code?: string
+  /**
+   * Name of an earlier step whose assigned position this step must repeat.
+   * Used by the retry scenario to prove the position is not re-allocated.
+   */
+  samePositionAs?: string
+}
+
+/** A complete, ordered scenario. */
+export interface Scenario {
+  name: ScenarioName
+  projectId: string
+  runId: string
+  steps: ScenarioStep[]
+}
+
+export const SCENARIO_NAMES = ['full', 'retry', 'conflict'] as const
+export type ScenarioName = (typeof SCENARIO_NAMES)[number]
+
+/** `EventAccepted` from the contract. */
+export interface EventAccepted {
+  projectId: string
+  position: number
+  serverEventId: string
+  clientEventId: string
+  duplicate: boolean
+  receivedAt: string
+}
+
+/** RFC 9457 problem document as the backend returns it. */
+export interface ProblemDocument {
+  type?: string
+  title?: string
+  status?: number
+  detail?: string
+  code?: string
+  instance?: string
+  errors?: { field?: string; code?: string; message?: string }[]
+}

--- a/simulator/test/catalogue.test.ts
+++ b/simulator/test/catalogue.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The catalogue is closed and the simulator has to exercise all of it: whatever
+ * the contract allows, the E2E test in #14 must be able to see happen.
+ *
+ * The expected set is read from `api/openapi.yaml` rather than restated here, so
+ * adding a 21st event type to the contract fails this test until the scenario
+ * reports it too.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { loadContract } from '../src/contract.js'
+import { DEFAULT_OPTIONS } from '../src/options.js'
+import { buildFullScenario, DEFAULT_PROJECT_IDS } from '../src/scenarios/index.js'
+
+const contract = loadContract()
+const base = {
+  projectId: DEFAULT_PROJECT_IDS.full,
+  runId: 'run-2026-08-04-0001',
+  seed: DEFAULT_OPTIONS.seed,
+}
+
+const typesOf = (finish: boolean): Set<string> =>
+  new Set(buildFullScenario({ ...base, finish }).steps.map((step) => step.event.type))
+
+describe('event catalogue coverage', () => {
+  it('covers every type of the published catalogue', () => {
+    const covered = typesOf(true)
+    const missing = contract.eventTypes.filter((type) => !covered.has(type))
+
+    expect(missing, `not reported by the full scenario: ${missing.join(', ')}`).toEqual([])
+    expect(covered.size).toBe(contract.eventTypes.length)
+  })
+
+  it('reports nothing that is not in the catalogue', () => {
+    const catalogue = new Set(contract.eventTypes)
+    for (const type of typesOf(true)) {
+      expect(catalogue).toContain(type)
+    }
+  })
+
+  it('leaves exactly one documented type out of the default run', () => {
+    // `run.finished` is optional by contract and off by default, because a run
+    // that never reports a terminal state is the case that proves the cockpit
+    // derives nothing from silence. It is the only permitted omission, and
+    // `--finish true` restores it.
+    const covered = typesOf(false)
+    const missing = contract.eventTypes.filter((type) => !covered.has(type))
+
+    expect(missing).toEqual(['run.finished'])
+  })
+})

--- a/simulator/test/contract.test.ts
+++ b/simulator/test/contract.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { ContractViolationError, loadContract } from '../src/contract.js'
+import { DEFAULT_OPTIONS } from '../src/options.js'
+import {
+  buildConflictScenario,
+  buildFullScenario,
+  buildRetryScenario,
+  DEFAULT_PROJECT_IDS,
+} from '../src/scenarios/index.js'
+import type { EventEnvelope } from '../src/types.js'
+
+const contract = loadContract()
+
+const base = {
+  projectId: DEFAULT_PROJECT_IDS.full,
+  runId: 'run-2026-08-04-0001',
+  seed: DEFAULT_OPTIONS.seed,
+}
+
+const scenarios = [
+  ['full', buildFullScenario({ ...base, finish: true })],
+  ['retry', buildRetryScenario({ ...base, runId: 'run-2026-08-04-0002' })],
+  ['conflict', buildConflictScenario({ ...base, runId: 'run-2026-08-04-0003' })],
+] as const
+
+describe('contract conformance', () => {
+  it.each(scenarios)('every event of the %s scenario validates as IngestEventRequest', (_, scenario) => {
+    for (const step of scenario.steps) {
+      expect(() => contract.assertIngestible(step.event)).not.toThrow()
+    }
+  })
+
+  it('loads the contract the repository publishes', () => {
+    expect(contract.path.replaceAll('\\', '/')).toMatch(/\/api\/openapi\.yaml$/)
+    expect(contract.eventTypes.length).toBeGreaterThan(0)
+  })
+
+  it('refuses an event the contract does not allow', () => {
+    const [first] = buildFullScenario({ ...base, finish: false }).steps
+    const broken = {
+      ...(first as { event: EventEnvelope }).event,
+      payload: { role: 'orchestrator', displayName: 'x', assignedTask: 'y', rawTerminalOutput: '$ ls' },
+    }
+
+    expect(() => contract.assertIngestible(broken)).toThrow(ContractViolationError)
+  })
+
+  it('refuses an event type outside the closed catalogue', () => {
+    const [first] = buildFullScenario({ ...base, finish: false }).steps
+    const broken = { ...(first as { event: EventEnvelope }).event, type: 'tool.invoked' }
+
+    expect(() => contract.assertIngestible(broken)).toThrow(ContractViolationError)
+  })
+
+  it('refuses a client event id that is not a uuid', () => {
+    const [first] = buildFullScenario({ ...base, finish: false }).steps
+    const broken = { ...(first as { event: EventEnvelope }).event, clientEventId: 'not-a-uuid' }
+
+    expect(() => contract.assertIngestible(broken)).toThrow(ContractViolationError)
+  })
+})

--- a/simulator/test/coverage.test.ts
+++ b/simulator/test/coverage.test.ts
@@ -1,0 +1,310 @@
+/**
+ * What #14 has to be able to assert against a browser. Each test below maps to
+ * one bullet of the mandatory end-to-end acceptance run, so a scenario edit that
+ * quietly drops a case fails here instead of in Playwright.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_OPTIONS } from '../src/options.js'
+import { buildFullScenario, DEFAULT_PROJECT_IDS } from '../src/scenarios/index.js'
+import type { EventEnvelope, ScenarioStep } from '../src/types.js'
+
+const scenario = buildFullScenario({
+  projectId: DEFAULT_PROJECT_IDS.full,
+  runId: 'run-2026-08-04-0001',
+  seed: DEFAULT_OPTIONS.seed,
+  finish: true,
+})
+
+const eventsOf = (type: string): EventEnvelope[] =>
+  scenario.steps.filter((step: ScenarioStep) => step.event.type === type).map((step) => step.event)
+
+const snapshot = eventsOf('architecture.snapshot_published')[0]?.payload as {
+  components: { componentId: string; parentComponentId: string | null }[]
+  relationships: { kind: string; channel?: string; targetComponentId: string }[]
+}
+
+/** Depth of a node in a flat parent-pointer list, root = 1. */
+function depthOf(id: string | null, parents: Map<string, string | null>): number {
+  let depth = 0
+  let current = id
+  while (current !== null && current !== undefined) {
+    depth += 1
+    current = parents.get(current) ?? null
+  }
+  return depth
+}
+
+describe('agent tree', () => {
+  const started = eventsOf('agent.started')
+  const parents = new Map<string, string | null>(
+    started.map((event) => [event.agentId, event.parentAgentId]),
+  )
+
+  it('runs at least three subagents', () => {
+    const subagents = started.filter(
+      (event) => (event.payload as { role?: string }).role === 'subagent',
+    )
+    expect(subagents.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('nests a subagent below another subagent, three levels including the root', () => {
+    const depths = [...parents.keys()].map((id) => depthOf(id, parents))
+    expect(Math.max(...depths)).toBeGreaterThanOrEqual(3)
+  })
+
+  it('separates the orchestrator estimate from the subagents own-task progress', () => {
+    const progress = eventsOf('agent.progress_reported').map((event) => ({
+      agentId: event.agentId,
+      ...(event.payload as { percent: number; scope: string }),
+    }))
+
+    const overall = progress.filter((p) => p.scope === 'overall_estimate')
+    const own = progress.filter((p) => p.scope === 'own_task')
+
+    expect(overall.length).toBeGreaterThan(0)
+    expect(own.length).toBeGreaterThan(0)
+    // Every orchestrator estimate is reported by the root; own_task never is.
+    expect(new Set(overall.map((p) => p.agentId)).size).toBe(1)
+    expect(own.some((p) => p.agentId === overall[0]?.agentId)).toBe(false)
+    // The two scopes must be distinguishable at a glance, not accidentally equal.
+    for (const estimate of overall) {
+      expect(own.some((p) => p.percent === estimate.percent)).toBe(false)
+    }
+  })
+
+  it('reports several distinct statuses', () => {
+    const statuses = new Set(
+      eventsOf('agent.status_reported').map((event) => (event.payload as { status: string }).status),
+    )
+    expect(statuses.size).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('architecture snapshot', () => {
+  it('nests components at least three levels deep', () => {
+    const parents = new Map<string, string | null>(
+      snapshot.components.map((component) => [component.componentId, component.parentComponentId]),
+    )
+    const depths = snapshot.components.map((component) => depthOf(component.componentId, parents))
+    expect(Math.max(...depths)).toBeGreaterThanOrEqual(3)
+  })
+
+  it('references only components contained in the same model', () => {
+    const known = new Set(snapshot.components.map((component) => component.componentId))
+    for (const component of snapshot.components) {
+      if (component.parentComponentId !== null) {
+        expect(known).toContain(component.parentComponentId)
+      }
+    }
+    for (const relationship of snapshot.relationships) {
+      expect(known).toContain(relationship.targetComponentId)
+    }
+  })
+
+  it('uses every relationship kind of the contract', () => {
+    const kinds = new Set(snapshot.relationships.map((relationship) => relationship.kind))
+    expect([...kinds].sort()).toEqual(
+      ['async', 'data', 'dependency', 'grpc', 'http', 'nats_topic'].sort(),
+    )
+  })
+
+  it('models at least two separate NATS topics', () => {
+    const channels = new Set(
+      snapshot.relationships
+        .filter((relationship) => relationship.kind === 'nats_topic')
+        .map((relationship) => relationship.channel),
+    )
+    expect(channels.size).toBeGreaterThanOrEqual(2)
+  })
+
+  it('fans one topic out to two consumers as two separate relationships', () => {
+    const perChannel = new Map<string, number>()
+    for (const relationship of snapshot.relationships) {
+      if (relationship.kind !== 'nats_topic' || !relationship.channel) continue
+      perChannel.set(relationship.channel, (perChannel.get(relationship.channel) ?? 0) + 1)
+    }
+    // publisher + two consumers on the same channel, never merged into one edge
+    expect(Math.max(...perChannel.values())).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('changes', () => {
+  const planned = [...eventsOf('component.change_planned'), ...eventsOf('relationship.change_planned')]
+  const applied = [...eventsOf('component.change_applied'), ...eventsOf('relationship.change_applied')]
+
+  it('plans component and relationship changes and applies them under the same changeId', () => {
+    expect(eventsOf('component.change_planned').length).toBeGreaterThan(0)
+    expect(eventsOf('relationship.change_planned').length).toBeGreaterThan(0)
+
+    const plannedIds = new Set(planned.map((event) => (event.payload as { changeId: string }).changeId))
+    const appliedIds = new Set(applied.map((event) => (event.payload as { changeId?: string }).changeId))
+
+    expect(appliedIds.size).toBeGreaterThan(0)
+    for (const id of appliedIds) {
+      expect(plannedIds).toContain(id)
+    }
+  })
+
+  it('applies every change only after it was planned', () => {
+    const seen = new Set<string>()
+    for (const step of scenario.steps) {
+      const changeId = (step.event.payload as { changeId?: string }).changeId
+      if (!changeId) continue
+      if (step.event.type.endsWith('.change_planned')) {
+        seen.add(changeId)
+      } else if (step.event.type.endsWith('.change_applied')) {
+        expect(seen, `${changeId} applied without being planned`).toContain(changeId)
+      }
+    }
+  })
+
+  it('removes a component and a relationship', () => {
+    const removals = applied.filter(
+      (event) => (event.payload as { operation: string }).operation === 'remove',
+    )
+    expect(removals.length).toBeGreaterThanOrEqual(2)
+    expect(removals.some((event) => 'component' in (event.payload as object))).toBe(true)
+    expect(removals.some((event) => 'relationship' in (event.payload as object))).toBe(true)
+  })
+
+  it('retracts a planned change that was never applied', () => {
+    const retractions = eventsOf('retraction.issued')
+    expect(retractions).toHaveLength(1)
+
+    const target = (retractions[0]?.payload as { retractsClientEventId: string })
+      .retractsClientEventId
+    const retracted = scenario.steps.find((step) => step.event.clientEventId === target)?.event
+
+    expect(retracted?.type).toMatch(/\.change_planned$/)
+    const changeId = (retracted?.payload as { changeId: string }).changeId
+    expect(applied.some((event) => (event.payload as { changeId?: string }).changeId === changeId)).toBe(
+      false,
+    )
+  })
+
+  it('ends the run with a component and a relationship proposal still pending', () => {
+    const settled = new Set<string>()
+    for (const event of applied) {
+      const changeId = (event.payload as { changeId?: string }).changeId
+      if (changeId) settled.add(changeId)
+    }
+    for (const retraction of eventsOf('retraction.issued')) {
+      const target = (retraction.payload as { retractsClientEventId: string }).retractsClientEventId
+      const original = scenario.steps.find((step) => step.event.clientEventId === target)?.event
+      const changeId = (original?.payload as { changeId?: string } | undefined)?.changeId
+      if (changeId) settled.add(changeId)
+    }
+
+    // Neither applied nor retracted: the cockpit's `activeChanges` must still
+    // hold something once the run goes quiet.
+    const pending = planned.filter(
+      (event) => !settled.has((event.payload as { changeId: string }).changeId),
+    )
+    expect(pending.some((event) => event.type === 'component.change_planned')).toBe(true)
+    expect(pending.some((event) => event.type === 'relationship.change_planned')).toBe(true)
+  })
+
+  it('corrects an earlier event instead of rewriting it', () => {
+    const corrections = eventsOf('correction.issued')
+    expect(corrections.length).toBeGreaterThan(0)
+
+    for (const correction of corrections) {
+      const payload = correction.payload as { correctsClientEventId: string; correctedType: string }
+      const original = scenario.steps.find(
+        (step) => step.event.clientEventId === payload.correctsClientEventId,
+      )?.event
+      expect(original?.type).toBe(payload.correctedType)
+    }
+  })
+})
+
+describe('component evidence', () => {
+  it('reports at least four single-file unified diffs', () => {
+    const diffs = eventsOf('diff.reported')
+    expect(diffs.length).toBeGreaterThanOrEqual(4)
+
+    for (const diff of diffs) {
+      const payload = diff.payload as { filePath: string; unifiedDiff: string }
+      expect(payload.filePath.startsWith('/')).toBe(false)
+      expect(payload.unifiedDiff).toContain('--- ')
+      expect(payload.unifiedDiff).toContain('+++ ')
+      expect(payload.unifiedDiff).toContain('@@')
+    }
+  })
+
+  it('groups several diffs under one changeId', () => {
+    const perChange = new Map<string, number>()
+    for (const diff of eventsOf('diff.reported')) {
+      const changeId = (diff.payload as { changeId?: string }).changeId
+      if (!changeId) continue
+      perChange.set(changeId, (perChange.get(changeId) ?? 0) + 1)
+    }
+    expect(Math.max(...perChange.values())).toBeGreaterThanOrEqual(3)
+  })
+
+  it('publishes real markdown feedback for several components', () => {
+    const feedback = eventsOf('feedback.published')
+    expect(feedback.length).toBeGreaterThanOrEqual(2)
+
+    const components = new Set<string>()
+    for (const event of feedback) {
+      const payload = event.payload as { componentIds: string[]; format: string; body: string }
+      expect(payload.format).toBe('markdown')
+      payload.componentIds.forEach((id) => components.add(id))
+      expect(payload.body).toMatch(/^## /m)
+      expect(payload.body).toMatch(/^[-*\d]/m)
+      expect(payload.body).toMatch(/`[^`\n]+`/)
+    }
+    expect(components.size).toBeGreaterThanOrEqual(3)
+    // At least one body carries a fenced code block.
+    expect(
+      feedback.some((event) => (event.payload as { body: string }).body.includes('```')),
+    ).toBe(true)
+  })
+
+  it('reports a risk and a problem', () => {
+    expect(eventsOf('risk.reported').length).toBeGreaterThan(0)
+    expect(eventsOf('problem.reported').length).toBeGreaterThan(0)
+  })
+})
+
+describe('plan', () => {
+  it('publishes a revision of the same plan', () => {
+    const plans = eventsOf('plan.published').map(
+      (event) => event.payload as { planId: string; revision: number },
+    )
+    expect(plans.length).toBeGreaterThanOrEqual(2)
+    expect(new Set(plans.map((plan) => plan.planId)).size).toBe(1)
+    expect(plans.map((plan) => plan.revision)).toEqual([1, 2])
+  })
+
+  it('updates steps of the published plan', () => {
+    const published = eventsOf('plan.published').flatMap((event) =>
+      (event.payload as { steps: { stepId: string }[] }).steps.map((step) => step.stepId),
+    )
+    const updates = eventsOf('plan.step_updated')
+
+    expect(updates.length).toBeGreaterThan(0)
+    for (const update of updates) {
+      expect(published).toContain((update.payload as { stepId: string }).stepId)
+    }
+  })
+
+  it('links work steps to plan steps and completes what it starts', () => {
+    const started = eventsOf('work.step_started').map(
+      (event) => event.payload as { workStepId: string; planStepId?: string },
+    )
+    const completed = new Set(
+      eventsOf('work.step_completed').map(
+        (event) => (event.payload as { workStepId: string }).workStepId,
+      ),
+    )
+
+    expect(started.length).toBeGreaterThan(0)
+    for (const step of started) {
+      expect(completed, `${step.workStepId} was never completed`).toContain(step.workStepId)
+      expect(step.planStepId).toBeDefined()
+    }
+  })
+})

--- a/simulator/test/determinism.test.ts
+++ b/simulator/test/determinism.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { BASE_INSTANT_MS } from '../src/clock.js'
+import {
+  buildConflictScenario,
+  buildFullScenario,
+  buildRetryScenario,
+  DEFAULT_PROJECT_IDS,
+} from '../src/scenarios/index.js'
+import { DEFAULT_OPTIONS } from '../src/options.js'
+
+const base = {
+  projectId: DEFAULT_PROJECT_IDS.full,
+  runId: 'run-2026-08-04-0001',
+  seed: DEFAULT_OPTIONS.seed,
+}
+
+describe('determinism', () => {
+  it('produces byte-identical envelopes for two builds with the same seed', () => {
+    const first = buildFullScenario({ ...base, finish: true })
+    const second = buildFullScenario({ ...base, finish: true })
+
+    expect(second.steps.map((s) => s.event)).toEqual(first.steps.map((s) => s.event))
+    // The pacing is seeded too, so even the pauses repeat.
+    expect(second.steps.map((s) => s.pauseMs)).toEqual(first.steps.map((s) => s.pauseMs))
+  })
+
+  it('is stable across the retry and conflict scenarios as well', () => {
+    expect(buildRetryScenario({ ...base, runId: 'run-2026-08-04-0002' }).steps).toEqual(
+      buildRetryScenario({ ...base, runId: 'run-2026-08-04-0002' }).steps,
+    )
+    expect(buildConflictScenario({ ...base, runId: 'run-2026-08-04-0003' }).steps).toEqual(
+      buildConflictScenario({ ...base, runId: 'run-2026-08-04-0003' }).steps,
+    )
+  })
+
+  it('changes every client event id when the seed changes', () => {
+    const a = buildFullScenario({ ...base, finish: true })
+    const b = buildFullScenario({ ...base, seed: base.seed + 1, finish: true })
+
+    const idsA = a.steps.map((s) => s.event.clientEventId)
+    const idsB = b.steps.map((s) => s.event.clientEventId)
+    expect(idsB).toHaveLength(idsA.length)
+    expect(idsB.some((id, index) => id === idsA[index])).toBe(false)
+  })
+
+  it('gives the three scenarios disjoint client event ids under one seed', () => {
+    const full = buildFullScenario({ ...base, finish: true })
+    const retry = buildRetryScenario({ ...base, runId: 'run-2026-08-04-0002' })
+    const conflict = buildConflictScenario({ ...base, runId: 'run-2026-08-04-0003' })
+
+    const ids = [full, retry, conflict].flatMap((scenario) =>
+      // The deliberate duplicates of retry/conflict are excluded: they repeat an
+      // id on purpose.
+      [...new Set(scenario.steps.map((s) => s.event.clientEventId))],
+    )
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('draws every client event id as a distinct UUIDv4', () => {
+    const scenario = buildFullScenario({ ...base, finish: true })
+    const ids = scenario.steps.map((s) => s.event.clientEventId)
+
+    for (const id of ids) {
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    }
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('reports a strictly increasing timeline anchored to the contract base date', () => {
+    const scenario = buildFullScenario({ ...base, finish: true })
+    const times = scenario.steps.map((s) => Date.parse(s.event.occurredAt))
+
+    expect(times[0]).toBeGreaterThan(BASE_INSTANT_MS)
+    for (let i = 1; i < times.length; i += 1) {
+      expect(times[i]).toBeGreaterThan(times[i - 1] as number)
+    }
+    // No wall clock anywhere: the whole run stays inside the simulated day.
+    expect(times.at(-1)).toBeLessThan(BASE_INSTANT_MS + 24 * 60 * 60 * 1000)
+  })
+})

--- a/simulator/test/lifecycle.test.ts
+++ b/simulator/test/lifecycle.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The preconditions the backend enforces inside the append transaction
+ * (ADR 0004). Getting them wrong turns a demo run into a wall of `422`s, so they
+ * are asserted on the generated sequence rather than discovered at runtime.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_OPTIONS } from '../src/options.js'
+import {
+  buildConflictScenario,
+  buildFullScenario,
+  buildRetryScenario,
+  DEFAULT_PROJECT_IDS,
+} from '../src/scenarios/index.js'
+import type { Scenario } from '../src/types.js'
+
+const base = {
+  projectId: DEFAULT_PROJECT_IDS.full,
+  runId: 'run-2026-08-04-0001',
+  seed: DEFAULT_OPTIONS.seed,
+}
+
+const scenarios: [string, Scenario][] = [
+  ['full', buildFullScenario({ ...base, finish: true })],
+  ['retry', buildRetryScenario({ ...base, runId: 'run-2026-08-04-0002' })],
+  ['conflict', buildConflictScenario({ ...base, runId: 'run-2026-08-04-0003' })],
+]
+
+describe.each(scenarios)('lifecycle preconditions of the %s scenario', (_, scenario) => {
+  it('opens the run with exactly one root orchestrator', () => {
+    const roots = scenario.steps.filter(
+      (step) =>
+        step.event.type === 'agent.started' &&
+        step.event.parentAgentId === null &&
+        (step.event.payload as { role?: string }).role === 'orchestrator',
+    )
+
+    expect(roots).toHaveLength(1)
+    expect(scenario.steps[0]?.event).toBe(roots[0]?.event)
+  })
+
+  it('reports agent.started before any other event of that agent', () => {
+    const started = new Set<string>()
+    for (const step of scenario.steps) {
+      const { agentId, type } = step.event
+      if (type === 'agent.started') {
+        started.add(agentId)
+        continue
+      }
+      expect(started, `${agentId} reported ${type} before agent.started`).toContain(agentId)
+    }
+  })
+
+  it('names only already started agents as parentAgentId', () => {
+    const started = new Set<string>()
+    for (const step of scenario.steps) {
+      const { agentId, parentAgentId, type } = step.event
+      if (parentAgentId !== null) {
+        expect(started, `parent ${parentAgentId} of ${agentId} never started`).toContain(
+          parentAgentId,
+        )
+      }
+      if (type === 'agent.started') started.add(agentId)
+    }
+  })
+
+  it('keeps every event inside one project and one run', () => {
+    for (const step of scenario.steps) {
+      expect(step.event.projectId).toBe(scenario.projectId)
+      expect(step.event.runId).toBe(scenario.runId)
+    }
+  })
+
+  it('corrects and retracts only events that were sent earlier', () => {
+    const seen = new Set<string>()
+    for (const step of scenario.steps) {
+      const payload = step.event.payload as Record<string, unknown>
+      const target = payload.correctsClientEventId ?? payload.retractsClientEventId
+      if (typeof target === 'string') {
+        expect(seen, `${step.event.type} refers to an unsent event`).toContain(target)
+      }
+      seen.add(step.event.clientEventId)
+    }
+  })
+
+  it('sends run.finished only from the run orchestrator, and last', () => {
+    const terminal = scenario.steps.findIndex((step) => step.event.type === 'run.finished')
+    if (terminal === -1) return
+
+    expect(terminal).toBe(scenario.steps.length - 1)
+    expect(scenario.steps[terminal]?.event.agentId).toBe(scenario.steps[0]?.event.agentId)
+  })
+})
+
+describe('the full scenario leaves the run open by default', () => {
+  it('omits run.finished unless --finish is given', () => {
+    const open = buildFullScenario({ ...base, finish: false })
+    expect(open.steps.some((step) => step.event.type === 'run.finished')).toBe(false)
+  })
+
+  it('appends run.finished as the only extra event when --finish is given', () => {
+    const open = buildFullScenario({ ...base, finish: false })
+    const closed = buildFullScenario({ ...base, finish: true })
+
+    expect(closed.steps).toHaveLength(open.steps.length + 1)
+    expect(closed.steps.slice(0, open.steps.length).map((s) => s.event)).toEqual(
+      open.steps.map((s) => s.event),
+    )
+    expect(closed.steps.at(-1)?.event.type).toBe('run.finished')
+  })
+})

--- a/simulator/test/options.test.ts
+++ b/simulator/test/options.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_OPTIONS, OptionsError, parseOptions } from '../src/options.js'
+import { buildScenario, DEFAULT_PROJECT_IDS, DEFAULT_RUN_IDS } from '../src/scenarios/index.js'
+
+const parse = (line: string) => parseOptions(line.split(' ').filter(Boolean))
+
+describe('options', () => {
+  it('defaults to the full scenario against localhost:8080 with an open run', () => {
+    expect(parse('')).toEqual(DEFAULT_OPTIONS)
+  })
+
+  it('reads every documented flag', () => {
+    expect(
+      parse('--base http://localhost:8091 --project demo-project --run run-x --speed 0 --scenario retry --seed 7 --finish true --json'),
+    ).toEqual({
+      baseUrl: 'http://localhost:8091',
+      projectId: 'demo-project' as string | null,
+      runId: 'run-x',
+      speed: 0,
+      scenario: 'retry',
+      seed: 7,
+      finish: true,
+      json: true,
+    })
+  })
+
+  it('treats a bare --finish as true', () => {
+    expect(parse('--finish')?.finish).toBe(true)
+    expect(parse('--finish false')?.finish).toBe(false)
+  })
+
+  it('strips a trailing slash from the base url', () => {
+    expect(parse('--base http://localhost:8091/')?.baseUrl).toBe('http://localhost:8091')
+  })
+
+  it('returns null for --help', () => {
+    expect(parse('--help')).toBeNull()
+  })
+
+  it.each([
+    ['--scenario nonsense', /--scenario/],
+    ['--speed -1', /--speed/],
+    ['--seed abc', /--seed/],
+    ['--base localhost:8091', /--base/],
+    ['--base http://localhost:8091/api', /--base/],
+    ['--unknown', /unknown option/],
+    ['--project', /requires a value/],
+  ])('rejects %s', (line, message) => {
+    expect(() => parse(line)).toThrow(OptionsError)
+    expect(() => parse(line)).toThrow(message)
+  })
+
+  it('gives each scenario its own project and run id by default', () => {
+    expect(new Set(Object.values(DEFAULT_RUN_IDS)).size).toBe(Object.keys(DEFAULT_RUN_IDS).length)
+    expect(new Set(Object.values(DEFAULT_PROJECT_IDS)).size).toBe(
+      Object.keys(DEFAULT_PROJECT_IDS).length,
+    )
+
+    for (const scenario of ['full', 'retry', 'conflict'] as const) {
+      const options = parse(`--scenario ${scenario}`)
+      expect(options).not.toBeNull()
+      expect(buildScenario(options!).runId).toBe(DEFAULT_RUN_IDS[scenario])
+      expect(buildScenario(options!).projectId).toBe(DEFAULT_PROJECT_IDS[scenario])
+    }
+  })
+
+  it('is stable across repeated invocations', () => {
+    expect(buildScenario(parse('')!).projectId).toBe(buildScenario(parse('')!).projectId)
+    expect(buildScenario(parse('')!).projectId).toBe(DEFAULT_PROJECT_IDS.full)
+  })
+
+  it('lets --run and --project override the scenario defaults', () => {
+    const options = parse('--scenario full --run run-override --project project-override')
+    expect(buildScenario(options!).runId).toBe('run-override')
+    expect(buildScenario(options!).projectId).toBe('project-override')
+  })
+})

--- a/simulator/test/runner.test.ts
+++ b/simulator/test/runner.test.ts
@@ -1,0 +1,203 @@
+/**
+ * The runner's assertions, exercised against a stub of the ingestion endpoint.
+ *
+ * A simulator that reports success when the server misbehaves is worse than no
+ * simulator, so the negative cases matter more than the happy path here.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { loadContract } from '../src/contract.js'
+import { DEFAULT_OPTIONS } from '../src/options.js'
+import { EVENTS_PATH, RunAbortedError, runScenario } from '../src/runner.js'
+import {
+  buildConflictScenario,
+  buildFullScenario,
+  buildRetryScenario,
+  DEFAULT_PROJECT_IDS,
+} from '../src/scenarios/index.js'
+import type { EventEnvelope, Scenario } from '../src/types.js'
+
+const contract = loadContract()
+const base = {
+  projectId: DEFAULT_PROJECT_IDS.full,
+  runId: 'run-2026-08-04-0001',
+  seed: DEFAULT_OPTIONS.seed,
+}
+
+interface StubOptions {
+  /** Answer the second delivery of a known id with a fresh position instead. */
+  reallocatePositionOnRetry?: boolean
+  /** Accept a conflicting redelivery instead of refusing it. */
+  acceptConflicts?: boolean
+}
+
+/**
+ * A minimal stand-in for `POST /api/v1/events`: it allocates positions, resolves
+ * idempotency on the exact request body and refuses a reused id with different
+ * content — the three behaviours the scenarios assert.
+ */
+function stubBackend(options: StubOptions = {}): typeof fetch {
+  const byClientEventId = new Map<string, { position: number; body: string }>()
+  let position = 0
+
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    const body = String(init?.body ?? '')
+    const event = JSON.parse(body) as EventEnvelope
+    const known = byClientEventId.get(event.clientEventId)
+    const respond = (status: number, payload: unknown): Response =>
+      new Response(JSON.stringify(payload), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      })
+
+    if (known && known.body === body) {
+      const assigned = options.reallocatePositionOnRetry ? (position += 1) : known.position
+      return respond(200, {
+        projectId: event.projectId,
+        position: assigned,
+        serverEventId: '00000000-0000-4000-8000-000000000001',
+        clientEventId: event.clientEventId,
+        duplicate: true,
+        receivedAt: '2026-08-04T09:00:00Z',
+      })
+    }
+
+    if (known && !options.acceptConflicts) {
+      return respond(409, {
+        type: 'https://visualise-ai.local/problems/client-event-id-conflict',
+        title: 'Client event id conflict',
+        status: 409,
+        detail: `clientEventId ${event.clientEventId} was already accepted`,
+        code: 'client_event_id_conflict',
+        instance: String(url),
+      })
+    }
+
+    position += 1
+    byClientEventId.set(event.clientEventId, { position, body })
+    return respond(201, {
+      projectId: event.projectId,
+      position,
+      serverEventId: '00000000-0000-4000-8000-000000000002',
+      clientEventId: event.clientEventId,
+      duplicate: false,
+      receivedAt: '2026-08-04T09:00:00Z',
+    })
+  }) as unknown as typeof fetch
+}
+
+const run = (scenario: Scenario, fetchImpl: typeof fetch) =>
+  runScenario(scenario, contract, {
+    baseUrl: 'http://localhost:8091',
+    speed: 0,
+    quietStdout: true,
+    silent: true,
+    fetchImpl,
+    sleep: async () => {},
+  })
+
+describe('runner', () => {
+  it('sends the full scenario and summarises it', async () => {
+    const scenario = buildFullScenario({ ...base, finish: true })
+    const summary = await run(scenario, stubBackend())
+
+    expect(summary.eventsSent).toBe(scenario.steps.length)
+    expect(summary.created).toBe(scenario.steps.length)
+    expect(summary.duplicates).toBe(0)
+    expect(summary.endPosition).toBe(scenario.steps.length)
+    expect(summary.projectUrl).toBe(`http://localhost:8091/projects/${scenario.projectId}`)
+  })
+
+  it('targets only the public ingestion route', async () => {
+    const seen: string[] = []
+    const backend = stubBackend()
+    const spy = ((url: string, init?: RequestInit) => {
+      seen.push(String(url))
+      return backend(url, init)
+    }) as unknown as typeof fetch
+
+    await run(buildRetryScenario({ ...base, runId: 'run-2026-08-04-0002' }), spy)
+
+    expect(new Set(seen)).toEqual(new Set([`http://localhost:8091${EVENTS_PATH}`]))
+  })
+
+  it('accepts a retry that repeats the original position', async () => {
+    const summary = await run(
+      buildRetryScenario({ ...base, runId: 'run-2026-08-04-0002' }),
+      stubBackend(),
+    )
+
+    expect(summary.duplicates).toBe(1)
+    expect(summary.created).toBe(2)
+    // The retry must not have moved the project forward.
+    expect(summary.endPosition).toBe(2)
+  })
+
+  it('aborts when a retry is given a new position', async () => {
+    await expect(
+      run(
+        buildRetryScenario({ ...base, runId: 'run-2026-08-04-0002' }),
+        stubBackend({ reallocatePositionOnRetry: true }),
+      ),
+    ).rejects.toThrow(RunAbortedError)
+  })
+
+  it('accepts the expected conflict', async () => {
+    const summary = await run(
+      buildConflictScenario({ ...base, runId: 'run-2026-08-04-0003' }),
+      stubBackend(),
+    )
+
+    expect(summary.conflicts).toBe(1)
+    expect(summary.created).toBe(2)
+  })
+
+  it('aborts when a conflicting redelivery is accepted instead of refused', async () => {
+    await expect(
+      run(
+        buildConflictScenario({ ...base, runId: 'run-2026-08-04-0003' }),
+        stubBackend({ acceptConflicts: true }),
+      ),
+    ).rejects.toThrow(RunAbortedError)
+  })
+
+  it('aborts on an unexpected status and names the event', async () => {
+    const failing = (() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            status: 422,
+            code: 'unknown_agent',
+            detail: 'agent "x" never reported agent.started',
+          }),
+          { status: 422, headers: { 'content-type': 'application/json' } },
+        ),
+      )) as unknown as typeof fetch
+
+    await expect(run(buildFullScenario({ ...base, finish: false }), failing)).rejects.toThrow(
+      /unknown_agent/,
+    )
+  })
+
+  it('aborts when the endpoint is unreachable', async () => {
+    const offline = (() => Promise.reject(new Error('ECONNREFUSED'))) as unknown as typeof fetch
+
+    await expect(run(buildFullScenario({ ...base, finish: false }), offline)).rejects.toThrow(
+      /ECONNREFUSED/,
+    )
+  })
+
+  it('aborts when the acknowledgement does not match the contract', async () => {
+    const malformed = (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ position: 1 }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )) as unknown as typeof fetch
+
+    await expect(run(buildFullScenario({ ...base, finish: false }), malformed)).rejects.toThrow(
+      /EventAccepted/,
+    )
+  })
+})

--- a/simulator/tsconfig.json
+++ b/simulator/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src", "test", "eslint.config.js"]
+}


### PR DESCRIPTION
## Summary

Adds `simulator/`, a deterministic Node/TypeScript developer and test client that
reports a complete, representative agent run through the published contract.
A fresh database leaves the cockpit empty; this is what fills it, and what the
mandatory Playwright acceptance run (#14) will drive.

The simulator talks to exactly one URL — `<base>/api/v1/events`, the public Nginx
route. It has no knowledge of internal ports and none of the database. A runner
test asserts that no other URL is ever requested.

Node rather than Go on purpose: the consumer is the Playwright suite of #14,
which is Node and must be able to start the simulator directly, with no compiled
binary and no container in between. Recorded in
[ADR 0007](docs/decisions/0007-deterministic-event-simulator.md).

Nothing under `backend/`, `frontend/` or `api/` was touched.

## Usage

```bash
cd simulator
npm install
npm run simulate                            # http://localhost:8080
npm run simulate -- --base http://localhost:8091
npm run simulate -- --speed 0               # no pauses, for CI/E2E
npm run simulate -- --scenario retry
npm run simulate -- --scenario conflict
npm run simulate -- --json                  # machine-readable summary on stdout
```

Flags: `--base`, `--project`, `--run`, `--speed`, `--scenario`, `--seed`,
`--finish`, `--json`, `--help`.

`--speed` is a pause **multiplier**, not a rate: `1` is the normal watchable
pace, `0` removes every pause, `2` doubles them. A rate would have made `0` mean
"divide by zero".

## Scenario overview

| Scenario | Project | Run | Events | Proves |
| --- | --- | --- | --- | --- |
| `full` | `visualise-ai` | `run-2026-08-04-0001` | 62 | The representative run |
| `retry` | `visualise-ai-retry` | `run-2026-08-04-0002` | 3 | `201`, then `200 duplicate: true` with the **same** position |
| `conflict` | `visualise-ai-conflict` | `run-2026-08-04-0003` | 3 | `409 client_event_id_conflict` |

Each probe writes into its own project. Per ADR 0005 `runs/current` resolves to
the run a root orchestrator opened last, so a probe sent into the demo project
would silently become the cockpit's current run and empty every default component
inspector — this was observed during development and is why they are separated.

The `full` run contains:

1. New project and root orchestrator (`role: orchestrator`, `parentAgentId: null`).
2. **Four parallel subagents, tree depth 3** — the reviewer and the test engineer
   are delegated by the *implementer*, not by the root.
3. **A 17-component snapshot, four hierarchy levels**
   (`shop-platform` → `orders` → `domain` → `pricing`), 11 relationships covering
   all six kinds, **two separate NATS topics**, and `orders.order.created` fanned
   out to **two consumers as two distinct relationships sharing one `channel`**.
4. `plan.published` revision 1 (4 steps), then **revision 2** (5 steps), plus two
   `plan.step_updated`.
5. Four work steps, each started and completed, each linked to a plan step.
6. `agent.progress_reported` — subagents `own_task` (40/65/80/100 %), the
   orchestrator `overall_estimate` (20/70 %). Never the same number.
7. `agent.status_reported` in all five states: `working`, `blocked`, `waiting`,
   `done`, `idle`.
8. Two `feedback.published` bodies of **real markdown** — headings, ordered and
   unordered lists, a task list, a table, inline code and a fenced Go block.
9. `risk.reported` and `problem.reported`.
10. **Planned and applied kept apart**: `component.change_planned` →
    `component.change_applied` under the same `changeId`, same for relationships,
    including two `operation: remove` (the legacy VAT module and its edge), plus
    **two proposals deliberately left pending** so `activeChanges` is non-empty
    once the run goes quiet.
11. **Five single-file unified diffs**, three of them sharing
    `change-2026-08-04-0007` so the inspector grouping of #12 is testable, one
    without a `changeId` so the ungrouped case exists too. Real `---`/`+++`/`@@`
    hunks.
12. `correction.issued` on an earlier `diff.reported` and `retraction.issued` on a
    planned relationship change that is consequently never applied.
13. `run.finished` **only** with `--finish true`. Default is an open run: it is
    optional by contract, no state is derived from silence, and an unterminated
    run is the more honest cockpit state.

## Determinism

* Client event ids are UUIDv4-shaped values drawn from a seeded mulberry32
  stream; `occurredAt` comes from a virtual clock anchored to the contract's
  example date. Ids, pauses and the clock are **three separate streams**, so
  re-pacing a phase cannot change an event's identity.
* `Math.random`, `Date.now` and `crypto.randomUUID` are banned by
  `no-restricted-properties` in `simulator/eslint.config.js`, each with a message
  naming the seeded replacement. Determinism is enforced by the linter, not by
  discipline.

### Proof: two runs against two fresh databases

```
docker compose -p … down -v && docker compose -p … up -d      # empty database
npm run simulate -- --base http://localhost:8091 --speed 0 --json           > run1-full.json
npm run simulate -- --base http://localhost:8091 --speed 0 --scenario retry --json    > run1-retry.json
npm run simulate -- --base http://localhost:8091 --speed 0 --scenario conflict --json > run1-conflict.json
node capture.mjs http://localhost:8091 visualise-ai run1-readmodels.json    # 19 projections, 48 history entries
# …down -v, up -d, repeat as run2…
```

`capture.mjs` reads every projection back — projects, project, architecture,
runs, run, agents, plans, and the inspector plus full paged history of six
components — and strips only the two fields the server stamps at receive time
(`serverEventId`, `receivedAt`). Positions are **kept**, because they are part of
the claim.

```
=== json summaries ===
IDENTICAL  full
IDENTICAL  retry
IDENTICAL  conflict
=== read models ===
IDENTICAL  read models (19 projections, 48 history entries, server receive fields stripped)
```

The unit suite additionally deep-equals the generated envelopes for two builds
with the same seed, asserts that a different seed changes **every** id, and that
the three scenarios draw disjoint ids under one seed.

## Contract conformance

Every envelope is validated against `api/openapi.yaml` **before** it is sent —
same approach as `api/scripts/validate-examples.mjs`: parse, register every
component schema under its canonical `$ref`, compile with Ajv 2020, format
assertions on. A violation aborts the process; it never reaches the network.

That fixes the meaning of a failure: if the simulator runs, whatever it sent was
contract legal, so a rejection is a statement about the *server*.

As in ADR 0004, the contract's own `discriminator.mapping` selects the single
branch first (so one bad field does not report the failures of 19 branches nobody
meant) and `IngestEventRequest` is the authoritative gate afterwards.

No bundling step: `api/openapi.yaml` has no external `$ref`, so the document is
read directly rather than depending on the git-ignored `api/dist/` bundle. The
contract is located by walking up from the module.

Responses are checked too — `EventAccepted` against the schema, plus the expected
status, `duplicate` flag and, for the retry, the **same** position. Anything else
aborts with the event, the status, the `code` and the `detail` printed.

## Tests

```
$ npm run lint && npm run typecheck && npm test

 ✓ test/coverage.test.ts (22 tests)
 ✓ test/options.test.ts (15 tests)
 ✓ test/determinism.test.ts (6 tests)
 ✓ test/lifecycle.test.ts (20 tests)
 ✓ test/catalogue.test.ts (3 tests)
 ✓ test/contract.test.ts (7 tests)
 ✓ test/runner.test.ts (9 tests)

 Test Files  7 passed (7)
      Tests  82 passed (82)
```

| File | Covers |
| --- | --- |
| `determinism.test.ts` | Deep-equal envelopes across builds, seed sensitivity, disjoint scenarios, UUIDv4 shape, strictly increasing simulated timeline |
| `contract.test.ts` | Every event of all three scenarios validates as `IngestEventRequest`; a smuggled payload field, an off-catalogue type and a non-UUID id are refused |
| `lifecycle.test.ts` | Exactly one root orchestrator and it is first; every agent started before its first other event; every `parentAgentId` already started; correction/retraction targets already sent; one project and run per scenario; `run.finished` last and orchestrator-only |
| `catalogue.test.ts` | Reads `EventType` **from the contract** and proves all 20 types are reported |
| `coverage.test.ts` | The #14 requirements: ≥3 subagents, tree depth ≥3, ≥3 hierarchy levels, all six relationship kinds, ≥2 NATS topics with a ≥2-consumer fan-out, ≥4 diffs with ≥3 grouped, planned+applied+removed+retracted+pending, markdown feedback structure, plan revision, work steps completed |
| `runner.test.ts` | Against a stub backend: only `/api/v1/events` is requested; a retry given a **new** position aborts; an accepted conflict aborts; an unexpected status, an unreachable endpoint and a malformed acknowledgement all abort |
| `options.test.ts` | Every documented flag, the defaults, and rejection of bad values |

### The one documented catalogue exception

`catalogue.test.ts` asserts all 20 types are covered with `--finish true`, and
separately that the default run omits **exactly** `run.finished` and nothing
else:

```ts
it('leaves exactly one documented type out of the default run', () => {
  const missing = contract.eventTypes.filter((type) => !typesOf(false).has(type))
  expect(missing).toEqual(['run.finished'])
})
```

`run.finished` is optional by contract; leaving the run open is the state that
demonstrates that the cockpit derives nothing from silence.

## Integration run against the real Compose system

`FRONTEND_HTTP_PORT=8091`, own Compose project name, empty database.
Ports 8080–8083 belong to an unrelated project and were not touched.

```
$ docker compose -p visualise-ai-sim13 down -v && docker compose -p visualise-ai-sim13 up --build -d
$ cd simulator && npm run simulate -- --base http://localhost:8091 --speed 0

simulator: scenario full, project visualise-ai, run run-2026-08-04-0001
           target http://localhost:8091/api/v1/events
           contract …/api/openapi.yaml (v1.1.0), 62 events

── Run start ─────────────────────────────────────────────────
     1  201  agent.started                   orchestrator-root             —
     2  201  agent.status_reported           orchestrator-root             —

── Subagents spawn ───────────────────────────────────────────
     3  201  agent.started                   subagent-architecture-mapper  —
     4  201  agent.started                   subagent-implementer          —
     5  201  agent.started                   subagent-reviewer             —
     6  201  agent.started                   subagent-test-engineer        —

── Architecture snapshot ─────────────────────────────────────
     7  201  agent.status_reported           subagent-architecture-mapper  —
     8  201  work.step_started               subagent-architecture-mapper  shop-platform, shop-platform.orders, shop-platform.orders.domain +2 more
     9  201  architecture.snapshot_published subagent-architecture-mapper  shop-platform, shop-platform.storefront, shop-platform.api-gateway +14 more
    10  201  work.step_completed             subagent-architecture-mapper  —
    11  201  agent.progress_reported         subagent-architecture-mapper  —

── Plan ──────────────────────────────────────────────────────
    12  201  plan.published                  orchestrator-root             shop-platform, shop-platform.orders.domain.pricing, shop-platform.orders.domain.tax
    13  201  agent.progress_reported         orchestrator-root             —

── Proposed changes ──────────────────────────────────────────
    14  201  component.change_planned        subagent-architecture-mapper  shop-platform.orders.domain.tax
    15  201  relationship.change_planned     subagent-architecture-mapper  shop-platform.orders.domain.pricing, shop-platform.orders.domain.tax
    16  201  component.change_planned        subagent-architecture-mapper  shop-platform.orders.domain.legacy-tax-rates
    17  201  relationship.change_planned     subagent-architecture-mapper  shop-platform.orders.domain.pricing, shop-platform.orders.domain.legacy-tax-rates
    18  201  relationship.change_planned     subagent-architecture-mapper  shop-platform.notifications, shop-platform.orders.api

── Implementation ────────────────────────────────────────────
    19  201  agent.status_reported           subagent-implementer          —
    20  201  work.step_started               subagent-implementer          shop-platform.orders.domain.pricing, shop-platform.orders.domain.tax, shop-platform.orders.domain.legacy-tax-rates
    21  201  diff.reported                   subagent-implementer          shop-platform.orders.domain.pricing
    22  201  diff.reported                   subagent-implementer          shop-platform.orders.domain.tax
    23  201  diff.reported                   subagent-implementer          shop-platform.orders.domain.tax
    24  201  agent.progress_reported         subagent-implementer          —
    25  201  correction.issued               subagent-implementer          shop-platform.orders.domain.pricing, shop-platform.orders.domain.tax
    26  201  diff.reported                   subagent-implementer          shop-platform.orders.domain.legacy-tax-rates
    27  201  diff.reported                   subagent-implementer          shop-platform.notifications

── Applied changes ───────────────────────────────────────────
    28  201  component.change_applied        subagent-architecture-mapper  shop-platform.orders.domain.tax
    29  201  relationship.change_applied     subagent-architecture-mapper  shop-platform.orders.domain.pricing, shop-platform.orders.domain.tax
    30  201  relationship.change_applied     subagent-architecture-mapper  shop-platform.orders.domain.pricing, shop-platform.orders.domain.legacy-tax-rates
    31  201  component.change_applied        subagent-architecture-mapper  shop-platform.orders.domain.legacy-tax-rates
    32  201  retraction.issued               subagent-architecture-mapper  —

── Review ────────────────────────────────────────────────────
    33  201  agent.status_reported           subagent-reviewer             —
    34  201  work.step_started               subagent-reviewer             shop-platform.orders.domain.pricing, shop-platform.orders.domain.tax
    35  201  feedback.published              subagent-reviewer             shop-platform.orders.domain.pricing, shop-platform.orders.domain.tax
    36  201  feedback.published              subagent-reviewer             shop-platform.notifications, shop-platform.events.order-created
    37  201  risk.reported                   subagent-reviewer             shop-platform.orders.domain.pricing, shop-platform.orders.domain.tax
    38  201  problem.reported                subagent-reviewer             shop-platform.notifications
    39  201  agent.progress_reported         subagent-reviewer             —
    40  201  work.step_completed             subagent-reviewer             —
    41  201  agent.status_reported           subagent-reviewer             —

── Tests ─────────────────────────────────────────────────────
    42  201  agent.status_reported           subagent-test-engineer        —
    43  201  work.step_started               subagent-test-engineer        shop-platform.orders.domain.tax
    44  201  agent.status_reported           subagent-test-engineer        —
    45  201  work.step_completed             subagent-test-engineer        —
    46  201  agent.progress_reported         subagent-test-engineer        —
    47  201  agent.status_reported           subagent-test-engineer        —
    48  201  agent.finished                  subagent-test-engineer        —

── Plan revision ─────────────────────────────────────────────
    49  201  plan.published                  orchestrator-root             shop-platform, shop-platform.orders.domain.pricing, shop-platform.orders.domain.tax +1 more
    50  201  plan.step_updated               orchestrator-root             —
    51  201  plan.step_updated               orchestrator-root             —
    52  201  agent.progress_reported         orchestrator-root             —

── Open proposals ────────────────────────────────────────────
    53  201  component.change_planned        subagent-architecture-mapper  shop-platform.orders.domain.rounding
    54  201  relationship.change_planned     subagent-architecture-mapper  shop-platform.orders.domain.tax, shop-platform.orders.domain.rounding

── Wind down ─────────────────────────────────────────────────
    55  201  agent.status_reported           subagent-reviewer             —
    56  201  agent.finished                  subagent-reviewer             —
    57  201  work.step_completed             subagent-implementer          —
    58  201  agent.status_reported           subagent-implementer          —
    59  201  agent.finished                  subagent-implementer          —
    60  201  agent.status_reported           subagent-architecture-mapper  —
    61  201  agent.finished                  subagent-architecture-mapper  —
    62  201  agent.status_reported           orchestrator-root             —

Summary
  scenario        full
  project         visualise-ai
  run             run-2026-08-04-0001
  events sent     62
  created (201)   62
  duplicate (200) 0
  conflict (409)  0
  end position    62
  open            http://localhost:8091/projects/visualise-ai
```

### Retry and conflict

```
$ npm run simulate -- --base http://localhost:8091 --scenario retry --speed 0

── First delivery ────────────────────────────────────────────
     2  201  agent.status_reported           orchestrator-retry            —

── Byte-identical redelivery ─────────────────────────────────
     2  200  agent.status_reported           orchestrator-retry            —
                ↑ same position, duplicate: true

  events sent     3
  created (201)   2
  duplicate (200) 1
  end position    2
```

```
$ npm run simulate -- --base http://localhost:8091 --scenario conflict --speed 0

── First delivery ────────────────────────────────────────────
     2  201  agent.status_reported           orchestrator-conflict         —

── Same id, different payload ────────────────────────────────
     —  409  agent.status_reported           orchestrator-conflict         —
                ↑ code client_event_id_conflict

  conflict (409)  1
  end position    2
```

### Read-API spot checks after the run

```
projects: visualise-ai (current run run-2026-08-04-0001, last position 62)
          visualise-ai-conflict (current run run-2026-08-04-0003, last position 2)
          visualise-ai-retry (current run run-2026-08-04-0002, last position 2)

counts: {"runs":1,"openRuns":1,"components":17,"relationships":11,"activeChanges":2}

architecture: components 17 relationships 11 activeChanges 2
activeChanges: change-2026-08-04-0013 add planned relationship
             | change-2026-08-04-0012 add planned component
max component depth: 4
relationship kinds: async, data, dependency, grpc, http, nats_topic
nats channels: {"orders.order.created":3,"inventory.item.reserved":2}

agents (current run):
   orchestrator-root            | parent -                    | status idle | progress  70% overall_estimate | outcome -
   subagent-architecture-mapper | parent orchestrator-root    | status done | progress  40% own_task         | outcome completed
   subagent-implementer         | parent orchestrator-root    | status done | progress  65% own_task         | outcome completed
   subagent-reviewer            | parent subagent-implementer | status done | progress  80% own_task         | outcome completed
   subagent-test-engineer       | parent subagent-implementer | status done | progress 100% own_task         | outcome completed

current run: run-2026-08-04-0001 isOpen true finishedAt null counts {"agents":5,"plans":1,"workSteps":4}
plans: plan-2026-08-04-0001 currentRevision 2 revisions 1(4 steps),2(5 steps)

inspector shop-platform.orders.domain.tax : feedback 1 diffs 3 risks 1 problems 0
  diff changeIds ["change-2026-08-04-0007","change-2026-08-04-0007","change-2026-08-04-0007"]
inspector shop-platform.notifications      : feedback 1 diffs 1 risks 0 problems 1
  diff changeIds [null]

legacy history (newest first): 49 plan.published, 31 component.change_applied,
  30 relationship.change_applied, 26 diff.reported, 20 work.step_started,
  17 relationship.change_planned, 16 component.change_planned,
  9 architecture.snapshot_published
removed component inspector -> component is null (evidence survives)
```

Note the third diff on the tax component: it is the *pricing* diff, reaching the
tax inspector because `correction.issued` re-scoped it. The correction was
projected without the original being rewritten — the history above still shows
both.

Cleaned up with `docker compose -p visualise-ai-sim13 down -v`.

## Deviations and open points

* **Per-scenario default project ids.** The brief asked for one stable default
  project id. `full` keeps `visualise-ai`; `retry` and `conflict` were moved to
  `visualise-ai-retry` / `visualise-ai-conflict` after observing that a probe run
  sent into the demo project becomes `runs/current` and empties every default
  component inspector. Each id is still fixed per scenario, and `--project`
  overrides all three.
* **Two extra pending proposals** were added beyond the brief so the run ends
  with a non-empty `activeChanges`. Without them the `planned` overlay state of
  #10 would only ever be visible while the simulator is mid-flight.
* **The determinism proof reads projections, not the SSE replay.** `/stream`
  (#6) is not merged yet, so the round trip goes through the read API — including
  the full paged component history, which carries the stored payloads verbatim.
  Once #6 lands, the same proof can be shortened to one replay from position 0.
* **The scenarios assume an empty database.** A second run against a populated
  one legitimately answers `200 duplicate` throughout, which is correct behaviour
  but not what the probes assert. `docker compose down -v` is part of the
  procedure and is documented in `simulator/README.md`.
* The simulated architecture, diffs and feedback are invented. v0 has no
  repository access and the contract states `unifiedDiff` is taken as reported.

Closes #13
