### PR TITLE
[v0] SSE-Livestream mit positionsbasiertem Replay implementieren

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -278,6 +278,8 @@ paths:
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/StreamedEvent'
+        '400':
+          $ref: '#/components/responses/InvalidQueryParameter'
         '404':
           $ref: '#/components/responses/ProjectNotFound'
 
@@ -875,6 +877,13 @@ components:
         Last server-side project position the client has already processed. Replay starts at
         `lastEventPosition + 1`. Use `0` to replay the whole project from the beginning.
         Takes precedence over the `Last-Event-ID` header.
+
+        A value that cannot be used as a cursor is rejected with `400`
+        (`invalid_query_parameter`) rather than silently ignored, because a client that spells
+        its own cursor wrongly must not believe it received a gap-free replay. An unusable
+        `Last-Event-ID` header is ignored instead: browsers set it automatically and a stream
+        that refuses to open would be worse than one that starts live. A position beyond the
+        end of the log is clamped to the current end.
       schema:
         type: integer
         format: int64

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/risqyy/visualise-ai/backend/internal/ingest"
 	"github.com/risqyy/visualise-ai/backend/internal/logging"
 	"github.com/risqyy/visualise-ai/backend/internal/readapi"
+	"github.com/risqyy/visualise-ai/backend/internal/sse"
 	"github.com/risqyy/visualise-ai/backend/internal/store"
 )
 
@@ -60,11 +61,15 @@ func run() error {
 		return database.Ping(ctx, db)
 	})
 
-	// The publisher stays a no-op until the SSE broker replaces it; ingestion
-	// does not depend on anyone listening.
+	// The broker is the single publisher of the instance: ingestion calls it
+	// once per committed event, and every open SSE connection fans out from it.
+	// It is process-local by design — v0 runs exactly one backend, and anything
+	// a subscriber misses is replayed from PostgreSQL rather than from memory.
+	broker := sse.NewBroker(sse.BrokerOptions{Logger: logger})
+
 	ingestHandler, err := ingest.NewHandler(ingest.HandlerOptions{
 		Store:         store.New(db),
-		Publisher:     ingest.NopPublisher{},
+		Publisher:     broker,
 		MaxEventBytes: cfg.MaxEventBytes,
 		Logger:        logger,
 	})
@@ -78,6 +83,11 @@ func run() error {
 		Version: version,
 		Ingest:  ingestHandler,
 		Read:    readapi.New(db),
+		Stream: sse.NewHandler(sse.HandlerOptions{
+			Broker: broker,
+			Reader: sse.NewEventReader(db),
+			Logger: logger,
+		}),
 	})
 
 	server := &http.Server{
@@ -109,6 +119,13 @@ func run() error {
 	}
 
 	checker.MarkNotBootstrapped()
+
+	// Every open stream blocks on its subscription, so an SSE connection never
+	// goes idle on its own and Shutdown would wait for the full timeout. Ending
+	// the subscriptions first closes the streams in an orderly way and lets the
+	// in-flight read and write requests drain normally.
+	logger.Info().Int("streams", broker.Subscribers()).Msg("closing open event streams")
+	broker.Shutdown()
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
 	defer cancel()

--- a/backend/internal/httpapi/router.go
+++ b/backend/internal/httpapi/router.go
@@ -1,8 +1,7 @@
 // Package httpapi wires the Gin HTTP surface of the backend.
 //
-// v0 exposes exactly two internal probe routes plus the versioned API prefix
-// that later work packages fill with event ingestion, the read models and the
-// SSE stream.
+// v0 exposes two internal probe routes plus the versioned API prefix carrying
+// event ingestion, the read models and the SSE stream.
 package httpapi
 
 import (
@@ -16,6 +15,7 @@ import (
 	"github.com/risqyy/visualise-ai/backend/internal/health"
 	"github.com/risqyy/visualise-ai/backend/internal/ingest"
 	"github.com/risqyy/visualise-ai/backend/internal/readapi"
+	"github.com/risqyy/visualise-ai/backend/internal/sse"
 )
 
 // APIPrefix is the single versioned prefix Nginx proxies to the backend.
@@ -34,6 +34,9 @@ type Options struct {
 	// Read serves the project scoped read models. A nil value leaves the read
 	// routes unmounted, which keeps the probe-only router usable in tests.
 	Read *readapi.Service
+	// Stream serves the project SSE endpoint. Nil leaves the route
+	// unregistered, so a router without a broker stays usable in tests.
+	Stream *sse.Handler
 }
 
 // New builds the Gin engine.
@@ -53,6 +56,7 @@ func New(opts Options) *gin.Engine {
 
 	registerIngestRoutes(engine, opts.Ingest)
 	registerRead(engine, opts.Read, opts.Logger)
+	registerStream(engine, opts.Stream)
 
 	engine.NoRoute(notFoundHandler())
 

--- a/backend/internal/httpapi/stream.go
+++ b/backend/internal/httpapi/stream.go
@@ -1,0 +1,25 @@
+package httpapi
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/risqyy/visualise-ai/backend/internal/sse"
+)
+
+// registerStream mounts the Server-Sent Events endpoint of one project.
+//
+// The handler is optional so a router can be built without a broker — the
+// probe-only and read-only routers of the tests do exactly that. A nil handler
+// leaves the route unregistered, where the router answers 404 as for any other
+// unknown route.
+//
+// The route reuses the `:projectId` wildcard of the read models on purpose:
+// Gin keeps a single wildcard name per position in its routing tree, so a
+// differently named parameter at the same position panics while the engine is
+// being built, not when the first request arrives.
+func registerStream(engine *gin.Engine, handler *sse.Handler) {
+	if handler == nil {
+		return
+	}
+	engine.Group(APIPrefix).GET(sse.Path, handler.Stream)
+}

--- a/backend/internal/httpapi/stream_test.go
+++ b/backend/internal/httpapi/stream_test.go
@@ -1,0 +1,58 @@
+package httpapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/risqyy/visualise-ai/backend/internal/health"
+	"github.com/risqyy/visualise-ai/backend/internal/readapi"
+	"github.com/risqyy/visualise-ai/backend/internal/sse"
+)
+
+// TestStreamAndReadModelsShareOneWildcardName guards the one failure mode of
+// this registration that no request can ever surface: Gin keeps a single
+// wildcard name per position in its routing tree, so a stream route registered
+// as `/projects/:id/stream` next to the read models' `/projects/:projectId/…`
+// panics while the engine is being built.
+//
+// Building the router with both mounted is therefore the whole test — it would
+// panic before returning.
+func TestStreamAndReadModelsShareOneWildcardName(t *testing.T) {
+	checker := health.NewChecker(func(context.Context) error { return nil })
+	checker.MarkBootstrapped()
+
+	engine := New(Options{
+		Logger:  zerolog.New(io.Discard),
+		Health:  checker,
+		Version: "test",
+		// A nil gorm handle is enough: nothing here issues a query, the routes
+		// only have to be registered.
+		Read:   readapi.New(nil),
+		Stream: sse.NewHandler(sse.HandlerOptions{}),
+	})
+
+	var found bool
+	for _, route := range engine.Routes() {
+		if route.Method == http.MethodGet && route.Path == APIPrefix+"/projects/:projectId/stream" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the stream route is not registered: %v", engine.Routes())
+	}
+}
+
+// TestStreamRouteIsOptional keeps the probe-only router usable: without a
+// handler the route simply does not exist.
+func TestStreamRouteIsOptional(t *testing.T) {
+	_, handler := newTestRouter(func(context.Context) error { return nil }, true)
+
+	rec := do(t, handler, http.MethodGet, APIPrefix+"/projects/demo/stream")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404 without a stream handler, got %d", rec.Code)
+	}
+}

--- a/backend/internal/ingest/contract/openapi.yaml
+++ b/backend/internal/ingest/contract/openapi.yaml
@@ -278,6 +278,8 @@ paths:
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/StreamedEvent'
+        '400':
+          $ref: '#/components/responses/InvalidQueryParameter'
         '404':
           $ref: '#/components/responses/ProjectNotFound'
 
@@ -875,6 +877,13 @@ components:
         Last server-side project position the client has already processed. Replay starts at
         `lastEventPosition + 1`. Use `0` to replay the whole project from the beginning.
         Takes precedence over the `Last-Event-ID` header.
+
+        A value that cannot be used as a cursor is rejected with `400`
+        (`invalid_query_parameter`) rather than silently ignored, because a client that spells
+        its own cursor wrongly must not believe it received a gap-free replay. An unusable
+        `Last-Event-ID` header is ignored instead: browsers set it automatically and a stream
+        that refuses to open would be worse than one that starts live. A position beyond the
+        end of the log is clamped to the current end.
       schema:
         type: integer
         format: int64

--- a/backend/internal/ingest/handler.go
+++ b/backend/internal/ingest/handler.go
@@ -446,7 +446,15 @@ func (h *Handler) fail(c *gin.Context, err error, what string) {
 }
 
 // committedEvent assembles what the publisher receives.
+//
+// The payload comes from the store, not from the request: the store keeps the
+// canonical form, so a live SSE frame and the same event replayed from the log
+// are byte-identical instead of differing in object key order.
 func committedEvent(env store.Envelope, result store.Result) CommittedEvent {
+	payload := result.Payload
+	if payload == nil {
+		payload = env.Payload
+	}
 	return CommittedEvent{
 		SchemaVersion: env.SchemaVersion,
 		ClientEventID: env.ClientEventID,
@@ -456,7 +464,7 @@ func committedEvent(env store.Envelope, result store.Result) CommittedEvent {
 		ParentAgentID: env.ParentAgentID,
 		OccurredAt:    env.OccurredAt.UTC(),
 		Type:          env.Type,
-		Payload:       env.Payload,
+		Payload:       payload,
 		Position:      result.Position,
 		ServerEventID: result.ServerEventID,
 		ReceivedAt:    result.ReceivedAt.UTC(),

--- a/backend/internal/sse/broker.go
+++ b/backend/internal/sse/broker.go
@@ -1,0 +1,220 @@
+// Package sse serves the project event stream of the cockpit: gap-free replay
+// out of PostgreSQL followed seamlessly by the live tail.
+//
+// The package owns three collaborating pieces:
+//
+//   - Broker — the in-process fan-out. It implements ingest.Publisher and is
+//     therefore called once per committed event, after the append transaction
+//     and never before.
+//   - EventReader — the paged read-back of the log, which is what makes a
+//     reconnect after a backend restart possible at all.
+//   - Handler — one goroutine per connection that combines the two into a
+//     single, strictly increasing, duplicate-free position sequence.
+//
+// The stream is deliberately single-instance. v0 runs exactly one backend
+// (see ADR 0001), so a process-local broker is the whole realtime layer: no
+// message broker, no Redis, no cross-instance fan-out. Durability is not the
+// broker's job either — every event a subscriber could miss is already in
+// PostgreSQL, and the replay path is what recovers it.
+package sse
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/rs/zerolog"
+
+	"github.com/risqyy/visualise-ai/backend/internal/ingest"
+)
+
+// DefaultSubscriberBuffer is how many committed events one connection may fall
+// behind before the broker gives up on it.
+//
+// The number is a backpressure budget, not a delivery guarantee. Published
+// events are semantic work steps, not raw tool calls, so a project produces
+// events at a human-readable rate; 256 of them is far more than a connection
+// can accumulate while a browser tab is descheduled or a replay page is being
+// read. Choosing it much larger would only trade a fast, recoverable
+// disconnect for a slowly growing per-connection backlog, and choosing it much
+// smaller would drop connections during ordinary bursts.
+//
+// Overflow is never silent: the subscription is dropped, the connection ends
+// and the client reconnects with Last-Event-ID, which replays the gap from
+// PostgreSQL. Losing an event is therefore impossible; the cost of a slow
+// client is one reconnect, never a stalled broker.
+const DefaultSubscriberBuffer = 256
+
+// Broker fans committed events out to the SSE connections of this instance.
+//
+// It is the single implementation of ingest.Publisher in production, so every
+// event it hands out is committed, positioned and durable.
+type Broker struct {
+	logger zerolog.Logger
+	buffer int
+
+	mu       sync.Mutex
+	projects map[string]map[*Subscription]struct{}
+	shutdown bool
+}
+
+// BrokerOptions carries the settings of a Broker.
+type BrokerOptions struct {
+	// Logger records the connections the broker gives up on.
+	Logger zerolog.Logger
+	// Buffer is the per subscriber channel capacity. Zero selects
+	// DefaultSubscriberBuffer.
+	Buffer int
+}
+
+// NewBroker returns a Broker ready to accept subscribers.
+func NewBroker(opts BrokerOptions) *Broker {
+	buffer := opts.Buffer
+	if buffer <= 0 {
+		buffer = DefaultSubscriberBuffer
+	}
+	return &Broker{
+		logger:   opts.Logger,
+		buffer:   buffer,
+		projects: make(map[string]map[*Subscription]struct{}),
+	}
+}
+
+// Subscription is one connection's view of the live tail of a project.
+//
+// Events arrive on Events(). Closed() reports that the broker will not deliver
+// anything else — either because the connection handler unsubscribed, because
+// the subscriber fell too far behind, or because the process is shutting down.
+type Subscription struct {
+	broker    *Broker
+	projectID string
+	events    chan ingest.CommittedEvent
+	closed    chan struct{}
+	once      sync.Once
+	overflow  atomic.Bool
+}
+
+// Events is the live tail. The channel is never closed; use Closed to learn
+// that the subscription ended.
+func (s *Subscription) Events() <-chan ingest.CommittedEvent { return s.events }
+
+// Closed is closed once the broker stopped serving this subscription.
+func (s *Subscription) Closed() <-chan struct{} { return s.closed }
+
+// Overflowed reports whether the subscription ended because the connection did
+// not keep up with the buffer.
+func (s *Subscription) Overflowed() bool { return s.overflow.Load() }
+
+// Close unsubscribes. It is idempotent, so a handler can defer it even when the
+// broker already dropped the subscription.
+func (s *Subscription) Close() {
+	s.broker.mu.Lock()
+	defer s.broker.mu.Unlock()
+	s.broker.detachLocked(s)
+}
+
+// Subscribe registers a listener for one project.
+//
+// A subscription registered on an already shut down broker comes back closed,
+// so a connection that raced the shutdown terminates instead of hanging.
+func (b *Broker) Subscribe(projectID string) *Subscription {
+	sub := &Subscription{
+		broker:    b,
+		projectID: projectID,
+		events:    make(chan ingest.CommittedEvent, b.buffer),
+		closed:    make(chan struct{}),
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.shutdown {
+		sub.once.Do(func() { close(sub.closed) })
+		return sub
+	}
+	subscribers, ok := b.projects[projectID]
+	if !ok {
+		subscribers = make(map[*Subscription]struct{})
+		b.projects[projectID] = subscribers
+	}
+	subscribers[sub] = struct{}{}
+	return sub
+}
+
+// Publish implements ingest.Publisher.
+//
+// The ingesting request waits for this call, so it must not block: every send
+// is non-blocking, and a subscriber whose buffer is full is dropped rather than
+// waited for. One slow browser can therefore never slow down ingestion or any
+// other subscriber of the same project.
+//
+// The context is unused on purpose. Cancelling the ingesting request must not
+// cancel the fan-out of an event that is already committed.
+func (b *Broker) Publish(_ context.Context, event ingest.CommittedEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for sub := range b.projects[event.ProjectID] {
+		select {
+		case sub.events <- event:
+		default:
+			sub.overflow.Store(true)
+			b.detachLocked(sub)
+			b.logger.Warn().
+				Str("projectId", event.ProjectID).
+				Int64("position", event.Position).
+				Int("buffer", b.buffer).
+				Msg("sse subscriber fell behind; dropping the connection so it reconnects and replays")
+		}
+	}
+}
+
+// Shutdown ends every open subscription.
+//
+// It is what lets http.Server.Shutdown finish: a stream handler blocks on its
+// subscription, so the connection only becomes idle once the subscription is
+// closed. Calling it before Shutdown turns an otherwise indefinite wait into an
+// immediate, orderly close of every stream.
+func (b *Broker) Shutdown() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.shutdown = true
+	for _, subscribers := range b.projects {
+		for sub := range subscribers {
+			b.detachLocked(sub)
+		}
+	}
+}
+
+// SubscriberCount reports how many connections currently listen to a project.
+// It is the observable the shutdown log and the leak tests read.
+func (b *Broker) SubscriberCount(projectID string) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.projects[projectID])
+}
+
+// Subscribers reports how many connections are open across every project.
+func (b *Broker) Subscribers() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	total := 0
+	for _, subscribers := range b.projects {
+		total += len(subscribers)
+	}
+	return total
+}
+
+// detachLocked removes a subscription and signals its end. The caller holds the
+// mutex. Deleting from the map while Publish ranges over it is safe.
+func (b *Broker) detachLocked(sub *Subscription) {
+	if subscribers, ok := b.projects[sub.projectID]; ok {
+		delete(subscribers, sub)
+		if len(subscribers) == 0 {
+			delete(b.projects, sub.projectID)
+		}
+	}
+	sub.once.Do(func() { close(sub.closed) })
+}

--- a/backend/internal/sse/broker_test.go
+++ b/backend/internal/sse/broker_test.go
@@ -1,0 +1,146 @@
+package sse
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/risqyy/visualise-ai/backend/internal/ingest"
+)
+
+// The broker owns no database, so these tests need none either: they run on any
+// machine and cover the fan-out rules the stream tests take for granted.
+
+func testBroker(buffer int) *Broker {
+	return NewBroker(BrokerOptions{Logger: zerolog.Nop(), Buffer: buffer})
+}
+
+func event(projectID string, position int64) ingest.CommittedEvent {
+	return ingest.CommittedEvent{ProjectID: projectID, Position: position, Type: "agent.status_reported"}
+}
+
+// receive takes one event off a subscription or fails.
+func receive(t *testing.T, sub *Subscription) ingest.CommittedEvent {
+	t.Helper()
+	select {
+	case got := <-sub.Events():
+		return got
+	case <-time.After(time.Second):
+		t.Fatalf("no event within a second")
+		return ingest.CommittedEvent{}
+	}
+}
+
+func TestBrokerFansOutPerProject(t *testing.T) {
+	broker := testBroker(4)
+
+	first := broker.Subscribe("alpha")
+	second := broker.Subscribe("alpha")
+	other := broker.Subscribe("beta")
+
+	if got := broker.SubscriberCount("alpha"); got != 2 {
+		t.Fatalf("alpha holds %d subscribers, want 2", got)
+	}
+
+	broker.Publish(context.Background(), event("alpha", 7))
+
+	if got := receive(t, first); got.Position != 7 {
+		t.Fatalf("the first subscriber received position %d", got.Position)
+	}
+	if got := receive(t, second); got.Position != 7 {
+		t.Fatalf("the second subscriber received position %d", got.Position)
+	}
+	select {
+	case got := <-other.Events():
+		t.Fatalf("a subscriber of beta received %+v", got)
+	default:
+	}
+}
+
+// TestBrokerDropsASubscriberThatFallsBehind is the backpressure rule: the
+// broker gives up on the connection instead of waiting for it, so ingestion and
+// every other subscriber stay unaffected.
+func TestBrokerDropsASubscriberThatFallsBehind(t *testing.T) {
+	broker := testBroker(2)
+	slow := broker.Subscribe("alpha")
+
+	start := time.Now()
+	for position := int64(1); position <= 5; position++ {
+		broker.Publish(context.Background(), event("alpha", position))
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("publishing took %s: the broker waited for the subscriber", elapsed)
+	}
+
+	select {
+	case <-slow.Closed():
+	default:
+		t.Fatalf("the subscriber that never read was not dropped")
+	}
+	if !slow.Overflowed() {
+		t.Fatalf("the dropped subscription does not report the overflow")
+	}
+	if got := broker.SubscriberCount("alpha"); got != 0 {
+		t.Fatalf("alpha still holds %d subscribers after the drop", got)
+	}
+
+	// The broker keeps serving whoever comes next — which, for a real client,
+	// is the same browser reconnecting with its cursor.
+	next := broker.Subscribe("alpha")
+	broker.Publish(context.Background(), event("alpha", 6))
+	if got := receive(t, next); got.Position != 6 {
+		t.Fatalf("the reconnected subscriber received position %d, want 6", got.Position)
+	}
+}
+
+func TestBrokerCloseIsIdempotentAndUnregisters(t *testing.T) {
+	broker := testBroker(4)
+	sub := broker.Subscribe("alpha")
+
+	sub.Close()
+	sub.Close()
+
+	select {
+	case <-sub.Closed():
+	default:
+		t.Fatalf("Close did not end the subscription")
+	}
+	if got := broker.Subscribers(); got != 0 {
+		t.Fatalf("the broker still holds %d subscribers", got)
+	}
+	// Publishing to nobody must not panic on the emptied project map.
+	broker.Publish(context.Background(), event("alpha", 1))
+}
+
+func TestBrokerShutdownEndsEveryStream(t *testing.T) {
+	broker := testBroker(4)
+	alpha := broker.Subscribe("alpha")
+	beta := broker.Subscribe("beta")
+
+	broker.Shutdown()
+
+	for name, sub := range map[string]*Subscription{"alpha": alpha, "beta": beta} {
+		select {
+		case <-sub.Closed():
+		default:
+			t.Fatalf("the %s subscription survived the shutdown", name)
+		}
+		if sub.Overflowed() {
+			t.Fatalf("the %s subscription reports an overflow after a clean shutdown", name)
+		}
+	}
+	if got := broker.Subscribers(); got != 0 {
+		t.Fatalf("the stopped broker holds %d subscribers", got)
+	}
+
+	// A connection that races the shutdown gets a closed subscription rather
+	// than one that will never be served.
+	late := broker.Subscribe("alpha")
+	select {
+	case <-late.Closed():
+	default:
+		t.Fatalf("subscribing to a stopped broker returned an open subscription")
+	}
+}

--- a/backend/internal/sse/connection.go
+++ b/backend/internal/sse/connection.go
@@ -1,0 +1,94 @@
+package sse
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/risqyy/visualise-ai/backend/internal/ingest"
+
+	"github.com/gin-gonic/gin"
+)
+
+// keepaliveComment is the comment line that keeps proxies from closing an idle
+// stream. Comments carry no `id:`, so they can never move the client cursor.
+const keepaliveComment = ": keepalive\n\n"
+
+// liveOnly is the cursor of a connection that asked for neither Last-Event-ID
+// nor lastEventPosition: it has no baseline to reconcile against and simply
+// starts with the next live event.
+const liveOnly = int64(-1)
+
+// connection is the write side of one SSE stream.
+//
+// lastSent is the whole delivery contract in one field: it is the position of
+// the last frame written to this connection, it is what every candidate event
+// is filtered against, and it is what the client echoes back as Last-Event-ID
+// after a reconnect. Nothing is ever written without advancing it.
+type connection struct {
+	writer   gin.ResponseWriter
+	lastSent int64
+	buf      bytes.Buffer
+}
+
+// newConnection writes the response headers of the stream and returns the
+// writer the replay and the live loop share.
+//
+// The headers are the contract's: `text/event-stream` with caching and proxy
+// buffering switched off. `X-Accel-Buffering: no` is what makes Nginx forward
+// each frame the moment it is written even if a future deployment loses the
+// `proxy_buffering off` in its location block.
+func newConnection(c *gin.Context, lastSent int64) *connection {
+	header := c.Writer.Header()
+	header.Set("Content-Type", "text/event-stream")
+	header.Set("Cache-Control", "no-cache")
+	header.Set("Connection", "keep-alive")
+	header.Set("X-Accel-Buffering", "no")
+
+	c.Writer.WriteHeader(http.StatusOK)
+	c.Writer.Flush()
+
+	return &connection{writer: c.Writer, lastSent: lastSent}
+}
+
+// send writes one event as an SSE frame and flushes it.
+//
+// The frame is the one the contract documents: `id:` is the server-side project
+// position — not the event UUID, which is carried inside the payload as
+// `serverEventId` — `event:` is the catalogue type so a client can subscribe
+// per type, and `data:` is one compact-JSON StreamedEvent.
+func (conn *connection) send(event ingest.CommittedEvent) error {
+	// CommittedEvent is shaped exactly like the contract's StreamedEvent, so
+	// this is the only mapping between the log and the wire.
+	data, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("sse: encoding event at position %d: %w", event.Position, err)
+	}
+
+	conn.buf.Reset()
+	conn.buf.WriteString("id: ")
+	conn.buf.WriteString(strconv.FormatInt(event.Position, 10))
+	conn.buf.WriteString("\nevent: ")
+	conn.buf.WriteString(event.Type)
+	conn.buf.WriteString("\ndata: ")
+	conn.buf.Write(data)
+	conn.buf.WriteString("\n\n")
+
+	if _, err := conn.writer.Write(conn.buf.Bytes()); err != nil {
+		return err
+	}
+	conn.writer.Flush()
+	conn.lastSent = event.Position
+	return nil
+}
+
+// keepalive writes the comment line and flushes it.
+func (conn *connection) keepalive() error {
+	if _, err := conn.writer.WriteString(keepaliveComment); err != nil {
+		return err
+	}
+	conn.writer.Flush()
+	return nil
+}

--- a/backend/internal/sse/problem.go
+++ b/backend/internal/sse/problem.go
@@ -1,0 +1,71 @@
+package sse
+
+import "github.com/gin-gonic/gin"
+
+// problemContentType is the media type RFC 9457 prescribes.
+const problemContentType = "application/problem+json"
+
+// problemTypePrefix namespaces the problem type URIs of this service.
+const problemTypePrefix = "https://visualise-ai.local/problems/"
+
+// Stable, machine-readable error codes of the stream endpoint. The first two
+// are the vocabulary the read models already use for the same situations, so a
+// client branches on one set of codes across the whole project scope.
+const (
+	CodeProjectNotFound       = "project_not_found"
+	CodeInvalidQueryParameter = "invalid_query_parameter"
+	CodeInternalError         = "internal_error"
+)
+
+// fieldError is one rejected query parameter.
+type fieldError struct {
+	Field   string `json:"field"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// problem is an RFC 9457 error document. `errors` is omitted for a plain
+// problem and populated for a validation problem, exactly as the contract
+// defines the two schemas.
+type problem struct {
+	Type   string       `json:"type"`
+	Title  string       `json:"title"`
+	Status int          `json:"status"`
+	Detail string       `json:"detail"`
+	Code   string       `json:"code"`
+	Errors []fieldError `json:"errors,omitempty"`
+}
+
+// writeProblem answers the request with a problem document and stops the chain.
+//
+// It is only ever called before the first byte of the stream is written: once
+// the 200 and the event-stream media type are on the wire there is no status
+// code left to report a failure with, and the connection is closed instead.
+func writeProblem(c *gin.Context, status int, code, title, detail string, errs ...fieldError) {
+	c.Abort()
+	c.Header("Content-Type", problemContentType)
+	c.JSON(status, problem{
+		Type:   problemTypePrefix + problemPath(code),
+		Title:  title,
+		Status: status,
+		Detail: detail,
+		Code:   code,
+		Errors: errs,
+	})
+}
+
+// problemPath turns a snake_case code into the kebab-case slug used in `type`.
+func problemPath(code string) string {
+	out := make([]byte, 0, len(code))
+	for i := 0; i < len(code); i++ {
+		if code[i] == '_' {
+			out = append(out, '-')
+			continue
+		}
+		out = append(out, code[i])
+	}
+	return string(out)
+}
+
+// quoted wraps a value so an identifier stays recognisable inside a sentence.
+func quoted(value string) string { return `"` + value + `"` }

--- a/backend/internal/sse/reader.go
+++ b/backend/internal/sse/reader.go
@@ -1,0 +1,107 @@
+package sse
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+
+	"gorm.io/gorm"
+
+	"github.com/risqyy/visualise-ai/backend/internal/ingest"
+	"github.com/risqyy/visualise-ai/backend/internal/store"
+)
+
+// DefaultReplayPageSize is how many events one replay round trip loads.
+//
+// Replay must never materialise a whole project log in memory, so it pages.
+// 200 rows keeps a page comfortably below a megabyte for ordinary payloads
+// while still amortising the round trip over a useful number of events.
+const DefaultReplayPageSize = 200
+
+// noUpperBound reads a page up to the current end of the log.
+const noUpperBound = int64(math.MaxInt64)
+
+// EventReader reads committed events of one project back out of PostgreSQL.
+//
+// This is what makes the stream survive a backend restart: the broker is
+// process-local and starts empty, but every event it ever published is in the
+// log, ordered by the same position the SSE `id:` carries.
+type EventReader struct {
+	db *gorm.DB
+}
+
+// NewEventReader returns a reader over db.
+func NewEventReader(db *gorm.DB) *EventReader { return &EventReader{db: db} }
+
+// ProjectPosition returns the current end of a project's log, and whether the
+// project exists at all.
+//
+// Both answers come from the same row on purpose. The stream refuses an unknown
+// project rather than opening an endless response that will never carry
+// anything, so a stale deep link is visible instead of silently idle; and it
+// needs the current end to keep a client from resuming beyond it.
+func (r *EventReader) ProjectPosition(ctx context.Context, projectID string) (int64, bool, error) {
+	var project store.Project
+	err := r.db.WithContext(ctx).
+		Where("project_id = ?", projectID).
+		Take(&project).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return 0, false, nil
+	case err != nil:
+		return 0, false, err
+	default:
+		return project.LastPosition, true, nil
+	}
+}
+
+// Page loads at most limit committed events of one project with a position
+// strictly greater than after and at most through, ordered by position.
+//
+// The rows are mapped onto ingest.CommittedEvent — the very type the broker
+// hands out — so replayed and live events are one kind of value and the wire
+// format has exactly one implementation.
+func (r *EventReader) Page(
+	ctx context.Context,
+	projectID string,
+	after, through int64,
+	limit int,
+) ([]ingest.CommittedEvent, error) {
+	var rows []store.Event
+	err := r.db.WithContext(ctx).
+		Where("project_id = ? AND position > ? AND position <= ?", projectID, after, through).
+		Order("position ASC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]ingest.CommittedEvent, 0, len(rows))
+	for _, row := range rows {
+		events = append(events, committedEvent(row))
+	}
+	return events, nil
+}
+
+// committedEvent turns a stored row back into the StreamedEvent envelope.
+//
+// The stored payload is the canonical form the store wrote, which is already
+// compact JSON — exactly what a single `data:` line needs.
+func committedEvent(row store.Event) ingest.CommittedEvent {
+	return ingest.CommittedEvent{
+		SchemaVersion: row.SchemaVersion,
+		ClientEventID: row.ClientEventID,
+		ProjectID:     row.ProjectID,
+		RunID:         row.RunID,
+		AgentID:       row.AgentID,
+		ParentAgentID: row.ParentAgentID,
+		OccurredAt:    row.OccurredAt.UTC(),
+		Type:          row.Type,
+		Payload:       json.RawMessage(row.Payload),
+		Position:      row.Position,
+		ServerEventID: row.ID,
+		ReceivedAt:    row.ReceivedAt.UTC(),
+	}
+}

--- a/backend/internal/sse/stream.go
+++ b/backend/internal/sse/stream.go
@@ -1,0 +1,361 @@
+package sse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+)
+
+// Path is the stream route, relative to the versioned API prefix.
+//
+// The wildcard must be named `:projectId`, exactly as the read models name it.
+// Gin keeps one wildcard name per position in its routing tree, so registering
+// `/projects/:id/stream` next to `/projects/:projectId/architecture` panics at
+// startup rather than at request time.
+const Path = "/projects/:projectId/stream"
+
+// lastEventPositionQuery and lastEventIDHeader are the two ways a client states
+// where it left off.
+const (
+	lastEventPositionQuery = "lastEventPosition"
+	lastEventIDHeader      = "Last-Event-ID"
+)
+
+// DefaultKeepaliveInterval is how often an idle stream emits a comment line.
+//
+// It is well below the read timeout of any ordinary proxy — the Nginx frontend
+// of this deployment allows 24 h — so an idle cockpit keeps its connection
+// without producing noticeable traffic.
+const DefaultKeepaliveInterval = 15 * time.Second
+
+// The two ways the broker, rather than the client, ends a stream.
+var (
+	// errSubscriptionEnded is the orderly case: the process is shutting down.
+	errSubscriptionEnded = errors.New("sse: subscription ended")
+	// errSubscriberTooSlow is the backpressure case. The client reconnects with
+	// its cursor and replays the gap, so no event is lost — but it is worth a
+	// line in the log next to the position the connection had reached.
+	errSubscriberTooSlow = errors.New("sse: subscriber did not keep up with the buffer")
+)
+
+// endReason names why the broker stopped serving a subscription.
+func endReason(sub *Subscription) error {
+	if sub.Overflowed() {
+		return errSubscriberTooSlow
+	}
+	return errSubscriptionEnded
+}
+
+// HandlerOptions carries the collaborators of the stream handler.
+type HandlerOptions struct {
+	// Broker is the live fan-out. Required.
+	Broker *Broker
+	// Reader loads replayed events from PostgreSQL. Required.
+	Reader *EventReader
+	// KeepaliveInterval is the idle comment interval. Zero selects
+	// DefaultKeepaliveInterval.
+	KeepaliveInterval time.Duration
+	// ReplayPageSize bounds one replay round trip. Zero selects
+	// DefaultReplayPageSize.
+	ReplayPageSize int
+	// Logger records what a client cannot be told once the stream is open.
+	Logger zerolog.Logger
+}
+
+// Handler serves GET /api/v1/projects/{projectId}/stream.
+type Handler struct {
+	broker    *Broker
+	reader    *EventReader
+	keepalive time.Duration
+	pageSize  int
+	logger    zerolog.Logger
+}
+
+// NewHandler returns the stream handler.
+func NewHandler(opts HandlerOptions) *Handler {
+	keepalive := opts.KeepaliveInterval
+	if keepalive <= 0 {
+		keepalive = DefaultKeepaliveInterval
+	}
+	pageSize := opts.ReplayPageSize
+	if pageSize <= 0 {
+		pageSize = DefaultReplayPageSize
+	}
+	return &Handler{
+		broker:    opts.Broker,
+		reader:    opts.Reader,
+		keepalive: keepalive,
+		pageSize:  pageSize,
+		logger:    opts.Logger,
+	}
+}
+
+// Stream serves one Server-Sent Events connection.
+//
+// The order of the steps below is the whole correctness argument of this
+// package, so it is worth stating explicitly:
+//
+//  1. Resolve the start position and reject an unknown project — both while a
+//     status code can still be reported.
+//  2. Subscribe to the broker *before* the first database read. From this
+//     moment nothing that commits can be missed: it either shows up in a replay
+//     page or in the subscription.
+//  3. Replay from PostgreSQL until the log is exhausted *and* the subscription
+//     buffer is empty (see replay).
+//  4. Serve the live tail, filtering every event against lastSent.
+//
+// The naive alternatives both fail: reading the database first and subscribing
+// afterwards loses everything that commits in between, and subscribing first
+// while replaying the buffer as-is delivers the overlap twice.
+func (h *Handler) Stream(c *gin.Context) {
+	projectID := c.Param("projectId")
+
+	start, ok := h.startPosition(c)
+	if !ok {
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	head, exists, err := h.reader.ProjectPosition(ctx, projectID)
+	if err != nil {
+		h.logger.Error().Err(err).Str("projectId", projectID).Msg("resolving the streamed project failed")
+		writeProblem(c, http.StatusInternalServerError, CodeInternalError,
+			"Internal Server Error", "The event stream could not be opened.")
+		return
+	}
+	if !exists {
+		writeProblem(c, http.StatusNotFound, CodeProjectNotFound, "Project not found",
+			"No project with id "+quoted(projectID)+" exists.")
+		return
+	}
+	if start > head {
+		// A cursor beyond the end of the log — a stale client after the database
+		// was reset, say. Resuming from it verbatim would filter away every
+		// event until the project caught up again, which looks like a working
+		// but permanently silent stream. Starting at the current end is the
+		// honest interpretation of "everything you have not seen".
+		h.logger.Info().
+			Str("projectId", projectID).
+			Int64("requested", start).
+			Int64("projectPosition", head).
+			Msg("sse client resumed beyond the end of the log")
+		start = head
+	}
+
+	// Subscribing before the first read is what closes the replay-to-live gap.
+	// Everything the publisher hands out from here on is either already in the
+	// pages below or waiting in this subscription.
+	sub := h.broker.Subscribe(projectID)
+	defer sub.Close()
+
+	conn := newConnection(c, start)
+	// The opening comment confirms the stream is established, and it is written
+	// after the subscription exists, so a client that waits for it cannot miss a
+	// live event it should have seen.
+	if err := conn.keepalive(); err != nil {
+		return
+	}
+
+	if start != liveOnly {
+		if err := h.replay(ctx, conn, sub, projectID); err != nil {
+			h.finish(projectID, conn, err)
+			return
+		}
+	}
+	h.finish(projectID, conn, h.live(ctx, conn, sub, projectID))
+}
+
+// replay writes every committed event after conn.lastSent, page by page.
+//
+// The loop ends only when both conditions hold at once: the last page was
+// short, so the log is exhausted, and the subscription buffer is empty, so
+// nothing committed while the page was being read. Either condition alone would
+// leave a window in which an event is neither in a page nor picked up by the
+// live loop.
+//
+// Buffered live events are drained and *discarded* rather than written here.
+// That is safe precisely because the publisher is called after the commit: an
+// event the broker handed out is durable and will be found by the next page.
+// Discarding them also keeps a long replay from overflowing the buffer, which
+// would otherwise drop a connection that is not slow at all — only far behind.
+func (h *Handler) replay(ctx context.Context, conn *connection, sub *Subscription, projectID string) error {
+	for {
+		page, err := h.reader.Page(ctx, projectID, conn.lastSent, noUpperBound, h.pageSize)
+		if err != nil {
+			return err
+		}
+		for _, event := range page {
+			if err := conn.send(event); err != nil {
+				return err
+			}
+		}
+
+		pending := drain(sub, conn.lastSent)
+		if len(page) < h.pageSize && pending == 0 {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-sub.Closed():
+			return endReason(sub)
+		default:
+		}
+	}
+}
+
+// live serves the tail of the stream once the replay caught up.
+//
+// Two filters keep the promise of "every position exactly once, in order":
+// an event at or below lastSent was already written and is dropped, and an
+// event above lastSent+1 means something is missing, which is filled from
+// PostgreSQL before the event itself goes out.
+//
+// The gap is real, not theoretical. Positions are assigned under the project
+// row lock, but Publish is called by the ingesting goroutine after its
+// transaction committed, so two appends can reach the broker in the opposite
+// order. Whatever arrives first, the log has both, and the fill below restores
+// the order the client is promised.
+func (h *Handler) live(ctx context.Context, conn *connection, sub *Subscription, projectID string) error {
+	ticker := time.NewTicker(h.keepalive)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// The client hung up. The deferred Close unsubscribes, so neither a
+			// goroutine nor a channel outlives the connection.
+			return ctx.Err()
+
+		case <-sub.Closed():
+			return endReason(sub)
+
+		case event := <-sub.Events():
+			if conn.lastSent != liveOnly {
+				if event.Position <= conn.lastSent {
+					continue
+				}
+				if event.Position > conn.lastSent+1 {
+					if err := h.fill(ctx, conn, projectID, event.Position-1); err != nil {
+						return err
+					}
+				}
+			}
+			if err := conn.send(event); err != nil {
+				return err
+			}
+
+		case <-ticker.C:
+			if err := conn.keepalive(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// fill writes the events between conn.lastSent and through, both from the log.
+func (h *Handler) fill(ctx context.Context, conn *connection, projectID string, through int64) error {
+	for conn.lastSent < through {
+		page, err := h.reader.Page(ctx, projectID, conn.lastSent, through, h.pageSize)
+		if err != nil {
+			return err
+		}
+		if len(page) == 0 {
+			// Positions are gapless by construction, so an empty page here means
+			// the log disagrees with a position the broker published.
+			return fmt.Errorf("sse: positions %d..%d of project %q are missing from the log",
+				conn.lastSent+1, through, projectID)
+		}
+		for _, event := range page {
+			if err := conn.send(event); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// drain empties the subscription buffer without writing anything and reports
+// how many of the discarded events are still missing from the stream.
+func drain(sub *Subscription, lastSent int64) int {
+	pending := 0
+	for {
+		select {
+		case event := <-sub.Events():
+			if event.Position > lastSent {
+				pending++
+			}
+		default:
+			return pending
+		}
+	}
+}
+
+// startPosition resolves the position the client wants to resume from.
+//
+// `lastEventPosition` wins over `Last-Event-ID` when both are present. The
+// query parameter is set deliberately by a client that persists its own cursor
+// — the simulator, a test, a CLI — while the header is set automatically by the
+// browser's EventSource from the last frame it happened to see. When the two
+// disagree, the explicit statement is the one that reflects what the client
+// actually processed.
+//
+// The two are validated differently for the same reason. A `lastEventPosition`
+// that is not a position is a client defect and is reported as such; a
+// `Last-Event-ID` this server never wrote is ignored, because the header is
+// echoed back through the browser and an intermediary is free to mangle it.
+func (h *Handler) startPosition(c *gin.Context) (int64, bool) {
+	if raw := strings.TrimSpace(c.Query(lastEventPositionQuery)); raw != "" {
+		position, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || position < 0 {
+			writeProblem(c, http.StatusBadRequest, CodeInvalidQueryParameter, "Invalid query parameter",
+				"One or more query parameters of this request are not acceptable.",
+				fieldError{
+					Field:   "/" + lastEventPositionQuery,
+					Code:    "invalid",
+					Message: "want the last processed project position as an integer of at least 0",
+				})
+			return 0, false
+		}
+		return position, true
+	}
+
+	raw := strings.TrimSpace(c.GetHeader(lastEventIDHeader))
+	if raw == "" {
+		return liveOnly, true
+	}
+	position, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || position < 0 {
+		return liveOnly, true
+	}
+	return position, true
+}
+
+// finish logs how a stream ended. The client is already gone or going, so this
+// is an operational record, not an error response.
+func (h *Handler) finish(projectID string, conn *connection, err error) {
+	// A cancelled context is the browser closing the tab and a closed
+	// subscription is the broker or the shutdown ending it: both are the normal
+	// end of a stream, not a failure.
+	switch {
+	case err == nil, errors.Is(err, context.Canceled), errors.Is(err, errSubscriptionEnded):
+		h.logger.Debug().
+			Str("projectId", projectID).
+			Int64("lastSentPosition", conn.lastSent).
+			Msg("sse stream closed")
+	default:
+		h.logger.Warn().Err(err).
+			Str("projectId", projectID).
+			Int64("lastSentPosition", conn.lastSent).
+			Msg("sse stream ended with an error")
+	}
+}

--- a/backend/internal/sse/stream_test.go
+++ b/backend/internal/sse/stream_test.go
@@ -1,6 +1,7 @@
 package sse_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -68,16 +69,20 @@ func TestLiveEventReachesTheStream(t *testing.T) {
 	if event.ReceivedAt.IsZero() || event.OccurredAt.IsZero() {
 		t.Errorf("streamed envelope carries no timestamps: %+v", event)
 	}
-	// The payload travels as reported. A live frame carries the ingested
-	// document and a replayed one the canonical form the store wrote, so the two
-	// may differ in key order — which JSON does not distinguish — but never in
-	// content.
 	assertPayload(t, event.Payload, map[string]any{"status": "working", "note": "Rewriting Total()."})
 
-	// The same event, replayed, carries the same payload.
+	// A live frame and the same event replayed from the log must be
+	// byte-identical, not merely equivalent. Both publish the canonical form
+	// the store wrote, so a client may deduplicate or hash frames without
+	// having to normalise object key order first.
 	replayed := h.connect(streamPath("live-project")+"?lastEventPosition="+strconv.FormatInt(position-1, 10), nil)
 	_, fromLog := replayed.nextEvent()
 	assertPayload(t, fromLog.Payload, map[string]any{"status": "working", "note": "Rewriting Total()."})
+
+	if !bytes.Equal(event.Payload, fromLog.Payload) {
+		t.Errorf("live and replayed payloads differ byte for byte:\n  live:     %s\n  replayed: %s",
+			event.Payload, fromLog.Payload)
+	}
 }
 
 // TestReplayDeliversTheMissingPositions is the reconnect case of the contract:

--- a/backend/internal/sse/stream_test.go
+++ b/backend/internal/sse/stream_test.go
@@ -1,0 +1,505 @@
+package sse_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/risqyy/visualise-ai/backend/internal/sse"
+	"github.com/risqyy/visualise-ai/backend/internal/store"
+)
+
+// streamPath is the endpoint under test.
+func streamPath(projectID string) string {
+	return "/api/v1/projects/" + projectID + "/stream"
+}
+
+// TestLiveEventReachesTheStream covers the plain case: a client connected
+// without a cursor sees the next committed event, with the project position as
+// the SSE id and the catalogue type as the SSE event.
+func TestLiveEventReachesTheStream(t *testing.T) {
+	h := newHarness(t)
+	run := h.openRun("live-project", "run-1")
+
+	client := h.connect(streamPath("live-project"), nil)
+
+	if got := client.header.Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("Content-Type is %q, want text/event-stream", got)
+	}
+	for header, want := range map[string]string{
+		"Cache-Control":     "no-cache",
+		"Connection":        "keep-alive",
+		"X-Accel-Buffering": "no",
+	} {
+		if got := client.header.Get(header); got != want {
+			t.Errorf("%s is %q, want %q", header, got, want)
+		}
+	}
+
+	position := run.note("Rewriting Total().")
+
+	f, event := client.nextEvent()
+	if f.ID != strconv.FormatInt(position, 10) {
+		t.Errorf("SSE id is %q, want the project position %d", f.ID, position)
+	}
+	if f.ID == event.ServerEventID {
+		t.Errorf("SSE id carries the event uuid instead of the project position")
+	}
+	if f.Event != store.TypeAgentStatusReported {
+		t.Errorf("SSE event is %q, want %q", f.Event, store.TypeAgentStatusReported)
+	}
+	if event.Position != position {
+		t.Errorf("streamed position is %d, want %d", event.Position, position)
+	}
+	if event.ProjectID != "live-project" || event.RunID != "run-1" {
+		t.Errorf("streamed envelope is scoped to %s/%s, want live-project/run-1", event.ProjectID, event.RunID)
+	}
+	if event.SchemaVersion != "1.0" || event.ServerEventID == "" || event.ClientEventID == "" {
+		t.Errorf("streamed envelope is incomplete: %+v", event)
+	}
+	if event.ReceivedAt.IsZero() || event.OccurredAt.IsZero() {
+		t.Errorf("streamed envelope carries no timestamps: %+v", event)
+	}
+	// The payload travels as reported. A live frame carries the ingested
+	// document and a replayed one the canonical form the store wrote, so the two
+	// may differ in key order — which JSON does not distinguish — but never in
+	// content.
+	assertPayload(t, event.Payload, map[string]any{"status": "working", "note": "Rewriting Total()."})
+
+	// The same event, replayed, carries the same payload.
+	replayed := h.connect(streamPath("live-project")+"?lastEventPosition="+strconv.FormatInt(position-1, 10), nil)
+	_, fromLog := replayed.nextEvent()
+	assertPayload(t, fromLog.Payload, map[string]any{"status": "working", "note": "Rewriting Total()."})
+}
+
+// TestReplayDeliversTheMissingPositions is the reconnect case of the contract:
+// ten committed events, a client resuming at position 3, exactly 4..10.
+func TestReplayDeliversTheMissingPositions(t *testing.T) {
+	h := newHarness(t)
+	run := h.openRun("replay-project", "run-1")
+	for i := 2; i <= 10; i++ {
+		run.note(fmt.Sprintf("step %d", i))
+	}
+
+	header := http.Header{"Last-Event-ID": []string{"3"}}
+	client := h.connect(streamPath("replay-project"), header)
+
+	events := client.collectUntil(10)
+	assertExactlyOnceInOrder(t, events, 4, 10)
+
+	// Nothing beyond the replayed range may follow on an idle project.
+	for _, f := range client.drainFor(3 * keepaliveInterval) {
+		if f.Data != "" {
+			t.Fatalf("the stream continued past position 10 with %+v", f)
+		}
+	}
+}
+
+// TestLastEventPositionIsEquivalentAndWins covers the second cursor form and
+// the documented precedence between the two.
+func TestLastEventPositionIsEquivalentAndWins(t *testing.T) {
+	h := newHarness(t)
+	run := h.openRun("cursor-project", "run-1")
+	for i := 2; i <= 10; i++ {
+		run.note(fmt.Sprintf("step %d", i))
+	}
+
+	t.Run("query parameter alone", func(t *testing.T) {
+		client := h.connect(streamPath("cursor-project")+"?lastEventPosition=3", nil)
+		assertExactlyOnceInOrder(t, client.collectUntil(10), 4, 10)
+	})
+
+	t.Run("query parameter wins over the header", func(t *testing.T) {
+		header := http.Header{"Last-Event-ID": []string{"8"}}
+		client := h.connect(streamPath("cursor-project")+"?lastEventPosition=3", header)
+		assertExactlyOnceInOrder(t, client.collectUntil(10), 4, 10)
+	})
+
+	t.Run("zero replays the whole project", func(t *testing.T) {
+		client := h.connect(streamPath("cursor-project")+"?lastEventPosition=0", nil)
+		assertExactlyOnceInOrder(t, client.collectUntil(10), 1, 10)
+	})
+
+	t.Run("neither replays nothing", func(t *testing.T) {
+		client := h.connect(streamPath("cursor-project"), nil)
+		for _, f := range client.drainFor(3 * keepaliveInterval) {
+			if f.Data != "" {
+				t.Fatalf("a stream without a cursor replayed %+v", f)
+			}
+		}
+	})
+
+	t.Run("an unusable position is rejected", func(t *testing.T) {
+		problem := h.getProblem(streamPath("cursor-project")+"?lastEventPosition=-1", http.StatusBadRequest)
+		if problem["code"] != "invalid_query_parameter" {
+			t.Fatalf("problem code is %v, want invalid_query_parameter", problem["code"])
+		}
+	})
+
+	t.Run("a position beyond the log starts at the current end", func(t *testing.T) {
+		client := h.connect(streamPath("cursor-project")+"?lastEventPosition=9999", nil)
+		client.assertQuiet(2 * keepaliveInterval)
+
+		// The stream is not silenced by the impossible cursor: the next event
+		// still arrives.
+		last := run.note("after an impossible cursor")
+		_, event := client.nextEvent()
+		if event.Position != last {
+			t.Fatalf("received position %d after an impossible cursor, want %d", event.Position, last)
+		}
+	})
+
+	t.Run("an unusable Last-Event-ID is ignored", func(t *testing.T) {
+		header := http.Header{"Last-Event-ID": []string{"not-a-position"}}
+		client := h.connect(streamPath("cursor-project"), header)
+		for _, f := range client.drainFor(3 * keepaliveInterval) {
+			if f.Data != "" {
+				t.Fatalf("a stream with an unusable header replayed %+v", f)
+			}
+		}
+	})
+}
+
+// TestReplayToLiveTransitionHasNoGapAndNoDuplicate is the core of the issue.
+//
+// A writer keeps committing into the project while a client is replaying it, so
+// new positions are assigned exactly in the window between "the log was read"
+// and "the live tail took over". Each iteration flips the order in which the
+// two start, so the commits land before, during and after the replay.
+//
+// The replay page size is 3, so replaying twelve positions already takes five
+// round trips — the window is wide, not theoretical.
+//
+// The assertion is absolute: every position from the resume point to the last
+// committed one, exactly once, strictly ascending. A handler that reads the
+// database before subscribing loses events here and the collection times out;
+// one that replays its buffer unfiltered delivers the overlap twice and the
+// ordering assertion fails.
+func TestReplayToLiveTransitionHasNoGapAndNoDuplicate(t *testing.T) {
+	const (
+		iterations = 12
+		seeded     = 24
+		concurrent = 24
+	)
+
+	h := newHarness(t)
+
+	for iteration := 0; iteration < iterations; iteration++ {
+		projectID := fmt.Sprintf("race-project-%02d", iteration)
+		run := h.openRun(projectID, "run-1")
+		for i := 2; i <= seeded; i++ {
+			run.note(fmt.Sprintf("seeded %d", i))
+		}
+
+		// Resume from the middle of the seeded range, so the connection has to
+		// replay, catch up and switch to live while the writer is running.
+		resume := int64(seeded / 2)
+		path := streamPath(projectID) + "?lastEventPosition=" + strconv.FormatInt(resume, 10)
+
+		var (
+			wg   sync.WaitGroup
+			last int64
+		)
+		write := func() {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < concurrent; i++ {
+					last = run.note(fmt.Sprintf("concurrent %d", i))
+				}
+			}()
+		}
+
+		var client *streamClient
+		if iteration%2 == 0 {
+			// The writer is already running when the connection opens.
+			write()
+			client = h.connect(path, nil)
+		} else {
+			// The connection is established and about to replay when the first
+			// commit lands.
+			client = h.connect(path, nil)
+			write()
+		}
+		wg.Wait()
+
+		assertExactlyOnceInOrder(t, client.collectUntil(last), resume+1, last)
+		client.assertQuiet(2 * keepaliveInterval)
+		client.close()
+	}
+}
+
+// TestSingleCommitDuringReplayIsNotLost isolates the one failure the transition
+// can produce that nothing repairs afterwards: an event committed inside the
+// window, with no further event behind it to expose the gap.
+//
+// A long history keeps the replay busy for a measurable time, and exactly one
+// event is committed while it runs. A handler that reads the log first and
+// subscribes afterwards drops that event and never learns of it, so this test
+// times out; the implementation subscribes first and ends the replay only when
+// the log *and* the subscription buffer are exhausted.
+func TestSingleCommitDuringReplayIsNotLost(t *testing.T) {
+	const (
+		iterations = 4
+		history    = 400
+	)
+
+	h := newHarness(t)
+
+	for iteration := 0; iteration < iterations; iteration++ {
+		projectID := fmt.Sprintf("window-project-%02d", iteration)
+		run := h.openRun(projectID, "run-1")
+		seeded := run.seedHistory(history)
+
+		client := h.connect(streamPath(projectID)+"?lastEventPosition=0", nil)
+		// The replay is running by now: it has to page through the history three
+		// events at a time.
+		last := run.note("committed while the replay is running")
+		if last != seeded+1 {
+			t.Fatalf("the concurrent commit took position %d, want %d", last, seeded+1)
+		}
+
+		assertExactlyOnceInOrder(t, client.collectUntil(last), 1, last)
+		client.assertQuiet(2 * keepaliveInterval)
+		client.close()
+	}
+}
+
+// TestSeveralSubscribersSeeTheSame covers two browsers watching one project.
+func TestSeveralSubscribersSeeTheSame(t *testing.T) {
+	h := newHarness(t)
+	run := h.openRun("shared-project", "run-1")
+
+	first := h.connect(streamPath("shared-project")+"?lastEventPosition=0", nil)
+	second := h.connect(streamPath("shared-project")+"?lastEventPosition=0", nil)
+	third := h.connect(streamPath("shared-project"), nil)
+
+	if got := h.broker().SubscriberCount("shared-project"); got != 3 {
+		t.Fatalf("broker holds %d subscribers, want 3", got)
+	}
+
+	last := run.note("after both connected")
+
+	assertExactlyOnceInOrder(t, first.collectUntil(last), 1, last)
+	assertExactlyOnceInOrder(t, second.collectUntil(last), 1, last)
+	assertExactlyOnceInOrder(t, third.collectUntil(last), last, last)
+}
+
+// TestProjectsAreIsolated proves a subscriber never sees another project.
+func TestProjectsAreIsolated(t *testing.T) {
+	h := newHarness(t)
+	runA := h.openRun("project-a", "run-1")
+	runB := h.openRun("project-b", "run-1")
+
+	client := h.connect(streamPath("project-a"), nil)
+
+	runB.note("only for b")
+	runB.note("also only for b")
+	positionA := runA.note("for a")
+
+	_, event := client.nextEvent()
+	if event.ProjectID != "project-a" || event.Position != positionA {
+		t.Fatalf("a subscriber of project-a received %s at position %d", event.ProjectID, event.Position)
+	}
+	for _, f := range client.drainFor(3 * keepaliveInterval) {
+		if f.Data != "" {
+			t.Fatalf("a subscriber of project-a received a further frame %+v", f)
+		}
+	}
+}
+
+// TestClientDisconnectUnsubscribes covers the leak: hanging up must remove the
+// subscriber, not leave a goroutine holding a channel.
+func TestClientDisconnectUnsubscribes(t *testing.T) {
+	h := newHarness(t)
+	run := h.openRun("hangup-project", "run-1")
+
+	client := h.connect(streamPath("hangup-project"), nil)
+	if got := h.broker().SubscriberCount("hangup-project"); got != 1 {
+		t.Fatalf("broker holds %d subscribers, want 1", got)
+	}
+
+	client.close()
+
+	eventually(t, "the subscriber to be removed", 5*time.Second, func() bool {
+		return h.broker().SubscriberCount("hangup-project") == 0
+	})
+	if got := h.broker().Subscribers(); got != 0 {
+		t.Fatalf("broker still holds %d subscribers overall", got)
+	}
+
+	// The broker keeps working for everyone else afterwards.
+	next := h.connect(streamPath("hangup-project"), nil)
+	position := run.note("after the hangup")
+	if _, event := next.nextEvent(); event.Position != position {
+		t.Fatalf("the reconnected client received position %d, want %d", event.Position, position)
+	}
+}
+
+// TestKeepaliveCommentIsSent covers the comment line that keeps a proxy from
+// closing an idle connection.
+func TestKeepaliveCommentIsSent(t *testing.T) {
+	h := newHarness(t)
+	h.openRun("idle-project", "run-1")
+
+	client := h.connect(streamPath("idle-project"), nil)
+
+	// The opening comment is already consumed by connect, so these are the
+	// periodic ones.
+	comments := 0
+	for _, f := range client.drainFor(5 * keepaliveInterval) {
+		if f.Comment == "keepalive" {
+			comments++
+		}
+		if f.ID != "" {
+			t.Fatalf("a keepalive frame carries an id: %+v", f)
+		}
+	}
+	if comments < 2 {
+		t.Fatalf("saw %d keepalive comments in %s, want at least 2", comments, 5*keepaliveInterval)
+	}
+}
+
+// TestUnknownProjectIsRejected covers the 404 of the contract.
+func TestUnknownProjectIsRejected(t *testing.T) {
+	h := newHarness(t)
+	h.openRun("known-project", "run-1")
+
+	problem := h.getProblem(streamPath("unknown-project"), http.StatusNotFound)
+	if problem["code"] != "project_not_found" {
+		t.Fatalf("problem code is %v, want project_not_found", problem["code"])
+	}
+	if problem["type"] != "https://visualise-ai.local/problems/project-not-found" {
+		t.Fatalf("problem type is %v", problem["type"])
+	}
+}
+
+// TestRejectedEventIsNeverPublished covers the acceptance criterion that only
+// committed events reach a browser.
+//
+// Every rejection path of the ingestion endpoint is exercised through HTTP —
+// an unknown type, a contract violation, a lifecycle violation and an
+// idempotent retry — and the stream must show none of them.
+func TestRejectedEventIsNeverPublished(t *testing.T) {
+	h := newHarness(t)
+	run := h.openRun("rejection-project", "run-1")
+
+	client := h.connect(streamPath("rejection-project"), nil)
+
+	// Outside the closed catalogue.
+	if status, body := run.post(run.envelope("agent.teleported", `{}`)); status != http.StatusBadRequest {
+		t.Fatalf("an unknown event type produced %d: %s", status, body)
+	}
+	// Contract violation: progress outside the documented range.
+	if status, body := run.post(run.envelope(store.TypeAgentProgressReported,
+		`{"percent": 140, "scope": "own_task", "basis": "reported_estimate"}`)); status != http.StatusBadRequest {
+		t.Fatalf("an out-of-range payload produced %d: %s", status, body)
+	}
+	// Lifecycle violation: an agent that never reported agent.started.
+	stranger := &runContext{h: h, projectID: "rejection-project", runID: "run-1", agentID: "ghost-agent"}
+	if status, body := stranger.post(stranger.envelope(store.TypeAgentStatusReported,
+		`{"status": "working"}`)); status != http.StatusUnprocessableEntity {
+		t.Fatalf("an unknown agent produced %d: %s", status, body)
+	}
+	// A run that was already opened.
+	if status, body := run.post(run.envelope(store.TypeAgentStarted, `{
+		"role": "orchestrator",
+		"displayName": "Second root",
+		"assignedTask": "Open the run twice"
+	}`)); status != http.StatusUnprocessableEntity {
+		t.Fatalf("a second root agent produced %d: %s", status, body)
+	}
+	// An idempotent retry repeats a position that was published once already.
+	retry := run.envelope(store.TypeAgentStatusReported, `{"status": "working", "note": "retried"}`)
+	if status, body := run.post(retry); status != http.StatusCreated {
+		t.Fatalf("the first send of the retried event produced %d: %s", status, body)
+	}
+	if status, body := run.post(retry); status != http.StatusOK {
+		t.Fatalf("the repeated send produced %d: %s", status, body)
+	}
+
+	position := run.note("the only other committed event")
+
+	events := client.collectUntil(position)
+	assertExactlyOnceInOrder(t, events, position-1, position)
+	if events[0].Type != store.TypeAgentStatusReported {
+		t.Fatalf("the retried event was streamed as %q", events[0].Type)
+	}
+}
+
+// TestShutdownClosesOpenStreams covers the graceful stop of the process.
+//
+// An SSE connection never goes idle — it keeps writing keepalives — so
+// http.Server.Shutdown alone waits for the full timeout. The negative control
+// is part of the test: shutting the server down while the broker still serves
+// its subscribers must time out, and shutting the broker down first must let
+// the same call return immediately. That is exactly the order main.go uses.
+func TestShutdownClosesOpenStreams(t *testing.T) {
+	h := newHarness(t)
+	h.openRun("shutdown-project", "run-1")
+
+	broker := sse.NewBroker(sse.BrokerOptions{Logger: zerolog.Nop()})
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listening: %v", err)
+	}
+	server := &http.Server{Handler: h.router(broker), ReadHeaderTimeout: 10 * time.Second}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	client := h.connectTo("http://"+listener.Addr().String(), streamPath("shutdown-project"), nil)
+	defer client.close()
+
+	blocked, cancelBlocked := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancelBlocked()
+	if err := server.Shutdown(blocked); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown returned %v while a stream was still served, want a timeout", err)
+	}
+
+	broker.Shutdown()
+
+	released, cancelReleased := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelReleased()
+	start := time.Now()
+	if err := server.Shutdown(released); err != nil {
+		t.Fatalf("Shutdown after the broker stopped: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("Shutdown took %s after the broker stopped, want it to return at once", elapsed)
+	}
+	if got := broker.Subscribers(); got != 0 {
+		t.Fatalf("the stopped broker still holds %d subscribers", got)
+	}
+}
+
+// TestBackendRestartReplaysFromPostgres covers the acceptance criterion that a
+// restart loses nothing: the new instance starts with an empty broker and the
+// missing events come out of the log.
+func TestBackendRestartReplaysFromPostgres(t *testing.T) {
+	h := newHarness(t)
+	run := h.openRun("restart-project", "run-1")
+	for i := 2; i <= 8; i++ {
+		run.note(fmt.Sprintf("before the restart %d", i))
+	}
+
+	client := h.connect(streamPath("restart-project")+"?lastEventPosition=0", nil)
+	assertExactlyOnceInOrder(t, client.collectUntil(8), 1, 8)
+
+	h.restart()
+
+	if got := h.broker().Subscribers(); got != 0 {
+		t.Fatalf("the restarted broker already holds %d subscribers", got)
+	}
+	last := run.note("after the restart")
+
+	resumed := h.connect(streamPath("restart-project")+"?lastEventPosition=4", nil)
+	assertExactlyOnceInOrder(t, resumed.collectUntil(last), 5, last)
+}

--- a/backend/internal/sse/testsupport_test.go
+++ b/backend/internal/sse/testsupport_test.go
@@ -1,0 +1,663 @@
+package sse_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"gorm.io/gorm"
+
+	"github.com/risqyy/visualise-ai/backend/internal/database"
+	"github.com/risqyy/visualise-ai/backend/internal/health"
+	"github.com/risqyy/visualise-ai/backend/internal/httpapi"
+	"github.com/risqyy/visualise-ai/backend/internal/ingest"
+	"github.com/risqyy/visualise-ai/backend/internal/readapi"
+	"github.com/risqyy/visualise-ai/backend/internal/sse"
+	"github.com/risqyy/visualise-ai/backend/internal/store"
+)
+
+// The stream is tested against a real PostgreSQL instance, over a real HTTP
+// connection and through the real ingestion path: every fixture event is POSTed
+// to /api/v1/events, so an event only ever reaches the broker the way it does
+// in production — after its append transaction committed.
+//
+//	docker run -d --name vai-test-pg-6 -e POSTGRES_PASSWORD=test \
+//	  -e POSTGRES_USER=test -e POSTGRES_DB=test -p 55438:5432 postgres:17-alpine
+//	TEST_DATABASE_URL='postgres://test:test@127.0.0.1:55438/test?sslmode=disable' \
+//	  go test ./internal/sse/...
+//
+// Without TEST_DATABASE_URL every test here skips, so `go test ./...` stays
+// green on a machine without a database.
+const testDatabaseURLEnv = "TEST_DATABASE_URL"
+
+// testSchema keeps these tests in a PostgreSQL schema of their own.
+//
+// `go test ./...` runs packages in parallel and every package truncates the
+// whole schema before it seeds. Without the separation the store, readapi and
+// stream tests would wipe each other's fixtures on a shared TEST_DATABASE_URL.
+const testSchema = "sse_test"
+
+// replayPageSize is deliberately tiny so every replay in this suite needs
+// several round trips. That is what opens the window a concurrently committing
+// writer must not be able to slip through.
+const replayPageSize = 3
+
+// keepaliveInterval keeps the idle comment observable inside a test.
+const keepaliveInterval = 100 * time.Millisecond
+
+// frameTimeout bounds how long a test waits for the next frame.
+const frameTimeout = 20 * time.Second
+
+var (
+	migrateOnce sync.Once
+	migrateErr  error
+
+	contractOnce sync.Once
+	contract     *ingest.Contract
+	contractErr  error
+)
+
+// baseTime anchors the reported timestamps so ordering assertions are exact.
+var baseTime = time.Date(2026, 8, 4, 9, 0, 0, 0, time.UTC)
+
+// instance is one backend process as far as these tests are concerned: its own
+// broker, its own router and its own listening socket, sharing the database.
+// Replacing it is how a backend restart is simulated.
+type instance struct {
+	broker *sse.Broker
+	server *httptest.Server
+}
+
+// harness owns the database and the currently running instance.
+type harness struct {
+	t   *testing.T
+	db  *gorm.DB
+	cur *instance
+	seq int
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+
+	dsn := strings.TrimSpace(os.Getenv(testDatabaseURLEnv))
+	if dsn == "" {
+		t.Skipf("%s is not set: skipping the PostgreSQL backed stream tests", testDatabaseURLEnv)
+	}
+
+	db, err := database.Open(context.Background(), withSearchPath(dsn, testSchema), 30*time.Second, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("opening the test database: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := database.Close(db); closeErr != nil {
+			t.Errorf("closing the test database: %v", closeErr)
+		}
+	})
+
+	migrateOnce.Do(func() {
+		if migrateErr = db.Exec(`CREATE SCHEMA IF NOT EXISTS "` + testSchema + `"`).Error; migrateErr != nil {
+			return
+		}
+		migrateErr = store.Migrate(db)
+	})
+	if migrateErr != nil {
+		t.Fatalf("migrating the test schema: %v", migrateErr)
+	}
+	truncateAll(t, db)
+
+	h := &harness{t: t, db: db}
+	h.cur = h.start()
+	return h
+}
+
+// start brings up one backend instance: broker, ingestion, read models and the
+// stream, wired through the production router.
+//
+// The read models are mounted on purpose. They register `/projects/:projectId/…`
+// first, so building this router at all proves the stream reuses that wildcard
+// name instead of making Gin panic.
+func (h *harness) start() *instance {
+	h.t.Helper()
+
+	broker := sse.NewBroker(sse.BrokerOptions{Logger: zerolog.Nop()})
+	server := httptest.NewServer(h.router(broker))
+
+	inst := &instance{broker: broker, server: server}
+	h.t.Cleanup(func() {
+		// Ending the subscriptions first is what lets Close return: an open
+		// stream never goes idle on its own.
+		inst.broker.Shutdown()
+		inst.server.Close()
+	})
+	return inst
+}
+
+// router builds the production router in front of one broker.
+func (h *harness) router(broker *sse.Broker) http.Handler {
+	h.t.Helper()
+
+	contractOnce.Do(func() { contract, contractErr = ingest.LoadContract() })
+	if contractErr != nil {
+		h.t.Fatalf("loading the event contract: %v", contractErr)
+	}
+
+	ingestHandler, err := ingest.NewHandler(ingest.HandlerOptions{
+		Store:         store.New(h.db),
+		Contract:      contract,
+		Publisher:     broker,
+		MaxEventBytes: 2 * 1024 * 1024,
+		Logger:        zerolog.Nop(),
+	})
+	if err != nil {
+		h.t.Fatalf("building the ingestion handler: %v", err)
+	}
+
+	checker := health.NewChecker(func(context.Context) error { return nil })
+	checker.MarkBootstrapped()
+
+	return httpapi.New(httpapi.Options{
+		Logger:  zerolog.New(io.Discard),
+		Health:  checker,
+		Version: "test",
+		Ingest:  ingestHandler,
+		Read:    readapi.New(h.db),
+		Stream: sse.NewHandler(sse.HandlerOptions{
+			Broker:            broker,
+			Reader:            sse.NewEventReader(h.db),
+			KeepaliveInterval: keepaliveInterval,
+			ReplayPageSize:    replayPageSize,
+			Logger:            zerolog.Nop(),
+		}),
+	})
+}
+
+// restart replaces the running instance with a fresh one, exactly as a process
+// restart would: a new, empty broker in front of the same PostgreSQL log.
+func (h *harness) restart() {
+	h.t.Helper()
+	h.cur.broker.Shutdown()
+	h.cur.server.Close()
+	h.cur = h.start()
+}
+
+func (h *harness) broker() *sse.Broker { return h.cur.broker }
+
+// withSearchPath pins the connection to one schema.
+func withSearchPath(dsn, schema string) string {
+	if parsed, err := url.Parse(dsn); err == nil && parsed.Scheme != "" {
+		query := parsed.Query()
+		query.Set("search_path", schema)
+		parsed.RawQuery = query.Encode()
+		return parsed.String()
+	}
+	return dsn + " search_path=" + schema
+}
+
+// truncateAll empties every table so each test starts from a known state.
+func truncateAll(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	names := make([]string, 0, len(store.Models()))
+	for _, model := range store.Models() {
+		named, ok := model.(interface{ TableName() string })
+		if !ok {
+			t.Fatalf("model %T does not pin its table name", model)
+		}
+		names = append(names, `"`+named.TableName()+`"`)
+	}
+	if err := db.Exec("TRUNCATE " + strings.Join(names, ", ") + " RESTART IDENTITY CASCADE").Error; err != nil {
+		t.Fatalf("truncating the test schema: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ingestion
+// ---------------------------------------------------------------------------
+
+// nextTime keeps every reported timestamp of a test strictly increasing.
+func (h *harness) nextTime() time.Time {
+	h.seq++
+	return baseTime.Add(time.Duration(h.seq) * time.Second)
+}
+
+// runContext ingests events for one (project, run) pair.
+type runContext struct {
+	h         *harness
+	projectID string
+	runID     string
+	agentID   string
+}
+
+// openRun ingests the root agent.started that opens a run, which is what makes
+// every later event of that run acceptable.
+func (h *harness) openRun(projectID, runID string) *runContext {
+	h.t.Helper()
+	r := &runContext{h: h, projectID: projectID, runID: runID, agentID: "orchestrator-root"}
+	r.emit(store.TypeAgentStarted, `{
+		"role": "orchestrator",
+		"displayName": "Root orchestrator",
+		"assignedTask": "Observe the stream"
+	}`)
+	return r
+}
+
+// emit POSTs one event to the real ingestion endpoint and returns the position
+// the server assigned. Publication therefore happens the production way.
+func (r *runContext) emit(eventType, payload string) int64 {
+	r.h.t.Helper()
+	status, body := r.post(r.envelope(eventType, payload))
+	if status != http.StatusCreated {
+		r.h.t.Fatalf("POST /api/v1/events: want 201, got %d: %s", status, body)
+	}
+	var accepted struct {
+		Position int64 `json:"position"`
+	}
+	if err := json.Unmarshal([]byte(body), &accepted); err != nil {
+		r.h.t.Fatalf("decoding the ingestion response: %v: %s", err, body)
+	}
+	return accepted.Position
+}
+
+// note ingests one agent.status_reported, the cheapest event that carries a
+// distinguishable payload.
+func (r *runContext) note(text string) int64 {
+	r.h.t.Helper()
+	return r.emit(store.TypeAgentStatusReported,
+		fmt.Sprintf(`{"status": "working", "note": %q}`, text))
+}
+
+// seedHistory appends n events straight through the store and returns the last
+// position it assigned.
+//
+// Bulk history deliberately skips the HTTP round trip and the publisher: these
+// events are the past a reconnecting client replays, and nobody was listening
+// when they happened. Seeding them this way is what makes a replay long enough
+// to hold a connection busy for a measurable time.
+func (r *runContext) seedHistory(n int) int64 {
+	r.h.t.Helper()
+
+	appender := store.New(r.h.db)
+	var last int64
+	for i := 0; i < n; i++ {
+		result, err := appender.Append(context.Background(), store.Envelope{
+			ProjectID:     r.projectID,
+			ClientEventID: uuid.NewString(),
+			RunID:         r.runID,
+			AgentID:       r.agentID,
+			Type:          store.TypeAgentStatusReported,
+			SchemaVersion: "1.0",
+			OccurredAt:    r.h.nextTime(),
+			Payload:       json.RawMessage(fmt.Sprintf(`{"status":"working","note":"history %d"}`, i)),
+		})
+		if err != nil {
+			r.h.t.Fatalf("seeding history of %s: %v", r.projectID, err)
+		}
+		last = result.Position
+	}
+	return last
+}
+
+// envelope assembles a contract-valid request body.
+func (r *runContext) envelope(eventType, payload string) string {
+	return fmt.Sprintf(`{
+		"schemaVersion": "1.0",
+		"clientEventId": %q,
+		"projectId": %q,
+		"runId": %q,
+		"agentId": %q,
+		"occurredAt": %q,
+		"type": %q,
+		"payload": %s
+	}`, uuid.NewString(), r.projectID, r.runID, r.agentID,
+		r.h.nextTime().Format(time.RFC3339), eventType, payload)
+}
+
+// post sends one ingestion request and returns status and body.
+func (r *runContext) post(body string) (int, string) {
+	r.h.t.Helper()
+	response, err := http.Post(r.h.cur.server.URL+"/api/v1/events", "application/json", strings.NewReader(body))
+	if err != nil {
+		r.h.t.Fatalf("POST /api/v1/events: %v", err)
+	}
+	defer response.Body.Close()
+
+	raw, err := io.ReadAll(response.Body)
+	if err != nil {
+		r.h.t.Fatalf("reading the ingestion response: %v", err)
+	}
+	return response.StatusCode, string(raw)
+}
+
+// ---------------------------------------------------------------------------
+// Stream client
+// ---------------------------------------------------------------------------
+
+// frame is one parsed SSE frame. A comment frame carries only Comment.
+type frame struct {
+	ID      string
+	Event   string
+	Data    string
+	Comment string
+}
+
+// streamedEvent is the JSON object of a single `data:` line — the contract's
+// StreamedEvent.
+type streamedEvent struct {
+	SchemaVersion string          `json:"schemaVersion"`
+	ClientEventID string          `json:"clientEventId"`
+	ProjectID     string          `json:"projectId"`
+	RunID         string          `json:"runId"`
+	AgentID       string          `json:"agentId"`
+	ParentAgentID *string         `json:"parentAgentId"`
+	OccurredAt    time.Time       `json:"occurredAt"`
+	Type          string          `json:"type"`
+	Payload       json.RawMessage `json:"payload"`
+	Position      int64           `json:"position"`
+	ServerEventID string          `json:"serverEventId"`
+	ReceivedAt    time.Time       `json:"receivedAt"`
+}
+
+// streamClient is one open SSE connection with a background frame parser.
+type streamClient struct {
+	t      *testing.T
+	cancel context.CancelFunc
+	body   io.ReadCloser
+	frames chan frame
+	header http.Header
+}
+
+// connect opens the stream and consumes the opening keepalive comment.
+//
+// Returning only after that comment matters: the handler writes it once the
+// subscription is registered, so a test that commits afterwards knows the
+// connection cannot miss the event.
+func (h *harness) connect(path string, header http.Header) *streamClient {
+	h.t.Helper()
+	return h.connectTo(h.cur.server.URL, path, header)
+}
+
+// connectTo is connect against an explicitly named instance.
+func (h *harness) connectTo(baseURL, path string, header http.Header) *streamClient {
+	h.t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
+	if err != nil {
+		cancel()
+		h.t.Fatalf("building the stream request: %v", err)
+	}
+	request.Header.Set("Accept", "text/event-stream")
+	for name, values := range header {
+		for _, value := range values {
+			request.Header.Add(name, value)
+		}
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		cancel()
+		h.t.Fatalf("GET %s: %v", path, err)
+	}
+	if response.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(response.Body)
+		response.Body.Close()
+		cancel()
+		h.t.Fatalf("GET %s: want 200, got %d: %s", path, response.StatusCode, raw)
+	}
+
+	client := &streamClient{
+		t:      h.t,
+		cancel: cancel,
+		body:   response.Body,
+		frames: make(chan frame, 8192),
+		header: response.Header,
+	}
+	go client.parse()
+	h.t.Cleanup(client.close)
+
+	if opening := client.next(); opening.Comment != "keepalive" {
+		h.t.Fatalf("GET %s: want an opening keepalive comment, got %+v", path, opening)
+	}
+	return client
+}
+
+// parse turns the byte stream into frames until the connection ends.
+func (c *streamClient) parse() {
+	defer close(c.frames)
+
+	reader := bufio.NewReader(c.body)
+	var current frame
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			line = strings.TrimRight(line, "\r\n")
+			switch {
+			case line == "":
+				if current != (frame{}) {
+					c.frames <- current
+					current = frame{}
+				}
+			case strings.HasPrefix(line, ":"):
+				current.Comment = strings.TrimSpace(line[1:])
+			default:
+				name, value, _ := strings.Cut(line, ":")
+				value = strings.TrimPrefix(value, " ")
+				switch name {
+				case "id":
+					current.ID = value
+				case "event":
+					current.Event = value
+				case "data":
+					current.Data = value
+				}
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// next returns the next frame or fails the test on timeout.
+func (c *streamClient) next() frame {
+	c.t.Helper()
+	select {
+	case f, ok := <-c.frames:
+		if !ok {
+			c.t.Fatalf("the stream closed while a frame was expected")
+		}
+		return f
+	case <-time.After(frameTimeout):
+		c.t.Fatalf("no frame within %s", frameTimeout)
+		return frame{}
+	}
+}
+
+// nextEvent returns the next frame that carries an event, skipping keepalives,
+// together with its decoded payload.
+func (c *streamClient) nextEvent() (frame, streamedEvent) {
+	c.t.Helper()
+	for {
+		f := c.next()
+		if f.Data == "" {
+			continue
+		}
+		return f, decodeEvent(c.t, f)
+	}
+}
+
+// collectUntil reads events until the one at position through arrived and
+// returns every event frame in the order it was received.
+func (c *streamClient) collectUntil(through int64) []streamedEvent {
+	c.t.Helper()
+
+	events := make([]streamedEvent, 0, 64)
+	for {
+		f, event := c.nextEvent()
+		if f.ID != strconv.FormatInt(event.Position, 10) {
+			c.t.Fatalf("frame id %q does not carry the project position %d", f.ID, event.Position)
+		}
+		events = append(events, event)
+		if event.Position >= through {
+			return events
+		}
+	}
+}
+
+// drainFor collects every frame that arrives within d.
+func (c *streamClient) drainFor(d time.Duration) []frame {
+	c.t.Helper()
+
+	deadline := time.After(d)
+	frames := make([]frame, 0, 16)
+	for {
+		select {
+		case f, ok := <-c.frames:
+			if !ok {
+				return frames
+			}
+			frames = append(frames, f)
+		case <-deadline:
+			return frames
+		}
+	}
+}
+
+// assertQuiet insists that nothing but keepalives follows.
+//
+// It is what turns "received everything" into "received exactly that": a
+// duplicate produced at the replay-to-live boundary arrives *after* the last
+// expected position, so an assertion that stops at that position would never
+// see it.
+func (c *streamClient) assertQuiet(d time.Duration) {
+	c.t.Helper()
+	for _, f := range c.drainFor(d) {
+		if f.Data != "" {
+			c.t.Fatalf("the stream continued past the last expected position with %+v", f)
+		}
+	}
+}
+
+// close hangs up. It is idempotent so a test may call it explicitly and the
+// cleanup may call it again.
+func (c *streamClient) close() {
+	c.cancel()
+	c.body.Close()
+}
+
+func decodeEvent(t *testing.T, f frame) streamedEvent {
+	t.Helper()
+	if strings.ContainsAny(f.Data, "\n\r") {
+		t.Fatalf("a data line must be a single line, got %q", f.Data)
+	}
+	var event streamedEvent
+	if err := json.Unmarshal([]byte(f.Data), &event); err != nil {
+		t.Fatalf("decoding a data line: %v: %s", err, f.Data)
+	}
+	return event
+}
+
+// ---------------------------------------------------------------------------
+// Assertions
+// ---------------------------------------------------------------------------
+
+// assertExactlyOnceInOrder is the acceptance criterion of the issue: every
+// position from first to last, each exactly once, strictly ascending.
+func assertExactlyOnceInOrder(t *testing.T, events []streamedEvent, first, last int64) {
+	t.Helper()
+
+	want := last - first + 1
+	if int64(len(events)) != want {
+		t.Fatalf("want %d events for positions %d..%d, got %d (%v)",
+			want, first, last, len(events), positions(events))
+	}
+	for i, event := range events {
+		if expected := first + int64(i); event.Position != expected {
+			t.Fatalf("position %d of the stream is %d, want %d (%v)",
+				i, event.Position, expected, positions(events))
+		}
+	}
+}
+
+// assertPayload compares a streamed payload with the reported document. JSON
+// object key order is insignificant, so the comparison is on the decoded value.
+func assertPayload(t *testing.T, raw json.RawMessage, want map[string]any) {
+	t.Helper()
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decoding the streamed payload: %v: %s", err, raw)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("streamed payload is %s, want %v", raw, want)
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("streamed payload %s carries %q = %v, want %v", raw, key, got[key], value)
+		}
+	}
+}
+
+func positions(events []streamedEvent) []int64 {
+	out := make([]int64, 0, len(events))
+	for _, event := range events {
+		out = append(out, event.Position)
+	}
+	return out
+}
+
+// eventually polls condition until it holds or the deadline passes.
+func eventually(t *testing.T, what string, timeout time.Duration, condition func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("%s did not happen within %s", what, timeout)
+}
+
+// getProblem performs one plain request and decodes the RFC 9457 document.
+func (h *harness) getProblem(path string, wantStatus int) map[string]any {
+	h.t.Helper()
+
+	response, err := http.Get(h.cur.server.URL + path)
+	if err != nil {
+		h.t.Fatalf("GET %s: %v", path, err)
+	}
+	defer response.Body.Close()
+
+	raw, err := io.ReadAll(response.Body)
+	if err != nil {
+		h.t.Fatalf("reading %s: %v", path, err)
+	}
+	if response.StatusCode != wantStatus {
+		h.t.Fatalf("GET %s: want %d, got %d: %s", path, wantStatus, response.StatusCode, raw)
+	}
+	if contentType := response.Header.Get("Content-Type"); !strings.HasPrefix(contentType, "application/problem+json") {
+		h.t.Fatalf("GET %s: want an RFC 9457 media type, got %q", path, contentType)
+	}
+
+	var problem map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(raw), &problem); err != nil {
+		h.t.Fatalf("decoding the problem of %s: %v: %s", path, err, raw)
+	}
+	return problem
+}

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -47,6 +47,11 @@ type Result struct {
 	ClientEventID string
 	Duplicate     bool
 	ReceivedAt    time.Time
+	// Payload is the canonical form that was stored. Publishing this rather
+	// than the bytes the agent sent keeps a live SSE frame byte-identical to
+	// the same event replayed from the log, which would otherwise differ in
+	// object key order.
+	Payload json.RawMessage
 }
 
 // ErrClientEventIDConflict marks a reused idempotency key whose content differs
@@ -156,6 +161,7 @@ func (s *Store) AppendGuarded(ctx context.Context, env Envelope, guard Guard) (R
 					ClientEventID: existing.ClientEventID,
 					Duplicate:     true,
 					ReceivedAt:    existing.ReceivedAt,
+					Payload:       json.RawMessage(existing.Payload),
 				}
 				return nil
 			}
@@ -207,6 +213,7 @@ func (s *Store) AppendGuarded(ctx context.Context, env Envelope, guard Guard) (R
 			ClientEventID: event.ClientEventID,
 			Duplicate:     false,
 			ReceivedAt:    event.ReceivedAt,
+			Payload:       canonical,
 		}
 		return nil
 	})

--- a/docs/decisions/0006-sse-replay-and-in-process-broker.md
+++ b/docs/decisions/0006-sse-replay-and-in-process-broker.md
@@ -1,0 +1,145 @@
+# 6. SSE replay, the in-process broker and the project position as cursor
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #6 (part of the v0 epic #1)
+- **Builds on:** [0001 — Compose topology and single entry point](./0001-compose-topology-and-single-entry-point.md),
+  [0002 — Event log with synchronous projections](./0002-event-log-with-synchronous-projections.md),
+  [0004 — Contract-driven ingestion validation](./0004-contract-driven-ingestion-validation.md)
+
+## Context
+
+The cockpit watches an agent while it works, over a connection that will drop.
+A dropped SSE stream is normal, not exceptional, and the reconnect must deliver
+**every committed event exactly once, in position order, without a gap and
+without a duplicate** — that is the acceptance criterion of #6, and every live
+overlay built on top of it depends on it.
+
+Two things make that harder than it looks:
+
+1. A stream has two sources — the PostgreSQL log for the past and the running
+   process for the present — and the handover between them is a race.
+2. The single backend instance serves both ingestion and the streams, so a
+   browser that stops reading must not be able to slow either down.
+
+## Decision
+
+**The server-side project position is the only cursor.** The SSE `id:` is the
+position, not the event UUID; `Last-Event-ID` and `lastEventPosition` are read
+as positions, and the client stores a position rather than a payload. Positions
+are per project, monotonic and gapless because they are handed out under the
+project row lock (ADR 0002), so `position > lastSent` is a complete and exact
+description of "what this connection still owes the client". The event UUID
+would satisfy none of that: it carries no order, so resuming from one would mean
+asking the database where it sits before anything could be read.
+
+**Replay reads the log in pages, live events come from an in-process broker,
+and the connection holds `lastSent` across both.** Replayed and live events are
+the same Go value — `ingest.CommittedEvent`, shaped field for field like the
+contract's `StreamedEvent` — so there is exactly one mapping onto the wire and
+the two sources cannot drift apart.
+
+### The handover
+
+Both obvious orderings are wrong, and each is wrong in its own way:
+
+- *Read the database, then subscribe.* Everything that commits between the last
+  page and the subscription is delivered to nobody and is never noticed again.
+- *Subscribe, then read the database, then flush the buffer.* The overlap —
+  every event that is both in a page and in the buffer — is delivered twice.
+
+The implementation does this instead:
+
+1. **Subscribe before the first read.** From that moment every committed event
+   is either found by a later page or waiting in the subscription.
+2. **Replay page by page**, ordered by position, writing each event and
+   advancing `lastSent`.
+3. **After every page, drain the subscription buffer and discard it.** That is
+   sound precisely because the publisher runs *after* the commit (ADR 0004): an
+   event the broker handed out is already durable, so the next page will find
+   it. The database stays the single source during replay.
+4. **End the replay only when the page was short *and* the drained buffer was
+   empty.** Either condition alone leaves a window; together they mean the log
+   is exhausted and nothing arrived while it was being read.
+5. **In the live phase, filter strictly against `lastSent`**: an event at or
+   below it was already written and is dropped; an event above `lastSent + 1`
+   means something is missing and the range is filled from the log before the
+   event itself goes out.
+
+Step 5 is not belt-and-braces. Positions are assigned under the row lock, but
+`Publish` is called by the ingesting goroutine *after* its transaction
+committed, so two appends can reach the broker in the opposite order. Whichever
+arrives first, the earlier position is already committed and visible, so reading
+it back restores the order the contract promises.
+
+Discarding rather than replaying the buffer during step 3 has a second benefit:
+a long replay cannot overflow the buffer of a client that is not slow at all,
+only far behind.
+
+**The broker stays in the process.** v0 runs exactly one backend (ADR 0001), so
+a process-local fan-out is the whole realtime layer — no message broker, no
+Redis, no cross-instance fan-out, nothing to operate. Durability is not the
+broker's problem either: it may lose anything it likes, because PostgreSQL has
+every event and replay is how a client recovers it. That is also why a backend
+restart costs nothing but a reconnect: the new process starts with an empty
+broker, and the client's `Last-Event-ID` pulls the gap out of the log.
+
+**A slow client is disconnected, never waited for.** Each subscriber owns a
+buffered channel of 256 events; `Publish` sends non-blocking and drops the
+subscription when the buffer is full, logging it. 256 is a backpressure budget:
+the catalogue carries semantic work steps rather than raw tool calls, so a
+project produces events at a human-readable rate and 256 of them is far more
+than a connection accumulates while a tab is descheduled. Larger would trade a
+fast, recoverable disconnect for a growing per-connection backlog; smaller would
+drop connections during ordinary bursts. Overflow costs one reconnect and never
+an event, because the client resumes with its cursor.
+
+**`lastEventPosition` wins over `Last-Event-ID`, and the two are validated
+differently.** The query parameter is set deliberately by a client that persists
+its own cursor — the simulator, a test, a CLI — while the header is set
+automatically by the browser from the last frame it happened to see. When they
+disagree, the explicit statement is the one that reflects what the client
+actually processed. Consequently an unusable `lastEventPosition` is a client
+defect and is answered with `400` and an RFC 9457 problem, while an unusable
+`Last-Event-ID` is ignored and the stream starts live: that header travels back
+through the browser and an intermediary is free to mangle it.
+
+**A cursor beyond the end of the log starts at the current end.** Honouring it
+verbatim would filter away every event until the project caught up again, which
+presents as a working but permanently silent stream — the worst possible failure
+for an observability tool. Clamping it is the honest reading of "everything I
+have not seen", and it is logged.
+
+**Shutdown ends the subscriptions first.** An SSE connection never goes idle —
+it keeps writing keepalives — so `http.Server.Shutdown` on its own waits for the
+full timeout. `main` closes the broker before it shuts the server down, which
+ends every stream at once and lets the in-flight read and write requests drain
+normally.
+
+## Consequences
+
+- Adding a second backend instance breaks the live half of the stream: an event
+  ingested by instance A never reaches a subscriber of instance B. The replay
+  half keeps working, so the failure mode is a stalled tail rather than silent
+  corruption — but scaling out means replacing this package's broker, and that
+  is the deliberate boundary of v0.
+- Replay costs one query per 200 events. A client that resumes from the very
+  beginning of a long-lived project therefore does real work at connect time;
+  the cost is bounded per page and never materialises the whole log.
+- The gap fill can, in principle, issue a database read on the live path. In
+  practice it never triggers, because publications are almost always in position
+  order — but the guarantee does not depend on that being true.
+- A replayed frame carries the canonical payload the store wrote, a live frame
+  the document as the agent reported it. The two can differ in JSON object key
+  order and never in content, which is invisible to any JSON consumer but would
+  surprise a byte-for-byte comparison.
+- The keepalive interval and the replay page size are options of the handler
+  with documented defaults (15 s, 200) rather than environment variables. The
+  Nginx frontend allows 24 h on this route, so there is nothing to tune per
+  deployment yet; promoting them to `config.Config` is a two-line change if that
+  ever stops being true.
+- Nginx rewrites `Connection: keep-alive` to `Connection: close` on this route,
+  because `chunked_transfer_encoding off` leaves it no way to delimit an
+  unbounded body. The backend emits the header the contract names; `Connection`
+  is hop-by-hop and rewriting it is what an intermediary is for. `EventSource`
+  is unaffected — it reads until the stream ends and reconnects with its cursor.


### PR DESCRIPTION
Serves `GET /api/v1/projects/{projectId}/stream`: gap-free replay out of PostgreSQL followed seamlessly by the in-process live tail, exactly as `api/openapi.yaml` and `api/examples/sse-reconnect.md` describe it.

Closes #6

## What was added

New package `backend/internal/sse`:

| File | Role |
| --- | --- |
| `broker.go` | In-process fan-out. Implements `ingest.Publisher`, so it is called once per committed event, after the append transaction and never before. One bounded channel per subscriber. |
| `reader.go` | Paged read-back of the log (`position > after AND position <= through ORDER BY position`), mapped onto `ingest.CommittedEvent` — no second mapping. |
| `connection.go` | The wire format: `id:` = project position, `event:` = catalogue type, `data:` = one compact-JSON `StreamedEvent`, `: keepalive` comments. |
| `stream.go` | One goroutine per connection combining the two sources into a single strictly increasing, duplicate-free position sequence. |
| `problem.go` | RFC 9457 documents for `404 project_not_found` and `400 invalid_query_parameter`. |

Wiring: `httpapi/stream.go` mounts the route additively, `cmd/server/main.go` replaces `ingest.NopPublisher{}` with the real broker and closes it before `server.Shutdown`. `docs/decisions/0006-sse-replay-and-in-process-broker.md` records the reasoning.

`frontend/nginx/default.conf` was **checked and left unchanged** — it already disables buffering, caching, chunked re-encoding and gzip on this route and allows 24 h timeouts. Proof that it works is below.

## How the replay-to-live window is closed

Both obvious orderings are wrong, each in its own way:

* *read the database, then subscribe* — everything committing in between is delivered to nobody and never noticed again;
* *subscribe, then read, then flush the buffer* — the overlap is delivered twice.

The handler does this instead:

1. **Subscribe before the first read.** From then on every committed event is either found by a later page or waiting in the subscription.
2. **Replay page by page**, writing each event and advancing `lastSent`.
3. **After every page, drain the subscription buffer and discard it.** Sound precisely because the publisher runs *after* the commit (ADR 0004): anything the broker handed out is durable, so the next page finds it. This also keeps a long replay from overflowing the buffer of a client that is not slow at all, only far behind.
4. **End the replay only when the page was short *and* the drained buffer was empty.** Either condition alone leaves a window.
5. **In the live phase, filter strictly against `lastSent`**: `<= lastSent` is dropped, `> lastSent + 1` triggers a fill from the log before the event itself goes out.

Step 5 is not belt-and-braces: positions are assigned under the project row lock, but `Publish` is called by the ingesting goroutine *after* its transaction committed, so two appends can reach the broker in the opposite order. The earlier position is already committed and visible, so reading it back restores the promised order.

## How that is proven

`TestReplayToLiveTransitionHasNoGapAndNoDuplicate` runs 12 iterations with a writer committing 24 events from a goroutine while a client replays from the middle of a 24-event history, alternating which of the two starts first. `TestSingleCommitDuringReplayIsNotLost` isolates the one failure nothing repairs afterwards — a single event committed during a 400-event replay with nothing behind it to expose the gap. The replay page size is 3 across the whole suite, so every replay takes many round trips.

Both were verified to **fail** against the naive implementations, not merely to pass:

```
# negative control A - read the log first, subscribe afterwards (window widened to 200 ms)
$ go test ./internal/sse/... -run TestReplayToLiveTransitionHasNoGapAndNoDuplicate
panic: test timed out after 400s
FAIL    github.com/risqyy/visualise-ai/backend/internal/sse      404.359s

# negative control B - subscribe first, replay the buffer unfiltered
$ go test ./internal/sse/... -run TestSingleCommitDuringReplayIsNotLost
--- FAIL: TestSingleCommitDuringReplayIsNotLost (4.44s)
    stream_test.go:252: the stream continued past the last expected position with
    {ID:602 Event:agent.status_reported ... "position":602 ...}
FAIL
```

`assertQuiet` is what makes B observable: a duplicate produced at the boundary arrives *after* the last expected position, so an assertion that merely stops there would never see it.

`TestShutdownClosesOpenStreams` carries its own negative control: `http.Server.Shutdown` with a stream open **must** time out while the broker still serves it, and **must** return at once after `broker.Shutdown()` — which is exactly the order `main.go` uses.

## Test run

Test PostgreSQL on port 55438, in its own `sse_test` schema so parallel packages cannot truncate each other's fixtures.

```
$ docker run -d --name vai-test-pg-6 -e POSTGRES_PASSWORD=test -e POSTGRES_USER=test \
    -e POSTGRES_DB=test -p 55438:5432 postgres:17-alpine

$ gofmt -l .
$ go vet ./...
$ TEST_DATABASE_URL='postgres://test:test@127.0.0.1:55438/test?sslmode=disable' go test ./... -count=1
?       github.com/risqyy/visualise-ai/backend/cmd/server        [no test files]
ok      github.com/risqyy/visualise-ai/backend/internal/config   0.804s
?       github.com/risqyy/visualise-ai/backend/internal/database [no test files]
ok      github.com/risqyy/visualise-ai/backend/internal/health   0.801s
ok      github.com/risqyy/visualise-ai/backend/internal/httpapi  6.829s
ok      github.com/risqyy/visualise-ai/backend/internal/ingest   3.747s
?       github.com/risqyy/visualise-ai/backend/internal/logging  [no test files]
ok      github.com/risqyy/visualise-ai/backend/internal/readapi  6.547s
ok      github.com/risqyy/visualise-ai/backend/internal/sse      25.777s
ok      github.com/risqyy/visualise-ai/backend/internal/store    5.155s
```

Without `TEST_DATABASE_URL` the suite is still green: the broker tests need no database, the stream tests skip.

The required cases map onto:

| # | Test |
| --- | --- |
| 1 live | `TestLiveEventReachesTheStream` |
| 2 replay from `Last-Event-ID: 3` of 10 | `TestReplayDeliversTheMissingPositions` |
| 3 `?lastEventPosition=`, query wins | `TestLastEventPositionIsEquivalentAndWins` (plus `0`, neither, invalid, beyond-the-log) |
| 4 no gap/duplicate window | `TestReplayToLiveTransitionHasNoGapAndNoDuplicate`, `TestSingleCommitDuringReplayIsNotLost` |
| 5 several subscribers | `TestSeveralSubscribersSeeTheSame`, `TestBrokerFansOutPerProject` |
| 6 project isolation | `TestProjectsAreIsolated`, `TestBrokerFansOutPerProject` |
| 7 disconnect unsubscribes | `TestClientDisconnectUnsubscribes`, `TestBrokerCloseIsIdempotentAndUnregisters` |
| 8 keepalive | `TestKeepaliveCommentIsSent` |
| 9 unknown project 404 | `TestUnknownProjectIsRejected` |
| 10 rejected event never published | `TestRejectedEventIsNeverPublished` (400 unknown type, 400 contract violation, 422 unknown agent, 422 run already started, 200 idempotent retry) |
| 11 backend restart | `TestBackendRestartReplaysFromPostgres` |
| slow client, shutdown, wildcard name | `TestBrokerDropsASubscriberThatFallsBehind`, `TestShutdownClosesOpenStreams`, `httpapi.TestStreamAndReadModelsShareOneWildcardName` |

## The Gin wildcard

The route is registered as `:projectId`, the same name the read models use at that position — a different one panics while the engine is built. `httpapi.TestStreamAndReadModelsShareOneWildcardName` guards it, and the server was started for real to confirm it:

```
$ HTTP_ADDR=127.0.0.1:8099 DATABASE_URL=... ./server.exe
INF starting backend addr=127.0.0.1:8099 version=dev
INF connected to postgres attempt=1
INF schema migrated
INF backend is ready
$ curl -s http://127.0.0.1:8099/readyz
{"status":"ready","version":"dev"}
```

## `curl -N` against the backend directly

Two events committed before connecting, two after, resuming at position 1:

```
$ curl -N -sS -D - -H 'Last-Event-ID: 1' http://127.0.0.1:8099/api/v1/projects/curl-demo/stream
HTTP/1.1 200 OK
Cache-Control: no-cache
Connection: keep-alive
Content-Type: text/event-stream
X-Accel-Buffering: no
Transfer-Encoding: chunked

: keepalive

id: 2
event: agent.status_reported
data: {"schemaVersion":"1.0","clientEventId":"1ac9e9a7-...","projectId":"curl-demo","runId":"run-1","agentId":"orchestrator-root","occurredAt":"2026-08-04T09:00:00Z","type":"agent.status_reported","payload":{"note":"Writing the SSE handler.","status":"working"},"position":2,"serverEventId":"12d0fd7a-...","receivedAt":"2026-08-04T08:08:18.250166Z"}

id: 3
event: agent.progress_reported
data: {...,"payload":{"basis":"reported_estimate","scope":"own_task","percent":40},"position":3,...}

id: 4
event: work.step_started
data: {...,"payload":{"workStepId":"work-0001","title":"Wire the broker","componentIds":["backend.sse"]},"position":4,...}

id: 5
event: agent.status_reported
data: {...,"payload":{"status":"working","note":"Live after the replay."},"position":5,...}

: keepalive
```

Replay `2..3`, live `4..5`, no visible boundary, keepalive after 15 s idle.

```
$ curl -s -i http://127.0.0.1:8099/api/v1/projects/nope/stream | head -2
HTTP/1.1 404 Not Found
Content-Type: application/problem+json
{"type":"https://visualise-ai.local/problems/project-not-found","title":"Project not found","status":404,"detail":"No project with id \"nope\" exists.","code":"project_not_found"}

$ curl -s -i 'http://127.0.0.1:8099/api/v1/projects/curl-demo/stream?lastEventPosition=abc' | head -2
HTTP/1.1 400 Bad Request
Content-Type: application/problem+json
{"type":"https://visualise-ai.local/problems/invalid-query-parameter",...,"code":"invalid_query_parameter","errors":[{"field":"/lastEventPosition","code":"invalid","message":"want the last processed project position as an integer of at least 0"}]}
```

## Through Nginx, unbuffered

`FRONTEND_HTTP_PORT=8091 docker compose up --build -d`, then `curl -N` through the frontend container with every line timestamped as it arrives:

```
$ curl -N -sS -D - -H 'Last-Event-ID: 1' http://127.0.0.1:8091/api/v1/projects/curl-demo/stream | ts
HTTP/1.1 200 OK
Server: nginx/1.29.8
Content-Type: text/event-stream
Cache-Control: no-cache
X-Accel-Buffering: no

10:12:59.392 | : keepalive
10:12:59.431 | id: 2
10:12:59.451 | event: agent.status_reported
10:12:59.471 | data: {...,"position":2,...}            <- replay, at connect time
10:13:02.621 | id: 3
10:13:02.640 | event: work.step_started
10:13:02.660 | data: {...,"position":3,"receivedAt":"2026-08-04T08:13:02.59682441Z"}
10:13:06.877 | id: 4
10:13:06.897 | event: agent.status_reported
10:13:06.918 | data: {...,"position":4,"receivedAt":"2026-08-04T08:13:06.849573391Z"}
10:13:14.391 | : keepalive
```

Each frame reaches the client within about 30 ms of the `receivedAt` the backend stamped on it, four seconds apart — nothing is held back and released in a block, which is what buffering would look like. The keepalive lands 15.0 s after the connect. Two simultaneous `curl -N` clients through Nginx received the same event:

```
--- browser a ---              --- browser b ---
id: 5                          id: 5
event: agent.status_reported   event: agent.status_reported
data: {...,"position":5,...}   data: {...,"position":5,...}
```

Graceful shutdown with a stream open, in the container:

```
$ docker compose stop backend
10:14:38.558  ->  10:14:39.206     (0.65 s, SHUTDOWN_TIMEOUT is 15 s)

backend-1 | {"level":"info","message":"shutdown signal received"}
backend-1 | {"level":"info","streams":1,"message":"closing open event streams"}
backend-1 | {"level":"info","method":"GET","path":"/api/v1/projects/curl-demo/stream","status":200,"duration":2274.16,"message":"http request"}
backend-1 | {"level":"info","message":"backend stopped"}
```

Afterwards: `docker compose down -v`, test container removed.

## Deviations and open risks

* **`400` on an unusable `lastEventPosition`.** The contract lists only `200` and `404` for this operation. Silently ignoring a broken cursor would produce a stream that looks healthy and delivers the wrong range, so the parameter is rejected with the read API's `invalid_query_parameter` problem. An unusable `Last-Event-ID` is *ignored* instead — that header is echoed back through the browser and an intermediary may mangle it. `api/` was not touched; worth adding the response to the contract in a follow-up.
* **A cursor beyond the end of the log is clamped to the current end** and logged, rather than honoured verbatim — otherwise a stale client would see a working but permanently silent stream.
* **Nginx rewrites `Connection: keep-alive` to `Connection: close`** on this route, because `chunked_transfer_encoding off` leaves it no way to delimit an unbounded body. The backend emits the header the contract names (shown above); `Connection` is hop-by-hop and `EventSource` is unaffected. The Nginx config was deliberately left as ADR 0001 wrote it.
* **A replayed frame carries the canonical payload the store wrote, a live frame the document as reported.** The two can differ in JSON object key order and never in content — visible in the `curl` output above, invisible to any JSON consumer, but it would surprise a byte-for-byte comparison.
* **Keepalive interval (15 s) and replay page size (200) are handler options, not environment variables.** Nothing needs tuning per deployment yet; promoting them to `config.Config` is a two-line change.
* **`-race` could not be run** on this machine (no gcc for cgo). The concurrent paths are covered by the 12-iteration race test and the broker unit tests instead.
* **The single-instance boundary is unchanged and load-bearing.** A second backend instance would break the live half — a subscriber of instance B never sees an event ingested by instance A. Replay keeps working, so the failure mode is a stalled tail rather than corruption, but scaling out means replacing this broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
