### PR TITLE
[v0] Hierarchischen Architekturcanvas mit React Flow und ELK umsetzen

### DIFF
--- a/docs/decisions/0008-architecture-canvas-layout-and-edge-bundling.md
+++ b/docs/decisions/0008-architecture-canvas-layout-and-edge-bundling.md
@@ -1,0 +1,235 @@
+# 8. Architecture canvas: ELK layered layout, resolvable edge bundling and a camera that stays put
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #9 (part of the v0 epic #1)
+- **Builds on:** [0003 — Frontend state split and live updates](./0003-frontend-state-split-and-live-updates.md),
+  [0005 — Read API shape and run scoping](./0005-read-api-shape-and-run-scoping.md)
+
+## Context
+
+The architecture canvas is the product. It is the dominant surface at
+1920 × 1080, it is what the user is looking at while agents work, and it is the
+entry point for the overlays (#10) and the inspector (#12).
+
+Four properties make it either usable or useless, and none of them is a matter
+of taste:
+
+- The picture of one model must not change between two viewings of it.
+- Parallel relationships — three NATS topics between the same two components —
+  must be readable at a glance *and* individually identifiable.
+- The camera belongs to the user, not to the data.
+- Nothing the user does to the picture may look like a change to the model.
+
+The read API delivers a flat list of components with `parentComponentId`, a flat
+list of typed relationships, and orders both by id (ADR 0005). It has no notion
+of coordinates, and it must not gain one: v0 is read-only observation, and the
+agent reports an architecture, not a diagram.
+
+## Decision
+
+### A pure projection adapter between the domain model and React Flow
+
+`src/canvas/graphProjection.ts` is the single translation from
+`Component[]`/`Relationship[]` to React Flow `Node[]`/`Edge[]`. It contains no
+React and no React Flow runtime code — the only import from `@xyflow/react` is a
+type import, which the compiler erases — so the hierarchy rules, the bundling
+rule and the robustness rules can be tested without rendering anything.
+
+It is **total**. A snapshot is agent-reported data, and agent-reported data can
+be wrong:
+
+| Input | Behaviour | Diagnostic |
+| --- | --- | --- |
+| `parentComponentId` not in the snapshot | component becomes a root | `orphanedParents` |
+| cycle in the hierarchy | alphabetically first member is cut loose | `hierarchyCycles` |
+| relationship endpoint not in the snapshot | relationship is not drawn | `danglingRelationships` |
+| duplicate id | first occurrence wins | `duplicate*Ids` |
+
+Nothing is dropped silently: everything the adapter had to repair is counted and
+surfaced on the canvas. Cutting the *alphabetically first* member of a cycle
+rather than the first one encountered is what makes the repair independent of
+the order the rows arrived in.
+
+### ELK `layered`, and determinism as a tested property
+
+An architecture model is a directed, mostly acyclic graph: callers left,
+callees right, one layer per hop. That is exactly what a Sugiyama-style
+algorithm draws, so `elk.algorithm: layered` with `elk.direction: RIGHT`.
+Force-directed layouts were rejected because they produce a different picture
+every run, and tree layouts because they cannot express the cross-links an
+architecture is full of.
+
+`elk.hierarchyHandling: INCLUDE_CHILDREN` lets one layout pass place the nested
+compound containers and route edges across container boundaries;
+`elk.edgeRouting: ORTHOGONAL` is not cosmetic, because the layered algorithm
+sizes the gap between two layers according to the routing style.
+
+**Determinism is secured on three levels, and each is covered by a test:**
+
+1. **Canonical input.** The projection emits nodes and edges sorted by id
+   (parents before children, as React Flow requires), and the layout sorts again
+   before handing the graph to ELK. The order the read API serialised its rows
+   in therefore cannot reach the solver.
+2. **Pinned randomness.** `elk.randomSeed` is fixed and the order-driven
+   heuristics are selected explicitly (`LAYER_SWEEP`,
+   `considerModelOrder.strategy: NODES_AND_EDGES`, `BRANDES_KOEPF`).
+3. **Fixed sizes.** Node sizes are constants, never measured from the DOM and
+   never dependent on the zoom-driven detail level. A layout that depended on a
+   rendered box would differ between a browser and a test, and between the first
+   and the second frame.
+
+The results are rounded to hundredths of a pixel, which turns "the same model
+lays out identically" into a statement that can be asserted bit for bit.
+`elkLayout.test.ts` lays the same model out twice, lays out a version with
+re-shuffled input lists, and compares positions and edge routes.
+
+ELK is loaded through a dynamic `import()`. Its bundled build is ~1.4 MB and has
+no business in the entry chunk of a cockpit that may never open a project; it
+now forms its own chunk, which is the code splitting ADR 0003 anticipated.
+
+**Handles are declared, not measured.** Every node carries its two handles
+(incoming left-centre, outgoing right-centre) on the node object, and ELK gets
+fixed ports at exactly those coordinates (`elk.portConstraints: FIXED_POS`). The
+polyline ELK returns therefore starts and ends *on* the handle. Edge geometry
+becomes a pure function of the layout instead of a function of a rendered DOM.
+
+### Relationship kinds are encoded without colour at all
+
+`src/index.css` reserves the accent hues for the four work states, because in
+this product colour means "phase of work" (ADR 0003). Spending six more hues on
+relationship kinds would either collide with that or force the reader to learn
+two unrelated colour languages at once.
+
+So relationship kinds use **no colour whatsoever**. Every edge is drawn in the
+same graphite, and the kind is carried by three channels that survive greyscale:
+a stroke pattern that is unique per kind, an arrow head (filled or open) and a
+text badge with the kind's abbreviation. A greyscale screenshot of the canvas
+loses no information about what kind an edge is, and the legend shows exactly
+those three channels.
+
+### Bundling is a rendering, and it must be reversible
+
+Every NATS topic is its own relationship; the server never merges them
+(ADR 0005), and neither does the adapter. But three parallel lines between the
+same two boxes are unreadable at overview zoom, so the canvas draws one edge per
+ordered node pair.
+
+That edge **carries the complete, individually addressable list**. Whether it is
+drawn as one line or as several is a rendering decision:
+
+- folded (default, low zoom): one line, one badge with the count and the kind
+  (`3 × NATS`),
+- unfolded (zoom ≥ 1.15, or one click on the badge): one line per relationship,
+  each labelled with what identifies it — `channel` for a topic, `operation` for
+  a call.
+
+Bundling by the **ordered** pair, not the unordered one, keeps the direction of
+an edge meaningful; `A → B` and `B → A` stay two edges.
+
+The reason the reversibility is a decision and not a detail: a bundle that could
+not be opened would be an aggregation, and an aggregation is exactly what the
+contract forbids for topics. If the user cannot get from the picture back to the
+individual reported topic, the canvas has silently lost data the agent sent.
+`resolveEdgeBundle` is the function that guarantees the way back, and a test
+asserts it by reading the `channel` and `operation` of each individual
+relationship of a folded bundle.
+
+The layout always runs on the folded graph — one ELK edge per pair — so
+unfolding a bundle never moves a node.
+
+### Progressive detail, without touching the layout
+
+Three levels: `overview` (name + kind), `standard` (+ technology), `full`
+(+ tags, bundles unfolded). The **node box size is the same at all three**. If
+the box grew with the detail level, zooming in would re-layout the graph and
+move everything under the camera — the exact motion this canvas exists to avoid.
+Only the content inside the fixed box changes.
+
+The levels are a shortcut, never a gate: everything hidden at `overview` stays
+reachable by interaction at that zoom level.
+
+### Temporary positions stay local
+
+Dragging a node is allowed, and it writes into `uiStore.nodePositions` — local,
+transient, not persisted, and never into the query cache or the domain model
+(ADR 0003). Two reasons, and the second is the important one:
+
+- v0 is read-only observation. The architecture is what the agent reported; it
+  is not the user's to edit.
+- If a drag reached the model, a refetch could not tell a user's gesture from a
+  reported change. The read API would then have to carry coordinates, and the
+  cockpit would start owning a diagram instead of showing an architecture.
+
+`applyTemporaryPositions` is the boundary: server-derived nodes in, local
+positions in, a render-only result out. Nothing writes back. Edges whose
+endpoint was dragged lose their ELK route and fall back to a plain orthogonal
+connection, so a moved node never drags a stale polyline behind it. The toolbar
+offers "Positionen zurücksetzen", which is a no-op on the model by construction.
+
+### The camera moves by itself only while the surface is still settling
+
+`fitView` runs in exactly three situations: the first laid-out model of a
+project, a change of the *surface size* before the user has touched the camera,
+and an explicit user action. **An incoming live event is none of them** — not a
+new component, not a removed relationship, not a replacing snapshot.
+
+The resize case is not a loophole, it is the fix for a real defect: the three
+panes measure themselves asynchronously, so the first layout can arrive while
+the centre pane is still a few hundred pixels wide. Fitting against that leaves
+the model pinned at minimum zoom with no indication why. The policy therefore
+waits for a surface of at least 240 × 240 and re-fits if the surface changes
+size *before* the first real pan or zoom. React Flow reports `null` as the event
+of a programmatic move and the input event of a user one, which is exactly the
+distinction needed to tell "still settling" from "the user is driving".
+
+The rule lives in `cameraPolicy.ts` as a pure function rather than inside the
+canvas component, so it can be asserted directly: five consecutive model updates
+must all return "do not move", and so must a resize after the user took over.
+The integration test additionally replaces the whole architecture through the
+real SSE code path and checks that the rendered viewport transform, the
+selection and the number of `fitView` calls are unchanged afterwards.
+
+`instance.fitView()` itself is not used. It schedules itself through React
+Flow's node-change queue, which a fully controlled graph without `onNodesChange`
+never drains — the call is silently dropped. The canvas computes the viewport
+from the layout bounds and applies it with `setViewport`, which also makes the
+resulting camera a pure function of the ELK layout.
+
+Selection is not canvas state either. A click writes the `component` search
+param through the typed route (#7); the canvas reads it back. A deep link and a
+click therefore produce the same state, and a live update cannot disturb either.
+
+### The minimap stays
+
+At 1920 × 1080 the centre pane is ~1037 px wide and ~880 px tall. The minimap is
+168 × 112 px in the top-right corner — about 2 % of the canvas area, and it sits
+over empty space rather than over the graph, because the layout grows to the
+right and downwards from the origin. That is a fair price for orientation in a
+model that no longer fits on screen, which is the normal case above ~20
+components. It is switchable, and the toggle is persisted with the other
+layout-ish UI state.
+
+## Consequences
+
+- The read API stays free of coordinates, and it must stay that way: the moment
+  a position is reported, the determinism argument above becomes the server's
+  problem instead of the client's.
+- A new relationship kind needs a new entry in `relationshipKinds.ts` with a
+  stroke pattern that is not already taken. Six kinds are comfortable; beyond
+  roughly eight, stroke patterns stop being distinguishable and the encoding
+  would have to change — probably to a badge-only scheme.
+- ELK is a real solver and the layout is asynchronous. The canvas keeps the
+  previous graph on screen while it runs and shows a quiet indicator, so a
+  re-layout never blanks the surface. A layout that fails leaves the last good
+  picture visible.
+- The layout is skipped entirely when the structural fingerprint of a refetch is
+  unchanged, which is the common case: TanStack Query's structural sharing keeps
+  the array identity, and a `projectionSignature` catches the rest.
+- The overlays in #10 attach to this structure without changing it: a work state
+  becomes a border style and an icon on an existing node, and a stroke colour on
+  an existing edge. Neither changes a node's box size, so neither can move the
+  layout.
+- The initial bundle grew by React Flow; ELK is lazy. The 500 kB warning of
+  ADR 0003 still applies to the entry chunk and is still acceptable for a
+  desktop cockpit on a local network.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.18",
+        "@xyflow/react": "^12.11.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "elkjs": "^0.12.0",
         "lucide-react": "^1.28.0",
         "radix-ui": "^1.6.7",
         "react": "^19.2.0",
@@ -3794,6 +3796,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4276,6 +4327,76 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.79",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -4564,6 +4685,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4682,6 +4809,111 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -4778,6 +5010,12 @@
       "integrity": "sha512-96EWDNjM59SYflgeV5Ylsf4EMiq1a25YjCnJH7cxn/AF2H3pILRweaUnoLax0yKHWdpOzY6JKEu45e8irqZIHA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elkjs": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.12.0.tgz",
+      "integrity": "sha512-YZcKynxVxYoKIOEpywEPwCFdg+BTbxQRNf3pbwdDCvc8O3kQD8bmIwSxKU1eOTVc4Xo+VG9Te+575mlfvOrhEQ==",
+      "license": "EPL-2.0 OR GPL-3.0-or-later"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,10 @@
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.18",
+    "@xyflow/react": "^12.11.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "elkjs": "^0.12.0",
     "lucide-react": "^1.28.0",
     "radix-ui": "^1.6.7",
     "react": "^19.2.0",

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -1,0 +1,427 @@
+import { act, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { queryKeys } from '@/api/queryKeys'
+import type { ArchitectureResponse } from '@/api/types'
+import { applyLiveEvent } from '@/api/useLiveStream'
+import { DEFAULT_CAMERA, useUiStore } from '@/state/uiStore'
+import {
+  BUNDLED_TOPIC_CHANNELS,
+  NESTED_COMPONENTS,
+  NESTED_RELATIONSHIPS,
+  grownArchitectureResponse,
+  nestedArchitectureResponse,
+} from '@/test/architectureFixtures'
+import { PROJECT_ID, RUN_ID, createFakeFetch, streamedEvent } from '@/test/fixtures'
+import { renderApp } from '@/test/renderApp'
+
+import { RELATIONSHIP_KIND_STYLES } from './relationshipKinds'
+
+const WORKSPACE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}`
+const ARCHITECTURE_PATH = `/api/v1/projects/${PROJECT_ID}/architecture`
+const BUNDLE_EDGE_ID = 'rel:platform.core.orders~>platform.bus'
+
+/** ELK runs for real in these tests; it needs a moment on a nested model. */
+const CANVAS_TIMEOUT = 15_000
+
+/**
+ * A fetch double whose architecture response can be swapped, so a test can
+ * simulate a live update that really changes the model.
+ */
+function architectureFetch(initial: ArchitectureResponse) {
+  const state = { response: initial }
+  const fetchImpl = createFakeFetch({
+    get [ARCHITECTURE_PATH]() {
+      return state.response
+    },
+  })
+  return {
+    fetchImpl,
+    publish(next: ArchitectureResponse) {
+      state.response = next
+    },
+  }
+}
+
+function renderCanvas(url = WORKSPACE_URL, initial = nestedArchitectureResponse) {
+  const architecture = architectureFetch(initial)
+  const app = renderApp(url, { fetchImpl: architecture.fetchImpl })
+  return { ...app, ...architecture }
+}
+
+/** Resolves once the first ELK layout landed. */
+async function waitForCanvas(): Promise<HTMLElement> {
+  const canvas = await screen.findByTestId('architecture-canvas', undefined, {
+    timeout: CANVAS_TIMEOUT,
+  })
+  await waitFor(
+    () => expect(canvas.getAttribute('data-layouting')).toBe('false'),
+    { timeout: CANVAS_TIMEOUT },
+  )
+  return canvas
+}
+
+/** The rendered zoom and pan — the ground truth of where the camera is. */
+function viewportTransform(): string {
+  const viewport = document.querySelector<HTMLElement>('.react-flow__viewport')
+  return viewport?.style.transform ?? ''
+}
+
+/**
+ * Resolves once the camera stopped moving, i.e. once the one automatic fit of
+ * the first model has run its course. Everything after this point must leave
+ * the camera alone.
+ */
+async function waitForCameraSettled(): Promise<void> {
+  // The initial fit always moves the camera off the default for this fixture.
+  await waitFor(
+    () => expect(useUiStore.getState().camera).not.toEqual(DEFAULT_CAMERA),
+    { timeout: CANVAS_TIMEOUT },
+  )
+  let previous = useUiStore.getState().camera
+  await waitFor(
+    () => {
+      const current = useUiStore.getState().camera
+      const settled = current === previous
+      previous = current
+      expect(settled).toBe(true)
+    },
+    { timeout: CANVAS_TIMEOUT, interval: 40 },
+  )
+}
+
+describe('architecture canvas — rendering', () => {
+  it(
+    'renders every component of the nested snapshot as a node',
+    async () => {
+      renderCanvas()
+      const canvas = await waitForCanvas()
+
+      expect(canvas.getAttribute('data-node-count')).toBe(
+        String(NESTED_COMPONENTS.length),
+      )
+
+      for (const component of NESTED_COMPONENTS) {
+        const node = await screen.findByTestId(`canvas-node-${component.componentId}`)
+        expect(within(node).getByTestId('node-name')).toHaveTextContent(component.name)
+      }
+
+      // Containers render as compound nodes, leaves do not.
+      expect(screen.getByTestId('canvas-node-platform')).toHaveAttribute(
+        'data-compound',
+        'true',
+      )
+      expect(
+        screen.getByTestId('canvas-node-platform.api.http.router'),
+      ).not.toHaveAttribute('data-compound')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'draws one edge per node pair and keeps all eight relationships',
+    async () => {
+      renderCanvas()
+      const canvas = await waitForCanvas()
+
+      // Six pairs carry eight relationships — three NATS topics share a pair.
+      expect(canvas.getAttribute('data-edge-count')).toBe('6')
+      expect(NESTED_RELATIONSHIPS).toHaveLength(8)
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('architecture canvas — colour-independent relationship kinds', () => {
+  it('gives every kind a unique stroke pattern, an arrow head and a badge', () => {
+    const dashArrays = RELATIONSHIP_KIND_STYLES.map((style) => style.strokeDasharray)
+    const abbreviations = RELATIONSHIP_KIND_STYLES.map((style) => style.abbreviation)
+
+    expect(RELATIONSHIP_KIND_STYLES).toHaveLength(6)
+    // The stroke pattern alone already separates all six kinds…
+    expect(new Set(dashArrays).size).toBe(6)
+    // …and so does the badge text.
+    expect(new Set(abbreviations).size).toBe(6)
+    // Two different arrow heads add a third channel.
+    expect(new Set(RELATIONSHIP_KIND_STYLES.map((style) => style.marker)).size).toBe(2)
+    // None of the styles carries a colour at all: colour is reserved for the
+    // work states, so a kind must survive a greyscale screenshot.
+    for (const style of RELATIONSHIP_KIND_STYLES) {
+      expect(Object.keys(style)).not.toContain('color')
+      expect(Object.keys(style)).not.toContain('colorVar')
+    }
+  })
+
+  it(
+    'renders the drawn edge with its kind as stroke pattern and marker, not colour',
+    async () => {
+      renderCanvas()
+      await waitForCanvas()
+
+      // `platform.core.orders -> platform.db` is the single `data` edge.
+      const path = await screen.findByTestId(
+        'edge-path-rel:platform.core.orders~>platform.db',
+      )
+      expect(path).toHaveAttribute('data-relationship-kind', 'data')
+      expect(path).toHaveAttribute('stroke-dasharray', '2 4')
+      expect(path.getAttribute('marker-end')).toContain('vai-edge-marker-arrow')
+      // The stroke itself is the neutral graphite of every edge.
+      expect(path).toHaveAttribute('stroke', 'currentColor')
+      expect(path.getAttribute('class')).toContain('text-muted-foreground')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it('lists all six kinds in the legend with their line style and marker', async () => {
+    renderCanvas()
+    await waitForCanvas()
+
+    for (const style of RELATIONSHIP_KIND_STYLES) {
+      const entry = screen.getByTestId(`relationship-legend-${style.id}`)
+      expect(entry).toHaveAttribute('data-dasharray', style.strokeDasharray)
+      expect(entry).toHaveAttribute('data-marker', style.marker)
+      expect(entry).toHaveTextContent(style.abbreviation)
+    }
+  })
+})
+
+describe('architecture canvas — edge bundling stays resolvable', () => {
+  it(
+    'bundles the three NATS topics and makes each of them reachable by clicking',
+    async () => {
+      const user = userEvent.setup()
+      renderCanvas()
+      await waitForCanvas()
+
+      // Folded: one collector edge carrying the count.
+      const bundle = await screen.findByTestId(`edge-bundle-${BUNDLE_EDGE_ID}`)
+      expect(bundle).toHaveTextContent('3 × NATS')
+      for (const channel of BUNDLED_TOPIC_CHANNELS) {
+        expect(screen.queryByText(new RegExp(channel))).not.toBeInTheDocument()
+      }
+
+      // Unfolding it is an interaction on the canvas, available at any zoom.
+      await user.click(bundle)
+
+      // Every single topic is now individually addressable, labelled with its
+      // own channel — the bundle was a rendering, never a merge.
+      for (const relationshipId of ['r-05', 'r-06', 'r-07']) {
+        const label = screen.getByTestId(`edge-label-${relationshipId}`)
+        const channel = NESTED_RELATIONSHIPS.find(
+          (relationship) => relationship.relationshipId === relationshipId,
+        )?.channel
+        expect(channel).toBeTruthy()
+        expect(label).toHaveTextContent(`NATS · ${channel}`)
+        expect(label).toHaveAttribute('title', expect.stringContaining('publish'))
+
+        const path = screen.getByTestId(`edge-path-${relationshipId}`)
+        expect(path).toHaveAttribute('data-relationship-kind', 'nats_topic')
+      }
+
+      // The three lines are drawn as separate, parallel paths.
+      const paths = ['r-05', 'r-06', 'r-07'].map((id) =>
+        screen.getByTestId(`edge-path-${id}`).getAttribute('d'),
+      )
+      expect(new Set(paths).size).toBe(3)
+
+      // Folding it again returns to the collector edge.
+      await user.click(screen.getByTestId(`edge-collapse-${BUNDLE_EDGE_ID}`))
+      expect(screen.getByTestId(`edge-bundle-${BUNDLE_EDGE_ID}`)).toBeInTheDocument()
+      expect(screen.queryByTestId('edge-label-r-05')).not.toBeInTheDocument()
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'selecting one topic of an unfolded bundle marks exactly that relationship',
+    async () => {
+      const user = userEvent.setup()
+      renderCanvas()
+      await waitForCanvas()
+
+      await user.click(await screen.findByTestId(`edge-bundle-${BUNDLE_EDGE_ID}`))
+      await user.click(screen.getByTestId('edge-label-r-06'))
+
+      expect(useUiStore.getState().selectedRelationshipId).toBe('r-06')
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('architecture canvas — selection', () => {
+  it(
+    'writes the clicked component into the `component` search parameter',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCanvas()
+      await waitForCanvas()
+
+      expect(router.state.location.search).toEqual({})
+
+      await user.click(await screen.findByTestId('canvas-node-platform.core.orders'))
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({
+          component: 'platform.core.orders',
+        }),
+      )
+
+      // The URL is the single source of truth; the canvas mirrors it back.
+      await waitFor(() =>
+        expect(screen.getByTestId('canvas-node-platform.core.orders')).toHaveAttribute(
+          'data-selected',
+          'true',
+        ),
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'restores the selection from a deep link without a click',
+    async () => {
+      renderCanvas(`${WORKSPACE_URL}?component=platform.db`)
+      await waitForCanvas()
+
+      await waitFor(() =>
+        expect(screen.getByTestId('canvas-node-platform.db')).toHaveAttribute(
+          'data-selected',
+          'true',
+        ),
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('architecture canvas — live updates never move the camera', () => {
+  it(
+    'keeps zoom, pan and selection when the architecture is replaced live',
+    async () => {
+      const { queryClient, publish } = renderCanvas(
+        `${WORKSPACE_URL}?component=platform.db`,
+      )
+      const canvas = await waitForCanvas()
+
+      // The one automatic camera movement: the first model of this project.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+      await waitForCameraSettled()
+
+      const cameraBefore = useUiStore.getState().camera
+      const transformBefore = viewportTransform()
+      expect(transformBefore).not.toBe('')
+      expect(useUiStore.getState().selectedComponentId).toBe('platform.db')
+
+      // A real live event: a replacing architecture snapshot, routed through
+      // the very same code path the SSE client uses.
+      publish(grownArchitectureResponse)
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent('architecture.snapshot_published', {
+            snapshotId: 'snapshot-2',
+            components: grownArchitectureResponse.components,
+            relationships: grownArchitectureResponse.relationships,
+          }),
+        )
+      })
+
+      // The new component really arrived…
+      expect(
+        await screen.findByTestId('canvas-node-platform.core.shipping', undefined, {
+          timeout: CANVAS_TIMEOUT,
+        }),
+      ).toBeInTheDocument()
+      await waitFor(
+        () => expect(canvas.getAttribute('data-layouting')).toBe('false'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+
+      // …and nothing about the camera or the selection moved with it.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+      expect(viewportTransform()).toBe(transformBefore)
+      expect(useUiStore.getState().camera).toEqual(cameraBefore)
+      expect(useUiStore.getState().selectedComponentId).toBe('platform.db')
+      expect(screen.getByTestId('canvas-node-platform.db')).toHaveAttribute(
+        'data-selected',
+        'true',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'fits the view again only when the user asks for it',
+    async () => {
+      const user = userEvent.setup()
+      renderCanvas()
+      const canvas = await waitForCanvas()
+
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+      await user.click(screen.getByTestId('canvas-fit-view'))
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('2')
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('architecture canvas — temporary node positions', () => {
+  it(
+    'keeps a dragged position out of the server state and out of the model',
+    async () => {
+      const { queryClient } = renderCanvas()
+      await waitForCanvas()
+
+      const cached = () =>
+        queryClient.getQueryData<ArchitectureResponse>(queryKeys.architecture(PROJECT_ID))
+      const before = structuredClone(cached())
+      expect(before?.components).toHaveLength(NESTED_COMPONENTS.length)
+
+      // What `onNodeDragStop` does: local UI state, nothing else.
+      act(() => {
+        useUiStore.getState().setNodePosition('external.payments', { x: 1234, y: 567 })
+      })
+
+      expect(useUiStore.getState().nodePositions).toEqual({
+        'external.payments': { x: 1234, y: 567 },
+      })
+      // It really moves on screen…
+      await waitFor(() =>
+        expect(
+          document.querySelector<HTMLElement>(
+            '.react-flow__node[data-id="external.payments"]',
+          )?.style.transform,
+        ).toBe('translate(1234px,567px)'),
+      )
+      // The cached read model is byte-for-byte what the API returned.
+      expect(cached()).toEqual(before)
+      expect(JSON.stringify(cached())).not.toContain('1234')
+
+      // A refetch brings the reported model back untouched — a drag can never
+      // be mistaken for a domain change.
+      await act(async () => {
+        await queryClient.refetchQueries({ queryKey: queryKeys.architecture(PROJECT_ID) })
+      })
+      expect(cached()).toEqual(before)
+
+      // The drag is also not persisted: only layout-ish UI state is.
+      const persisted = JSON.parse(localStorage.getItem('visualise-ai.ui') ?? '{}')
+      expect(JSON.stringify(persisted)).not.toContain('nodePositions')
+
+      // And it can be undone without touching the model.
+      const reset = await screen.findByTestId('canvas-reset-positions')
+      act(() => reset.click())
+      expect(useUiStore.getState().nodePositions).toEqual({})
+      expect(cached()).toEqual(before)
+      await waitFor(() =>
+        expect(
+          document.querySelector<HTMLElement>(
+            '.react-flow__node[data-id="external.payments"]',
+          )?.style.transform,
+        ).not.toBe('translate(1234px,567px)'),
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+})

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -1,0 +1,467 @@
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  Panel,
+  ReactFlow,
+  ReactFlowProvider,
+  getNodesBounds,
+  getViewportForBounds,
+  useReactFlow,
+  useStore,
+  useStoreApi,
+  type NodeMouseHandler,
+  type OnNodeDrag,
+  type Viewport,
+} from '@xyflow/react'
+import { Map, MapPinOff, Maximize2, RotateCcw, TriangleAlert } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import '@xyflow/react/dist/style.css'
+
+import type { ComponentId, ProjectId } from '@/api/types'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useUiStore } from '@/state/uiStore'
+
+import { EdgeMarkerDefs } from './RelationshipEdge'
+import {
+  INITIAL_CAMERA_POLICY,
+  onLayoutReady,
+  onProjectChanged,
+  onUserFitRequest,
+  type CameraPolicyState,
+} from './cameraPolicy'
+import {
+  DETAIL_LEVEL_DESCRIPTIONS,
+  DETAIL_LEVEL_LABELS,
+  detailLevelForZoom,
+} from './detailLevel'
+import { ARCHITECTURE_EDGE_TYPES, ARCHITECTURE_NODE_TYPES } from './flowRegistry'
+import {
+  COMPOUND_NODE_TYPE,
+  diagnosticsCount,
+  type ArchitectureEdge,
+  type ArchitectureModel,
+} from './graphProjection'
+import {
+  applyTemporaryPositions,
+  routesInvalidatedByDrag,
+  useArchitectureGraph,
+} from './useArchitectureGraph'
+
+/**
+ * The interactive architecture canvas.
+ *
+ * Everything structural happens elsewhere — `graphProjection` builds the graph,
+ * `elkLayout` places it, `cameraPolicy` decides when the camera may move. This
+ * component wires those to React Flow and owns exactly three interaction rules:
+ *
+ * 1. **Selecting a component is a URL change**, not canvas state. Clicking a
+ *    node calls back into the route, which sets the `component` search param and
+ *    with it the inspector context. The canvas reads the selection back from
+ *    there, so a deep link and a click produce the same state.
+ * 2. **Dragging is temporary and local.** `onNodeDragStop` writes into the UI
+ *    store and nowhere else. The architecture read model is what the agent
+ *    reported; it is not the user's to edit, and a refetch must not be able to
+ *    pick a drag up as a domain change.
+ * 3. **The camera is the user's.** `fitView` runs on the first model of a
+ *    project and on an explicit click, never because data arrived.
+ */
+
+const MIN_ZOOM = 0.12
+const MAX_ZOOM = 2.5
+/** Never zoom *in* to fit: a two-component model must not fill the screen. */
+const FIT_VIEW_MAX_ZOOM = 1
+const FIT_VIEW_PADDING = 0.1
+
+const NODE_TYPES = ARCHITECTURE_NODE_TYPES
+const EDGE_TYPES = ARCHITECTURE_EDGE_TYPES
+
+export interface ArchitectureCanvasProps {
+  projectId: ProjectId
+  model: ArchitectureModel
+  selectedComponentId?: ComponentId | undefined
+  onSelectComponent: (componentId: ComponentId | null) => void
+}
+
+export function ArchitectureCanvas(props: ArchitectureCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <ArchitectureCanvasInner {...props} />
+    </ReactFlowProvider>
+  )
+}
+
+function ArchitectureCanvasInner({
+  projectId,
+  model,
+  selectedComponentId,
+  onSelectComponent,
+}: ArchitectureCanvasProps) {
+  const graph = useArchitectureGraph(model)
+  const flow = useReactFlow()
+  const storeApi = useStoreApi()
+
+  const camera = useUiStore((state) => state.camera)
+  const setCamera = useUiStore((state) => state.setCamera)
+  const nodePositions = useUiStore((state) => state.nodePositions)
+  const setNodePosition = useUiStore((state) => state.setNodePosition)
+  const clearNodePositions = useUiStore((state) => state.clearNodePositions)
+  const minimapVisible = useUiStore((state) => state.minimapVisible)
+  const setMinimapVisible = useUiStore((state) => state.setMinimapVisible)
+  const clearExpandedEdges = useUiStore((state) => state.clearExpandedEdges)
+
+  // The size of the drawing surface, as React Flow measures it. Subscribing
+  // here is what lets the initial fit wait for the three panes to settle
+  // instead of fitting against a pane that has not measured itself yet.
+  const surfaceWidth = useStore((state) => state.width)
+  const surfaceHeight = useStore((state) => state.height)
+
+  const [detailLevel, setDetailLevel] = useState(() => detailLevelForZoom(camera.zoom))
+  const [fitViewCount, setFitViewCount] = useState(0)
+  const policyRef = useRef<CameraPolicyState>(INITIAL_CAMERA_POLICY)
+  // Flipped by the first pan or zoom that came from a real input event. From
+  // then on the camera is the user's and nothing but "Einpassen" touches it.
+  const userMovedCameraRef = useRef(false)
+  // The very first viewport React Flow renders with. Read once so a later
+  // camera change never re-mounts the flow.
+  const [initialViewport] = useState<Viewport>(() => useUiStore.getState().camera)
+
+  const nodes = useMemo(
+    () =>
+      applyTemporaryPositions(graph.nodes, nodePositions, selectedComponentId ?? null),
+    [graph.nodes, nodePositions, selectedComponentId],
+  )
+  /**
+   * Fits the whole model into the viewport.
+   *
+   * The viewport is computed and applied explicitly instead of going through
+   * `instance.fitView()`: that call schedules itself through React Flow's node
+   * change queue, which a fully controlled graph without `onNodesChange` never
+   * drains. Computing it here also makes the result a pure function of the ELK
+   * layout — the same model always ends up under the same camera.
+   */
+  const fitView = useCallback(() => {
+    setFitViewCount((count) => count + 1)
+
+    const { width, height, nodeLookup } = storeApi.getState()
+    if (nodeLookup.size === 0) return
+
+    const bounds = getNodesBounds([...nodeLookup.values()], { nodeLookup })
+    if (width <= 0 || height <= 0 || bounds.width <= 0 || bounds.height <= 0) return
+
+    const viewport = getViewportForBounds(
+      bounds,
+      width,
+      height,
+      MIN_ZOOM,
+      FIT_VIEW_MAX_ZOOM,
+      FIT_VIEW_PADDING,
+    )
+    void flow.setViewport(viewport)
+    setCamera(viewport)
+    setDetailLevel(detailLevelForZoom(viewport.zoom))
+  }, [flow, storeApi, setCamera])
+
+  // Switching projects makes the next model an initial one again.
+  useEffect(() => {
+    policyRef.current = onProjectChanged(policyRef.current, projectId)
+    clearExpandedEdges()
+  }, [projectId, clearExpandedEdges])
+
+  // The only automatic camera movement in the whole cockpit: the first laid-out
+  // model of a project, plus a resize of the surface while it is still settling
+  // and the user has not taken the camera over. Every later layout — an added
+  // component, a removed relationship, a replacing snapshot — returns `null`
+  // here and leaves zoom, pan and selection exactly where the user left them.
+  useEffect(() => {
+    const decision = onLayoutReady(policyRef.current, {
+      projectId,
+      hasLayout: graph.nodes.length > 0,
+      viewport: { width: surfaceWidth, height: surfaceHeight },
+      userMovedCamera: userMovedCameraRef.current,
+    })
+    policyRef.current = decision.state
+    if (decision.fit === null) return
+    fitView()
+  }, [projectId, graph.nodes.length, surfaceWidth, surfaceHeight, fitView])
+
+  const edges = useMemo<ArchitectureEdge[]>(() => {
+    const invalidated = routesInvalidatedByDrag(graph.edges, nodePositions)
+    return graph.edges.map((edge) => {
+      const route = invalidated.has(edge.id) ? undefined : graph.routes[edge.id]
+      if (!edge.data) return edge
+      return { ...edge, data: { ...edge.data, ...(route ? { route } : {}) } }
+    })
+  }, [graph.edges, graph.routes, nodePositions])
+
+  const onNodeClick = useCallback<NodeMouseHandler>(
+    (_event, node) => {
+      onSelectComponent(node.id === selectedComponentId ? null : node.id)
+    },
+    [onSelectComponent, selectedComponentId],
+  )
+
+  // Temporary, local, never persisted and never sent anywhere.
+  const onNodeDragStop = useCallback<OnNodeDrag>(
+    (_event, node) => {
+      setNodePosition(node.id, { x: node.position.x, y: node.position.y })
+    },
+    [setNodePosition],
+  )
+
+  // React Flow passes `null` for a programmatic move and the real input event
+  // for a user one — which is exactly the distinction the camera policy needs.
+  const onMoveStart = useCallback((event: unknown) => {
+    if (event !== null && event !== undefined) userMovedCameraRef.current = true
+  }, [])
+
+  const onMove = useCallback(
+    (_event: unknown, viewport: Viewport) => {
+      setDetailLevel(detailLevelForZoom(viewport.zoom))
+    },
+    [],
+  )
+
+  const onMoveEnd = useCallback(
+    (_event: unknown, viewport: Viewport) => {
+      setCamera(viewport)
+      setDetailLevel(detailLevelForZoom(viewport.zoom))
+    },
+    [setCamera],
+  )
+
+  const hasTemporaryPositions = Object.keys(nodePositions).length > 0
+  const problemCount = diagnosticsCount(graph.diagnostics)
+
+  return (
+    <div
+      className="relative h-full w-full min-w-0"
+      data-testid="architecture-canvas"
+      data-fit-view-count={fitViewCount}
+      data-detail-level={detailLevel}
+      data-node-count={nodes.length}
+      data-edge-count={edges.length}
+      data-layouting={graph.isRelayouting ? 'true' : 'false'}
+    >
+      <EdgeMarkerDefs />
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={NODE_TYPES}
+        edgeTypes={EDGE_TYPES}
+        defaultViewport={initialViewport}
+        minZoom={MIN_ZOOM}
+        maxZoom={MAX_ZOOM}
+        onNodeClick={onNodeClick}
+        onNodeDragStop={onNodeDragStop}
+        onMoveStart={onMoveStart}
+        onMove={onMove}
+        onMoveEnd={onMoveEnd}
+        nodesDraggable
+        nodesConnectable={false}
+        edgesReconnectable={false}
+        elementsSelectable
+        // Selection is owned by the URL, so React Flow must not manage its own.
+        selectNodesOnDrag={false}
+        multiSelectionKeyCode={null}
+        deleteKeyCode={null}
+        proOptions={{ hideAttribution: false }}
+        attributionPosition="bottom-left"
+        className="bg-canvas"
+        aria-label="Interaktiver Architekturgraph"
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={28}
+          size={1}
+          color="var(--canvas-grid)"
+        />
+        <Controls
+          showInteractive={false}
+          // The built-in fit control is replaced by "Einpassen" in the toolbar,
+          // which goes through the camera policy instead of around it.
+          showFitView={false}
+          position="bottom-right"
+          className="!border-border !bg-card/90 !shadow-none [&>button]:!border-border [&>button]:!bg-card [&>button]:!fill-current [&>button]:!text-foreground"
+        />
+        {minimapVisible && (
+          <MiniMap
+            position="top-right"
+            pannable
+            zoomable
+            ariaLabel="Übersichtskarte der Architektur"
+            className="!border-border !bg-card/80 !m-2 !rounded-md !border"
+            style={{ width: 168, height: 112 }}
+            maskColor="color-mix(in oklab, var(--background) 72%, transparent)"
+            nodeColor={(node) =>
+              node.type === COMPOUND_NODE_TYPE
+                ? 'var(--graphite-700)'
+                : 'var(--graphite-400)'
+            }
+            nodeStrokeWidth={0}
+          />
+        )}
+
+        <Panel position="top-left" className="!m-2">
+          <div className="border-border bg-card/90 flex items-center gap-1 rounded-md border px-1 py-1 backdrop-blur-sm">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1.5 px-2 text-xs"
+                  onClick={() => {
+                    policyRef.current = onUserFitRequest(policyRef.current).state
+                    fitView()
+                  }}
+                  data-testid="canvas-fit-view"
+                >
+                  <Maximize2 aria-hidden="true" />
+                  Einpassen
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Ansicht auf das gesamte Modell einpassen. Die Kamera bewegt sich sonst nur
+                beim ersten Laden — nie durch eintreffende Ereignisse.
+              </TooltipContent>
+            </Tooltip>
+
+            {hasTemporaryPositions && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 text-xs"
+                    onClick={clearNodePositions}
+                    data-testid="canvas-reset-positions"
+                  >
+                    <RotateCcw aria-hidden="true" />
+                    Positionen zurücksetzen
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Verschobene Knoten zurück auf das berechnete Layout. Verschiebungen sind
+                  ohnehin nur lokal und ändern das Architekturmodell nicht.
+                </TooltipContent>
+              </Tooltip>
+            )}
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7"
+                  onClick={() => setMinimapVisible(!minimapVisible)}
+                  aria-pressed={minimapVisible}
+                  data-testid="canvas-toggle-minimap"
+                >
+                  {minimapVisible ? (
+                    <Map aria-hidden="true" />
+                  ) : (
+                    <MapPinOff aria-hidden="true" />
+                  )}
+                  <span className="sr-only">
+                    Übersichtskarte {minimapVisible ? 'ausblenden' : 'einblenden'}
+                  </span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Übersichtskarte {minimapVisible ? 'ausblenden' : 'einblenden'}
+              </TooltipContent>
+            </Tooltip>
+
+            <span className="bg-border mx-0.5 h-4 w-px" aria-hidden="true" />
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="text-muted-foreground px-1 text-[11px] whitespace-nowrap"
+                  data-testid="canvas-detail-level"
+                >
+                  Detailstufe: {DETAIL_LEVEL_LABELS[detailLevel]}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{DETAIL_LEVEL_DESCRIPTIONS[detailLevel]}</TooltipContent>
+            </Tooltip>
+
+            {problemCount > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="text-state-planned flex items-center gap-1 px-1 text-[11px]"
+                    data-testid="canvas-diagnostics"
+                  >
+                    <TriangleAlert className="size-3.5" aria-hidden="true" />
+                    {problemCount} unstimmige Angaben
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-80">
+                  <DiagnosticsSummary graph={graph} />
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </Panel>
+
+        {graph.isRelayouting && (
+          <Panel position="top-center" className="!m-2">
+            <span
+              className="border-border bg-card/90 text-muted-foreground rounded-md border px-2 py-1 text-[11px]"
+              role="status"
+              data-testid="canvas-layouting"
+            >
+              Layout wird berechnet…
+            </span>
+          </Panel>
+        )}
+      </ReactFlow>
+    </div>
+  )
+}
+
+function DiagnosticsSummary({
+  graph,
+}: {
+  graph: ReturnType<typeof useArchitectureGraph>
+}) {
+  const { diagnostics } = graph
+  const lines: string[] = []
+  if (diagnostics.orphanedParents.length > 0) {
+    lines.push(
+      `${diagnostics.orphanedParents.length} Komponente(n) verweisen auf ein Elternteil, das nicht Teil des Snapshots ist. Sie werden als eigenständige Wurzeln gezeigt.`,
+    )
+  }
+  if (diagnostics.hierarchyCycles.length > 0) {
+    lines.push(
+      `${diagnostics.hierarchyCycles.length} Zyklus/Zyklen in der Hierarchie. Der jeweils erste Knoten wurde gelöst, damit die Struktur darstellbar bleibt.`,
+    )
+  }
+  if (diagnostics.danglingRelationships.length > 0) {
+    lines.push(
+      `${diagnostics.danglingRelationships.length} Beziehung(en) zeigen auf eine Komponente außerhalb des Snapshots und werden nicht gezeichnet.`,
+    )
+  }
+  if (diagnostics.duplicateComponentIds.length > 0) {
+    lines.push(
+      `${diagnostics.duplicateComponentIds.length} doppelte Komponenten-ID(s); jeweils die erste Meldung wird gezeigt.`,
+    )
+  }
+  if (diagnostics.duplicateRelationshipIds.length > 0) {
+    lines.push(
+      `${diagnostics.duplicateRelationshipIds.length} doppelte Beziehungs-ID(s); jeweils die erste Meldung wird gezeigt.`,
+    )
+  }
+  return (
+    <ul className="space-y-1 text-xs">
+      {lines.map((line) => (
+        <li key={line}>{line}</li>
+      ))}
+    </ul>
+  )
+}
+

--- a/frontend/src/canvas/ComponentNode.tsx
+++ b/frontend/src/canvas/ComponentNode.tsx
@@ -1,0 +1,184 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { memo } from 'react'
+
+import { cn } from '@/lib/utils'
+
+import { componentKindStyle, componentTags, technologyParts } from './componentKinds'
+import { showsTags, showsTechnology } from './detailLevel'
+import { HANDLE_IDS, type ArchitectureNode } from './graphProjection'
+import { useDetailLevel } from './useDetailLevel'
+
+/**
+ * The two node renderers of the architecture canvas.
+ *
+ * `ComponentNode` draws a component without children, `CompoundNode` draws a
+ * container around its children. Both take their size from the layout and
+ * **never change it with the detail level** — the box is a fixed part of the
+ * layout, only its content grows with the zoom (see `./detailLevel`).
+ */
+
+/** Invisible, non-interactive connection points. v0 is read-only. */
+function NodeHandles() {
+  return (
+    <>
+      <Handle
+        type="target"
+        id={HANDLE_IDS.target}
+        position={Position.Left}
+        isConnectable={false}
+        className="!size-1.5 !border-0 !bg-transparent"
+      />
+      <Handle
+        type="source"
+        id={HANDLE_IDS.source}
+        position={Position.Right}
+        isConnectable={false}
+        className="!size-1.5 !border-0 !bg-transparent"
+      />
+    </>
+  )
+}
+
+interface KindBadgeProps {
+  label: string
+  className?: string
+}
+
+function KindBadge({ label, className }: KindBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'border-border/80 text-muted-foreground shrink-0 rounded-sm border px-1 py-px text-[10px] leading-tight tracking-wide uppercase',
+        className,
+      )}
+      data-testid="node-kind"
+    >
+      {label}
+    </span>
+  )
+}
+
+function TechnologyRow({ parts }: { parts: string[] }) {
+  if (parts.length === 0) return null
+  return (
+    <p
+      className="text-muted-foreground truncate font-mono text-[10px] leading-tight"
+      data-testid="node-technology"
+      title={parts.join(' · ')}
+    >
+      {parts.join(' · ')}
+    </p>
+  )
+}
+
+function TagRow({ tags }: { tags: string[] }) {
+  if (tags.length === 0) return null
+  return (
+    <ul className="flex flex-wrap gap-1 overflow-hidden" data-testid="node-tags">
+      {tags.map((tag) => (
+        <li
+          key={tag}
+          className="bg-secondary/70 text-muted-foreground rounded-sm px-1 text-[10px] leading-tight"
+        >
+          {tag}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export const ComponentNode = memo(function ComponentNode({
+  data,
+  selected,
+}: NodeProps<ArchitectureNode>) {
+  const level = useDetailLevel()
+  const { component } = data
+  const kind = componentKindStyle(component.kind)
+  const Icon = kind.icon
+  const technology = technologyParts(component.technology)
+  const tags = componentTags(component)
+
+  return (
+    <div
+      className={cn(
+        'bg-card/95 border-border flex h-full w-full flex-col gap-1 overflow-hidden rounded-md border px-2.5 py-2 text-left shadow-sm transition-colors',
+        'hover:border-muted-foreground/60',
+        selected && 'ring-ring border-ring/70 ring-2',
+      )}
+      data-testid={`canvas-node-${component.componentId}`}
+      data-component-id={component.componentId}
+      data-detail-level={level}
+      data-selected={selected ? 'true' : 'false'}
+    >
+      <div className="flex items-start gap-1.5">
+        <Icon className="text-muted-foreground mt-px size-3.5 shrink-0" aria-hidden="true" />
+        <span
+          className="text-foreground min-w-0 flex-1 truncate text-[13px] leading-tight font-medium"
+          title={component.name}
+          data-testid="node-name"
+        >
+          {component.name}
+        </span>
+        <KindBadge label={kind.label} />
+      </div>
+
+      {showsTechnology(level) && <TechnologyRow parts={technology} />}
+      {showsTags(level) && <TagRow tags={tags} />}
+
+      <NodeHandles />
+    </div>
+  )
+})
+
+export const CompoundNode = memo(function CompoundNode({
+  data,
+  selected,
+}: NodeProps<ArchitectureNode>) {
+  const level = useDetailLevel()
+  const { component, childCount } = data
+  const kind = componentKindStyle(component.kind)
+  const Icon = kind.icon
+  const technology = technologyParts(component.technology)
+
+  return (
+    <div
+      className={cn(
+        'border-border/90 bg-card/35 h-full w-full rounded-lg border',
+        selected && 'ring-ring border-ring/70 ring-2',
+      )}
+      data-testid={`canvas-node-${component.componentId}`}
+      data-component-id={component.componentId}
+      data-detail-level={level}
+      data-compound="true"
+      data-selected={selected ? 'true' : 'false'}
+    >
+      {/* Header row. The ELK padding reserves exactly this height at the top of
+          the container, so it never overlaps a child. */}
+      <div className="border-border/70 flex h-10 items-center gap-1.5 border-b px-2.5">
+        <Icon className="text-muted-foreground size-3.5 shrink-0" aria-hidden="true" />
+        <span
+          className="text-foreground min-w-0 flex-1 truncate text-[13px] leading-tight font-medium"
+          title={component.name}
+          data-testid="node-name"
+        >
+          {component.name}
+        </span>
+        {showsTechnology(level) && technology.length > 0 && (
+          <span
+            className="text-muted-foreground max-w-40 truncate font-mono text-[10px]"
+            data-testid="node-technology"
+          >
+            {technology.join(' · ')}
+          </span>
+        )}
+        <span className="text-muted-foreground shrink-0 text-[10px]">
+          {childCount} Kinder
+        </span>
+        <KindBadge label={kind.label} />
+      </div>
+
+      <NodeHandles />
+    </div>
+  )
+})
+

--- a/frontend/src/canvas/RelationshipEdge.tsx
+++ b/frontend/src/canvas/RelationshipEdge.tsx
@@ -1,0 +1,377 @@
+import { EdgeLabelRenderer, type EdgeProps } from '@xyflow/react'
+import { memo, type ReactNode } from 'react'
+
+import type { Relationship } from '@/api/types'
+import { cn } from '@/lib/utils'
+import { useUiStore } from '@/state/uiStore'
+
+import { unfoldsBundles } from './detailLevel'
+import {
+  fallbackRoute,
+  fanOffset,
+  fanRoute,
+  pointAtRatio,
+  roundedPolylinePath,
+} from './edgeGeometry'
+import type { LayoutPoint } from './elkLayout'
+import { resolveRelationships, type ArchitectureEdge } from './graphProjection'
+import {
+  MARKER_IDS,
+  RELATIONSHIP_KIND_STYLE_BY_ID,
+  markerUrl,
+  reported,
+} from './relationshipKinds'
+import { useDetailLevel } from './useDetailLevel'
+
+/**
+ * One rendered relationship edge.
+ *
+ * An edge carries **all** relationships the agent reported for its ordered pair
+ * of components. Whether they are drawn as one line or as several is a
+ * rendering decision that depends on the zoom level and on what the user asked
+ * for — it is never a change to the model:
+ *
+ * * folded (low zoom, default): one line plus a badge with the count, and the
+ *   kinds it contains,
+ * * unfolded (high zoom, or after a click on the badge): one line per
+ *   relationship, each labelled with what identifies it — the topic name for a
+ *   NATS topic, the operation for a call.
+ *
+ * That is what makes the bundling reversible: no zoom level and no interaction
+ * can make a single reported topic unreachable.
+ */
+
+interface EdgeRouteProps {
+  points: LayoutPoint[]
+  strokeDasharray: string
+  marker: 'arrow' | 'arrowclosed'
+  emphasised: boolean
+  interactive: boolean
+  testId?: string
+  kind?: string
+}
+
+/**
+ * One drawn line. The wide transparent path underneath is the hit area: a 1.5 px
+ * line is not a pointer target.
+ */
+function EdgeRoute({
+  points,
+  strokeDasharray,
+  marker,
+  emphasised,
+  interactive,
+  testId,
+  kind,
+}: EdgeRouteProps) {
+  const path = roundedPolylinePath(points)
+  if (path === '') return null
+
+  return (
+    <>
+      {interactive && (
+        <path
+          d={path}
+          fill="none"
+          stroke="transparent"
+          strokeWidth={14}
+          className="react-flow__edge-interaction"
+        />
+      )}
+      <path
+        d={path}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={emphasised ? 2.25 : 1.5}
+        strokeDasharray={strokeDasharray === '0' ? undefined : strokeDasharray}
+        strokeLinecap="round"
+        markerEnd={markerUrl(marker, emphasised)}
+        className={cn(
+          'transition-colors',
+          emphasised ? 'text-ring' : 'text-muted-foreground',
+        )}
+        data-testid={testId}
+        data-relationship-kind={kind}
+        data-dasharray={strokeDasharray}
+      />
+    </>
+  )
+}
+
+/** HTML badge anchored to a point in flow coordinates. */
+function EdgeBadge({
+  point,
+  children,
+  onClick,
+  title,
+  testId,
+  emphasised,
+}: {
+  point: LayoutPoint
+  children: ReactNode
+  onClick?: () => void
+  title?: string
+  testId?: string
+  emphasised?: boolean
+}) {
+  const className = cn(
+    'pointer-events-auto rounded-sm border px-1 py-px font-mono text-[10px] leading-tight whitespace-nowrap',
+    emphasised
+      ? 'border-ring/70 bg-popover text-foreground'
+      : 'border-border bg-popover/95 text-muted-foreground',
+    onClick && 'hover:border-muted-foreground cursor-pointer',
+  )
+  const style = {
+    position: 'absolute' as const,
+    transform: `translate(-50%, -50%) translate(${point.x}px, ${point.y}px)`,
+  }
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        style={style}
+        className={className}
+        onClick={onClick}
+        title={title}
+        data-testid={testId}
+      >
+        {children}
+      </button>
+    )
+  }
+
+  return (
+    <span style={style} className={className} title={title} data-testid={testId}>
+      {children}
+    </span>
+  )
+}
+
+export const RelationshipEdge = memo(function RelationshipEdge({
+  id,
+  data,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+}: EdgeProps<ArchitectureEdge>) {
+  const level = useDetailLevel()
+  const expandedEdgeIds = useUiStore((state) => state.expandedEdgeIds)
+  const toggleEdgeExpanded = useUiStore((state) => state.toggleEdgeExpanded)
+  const selectedRelationshipId = useUiStore((state) => state.selectedRelationshipId)
+  const setSelectedRelationshipId = useUiStore((state) => state.setSelectedRelationshipId)
+
+  if (!data) return null
+
+  const resolved = resolveRelationships(data.relationships)
+  if (resolved.length === 0) return null
+
+  // The route comes from ELK when it is still valid. After a drag it is not,
+  // and a plain orthogonal fallback between the two handles takes over.
+  const route: LayoutPoint[] =
+    data.route ?? fallbackRoute({ x: sourceX, y: sourceY }, { x: targetX, y: targetY })
+
+  const bundled = resolved.length > 1
+  const unfolded = bundled && (unfoldsBundles(level) || expandedEdgeIds.includes(id))
+
+  if (!bundled || !unfolded) {
+    const kinds = [...new Set(resolved.map((entry) => entry.relationship.kind))]
+    const onlyKind = kinds.length === 1 ? kinds[0] : null
+    const style = onlyKind ? RELATIONSHIP_KIND_STYLE_BY_ID[onlyKind] : null
+    const single = resolved.length === 1 ? (resolved[0] ?? null) : null
+    const emphasised =
+      single !== null && single.relationship.relationshipId === selectedRelationshipId
+
+    const badgePoint = pointAtRatio(route, 0.5)
+    const badgeLabel = bundled
+      ? `${resolved.length} × ${
+          style
+            ? style.abbreviation
+            : kinds
+                .map((kind) => RELATIONSHIP_KIND_STYLE_BY_ID[kind]?.abbreviation ?? kind)
+                .join('/')
+        }`
+      : (style?.abbreviation ?? '')
+    const discriminator = single?.discriminator
+
+    return (
+      <>
+        <EdgeRoute
+          points={route}
+          strokeDasharray={style?.strokeDasharray ?? '3 3'}
+          marker={style?.marker ?? 'arrow'}
+          emphasised={emphasised}
+          interactive
+          testId={`edge-path-${id}`}
+          {...(onlyKind ? { kind: onlyKind } : {})}
+        />
+        <EdgeLabelRenderer>
+          {bundled ? (
+            <EdgeBadge
+              point={badgePoint}
+              onClick={() => toggleEdgeExpanded(id)}
+              title={`Sammelkante aufklappen: ${resolved
+                .map((entry) => entry.displayName)
+                .join(', ')}`}
+              testId={`edge-bundle-${id}`}
+            >
+              {badgeLabel} ▸
+            </EdgeBadge>
+          ) : (
+            level !== 'overview' &&
+            single && (
+              <EdgeBadge
+                point={badgePoint}
+                onClick={() =>
+                  setSelectedRelationshipId(
+                    emphasised ? null : single.relationship.relationshipId,
+                  )
+                }
+                title={relationshipTitle(single.relationship)}
+                testId={`edge-label-${single.relationship.relationshipId}`}
+                {...(emphasised ? { emphasised: true } : {})}
+              >
+                {badgeLabel}
+                {discriminator ? ` · ${discriminator}` : ''}
+              </EdgeBadge>
+            )
+          )}
+        </EdgeLabelRenderer>
+      </>
+    )
+  }
+
+  // Unfolded bundle: one line and one label per reported relationship.
+  return (
+    <>
+      {resolved.map((entry) => {
+        const style = RELATIONSHIP_KIND_STYLE_BY_ID[entry.relationship.kind]
+        const fanned = fanRoute(route, fanOffset(entry.index, entry.total))
+        const emphasised = entry.relationship.relationshipId === selectedRelationshipId
+        return (
+          <EdgeRoute
+            key={entry.relationship.relationshipId}
+            points={fanned}
+            strokeDasharray={style?.strokeDasharray ?? '3 3'}
+            marker={style?.marker ?? 'arrow'}
+            emphasised={emphasised}
+            interactive={false}
+            testId={`edge-path-${entry.relationship.relationshipId}`}
+            kind={entry.relationship.kind}
+          />
+        )
+      })}
+      <EdgeLabelRenderer>
+        {resolved.map((entry) => {
+          const style = RELATIONSHIP_KIND_STYLE_BY_ID[entry.relationship.kind]
+          const fanned = fanRoute(route, fanOffset(entry.index, entry.total))
+          const emphasised = entry.relationship.relationshipId === selectedRelationshipId
+          return (
+            <EdgeBadge
+              key={entry.relationship.relationshipId}
+              point={pointAtRatio(fanned, 0.5)}
+              onClick={() =>
+                setSelectedRelationshipId(
+                  emphasised ? null : entry.relationship.relationshipId,
+                )
+              }
+              title={relationshipTitle(entry.relationship)}
+              testId={`edge-label-${entry.relationship.relationshipId}`}
+              {...(emphasised ? { emphasised: true } : {})}
+            >
+              {style?.abbreviation ?? entry.relationship.kind}
+              {entry.discriminator ? ` · ${entry.discriminator}` : ''}
+            </EdgeBadge>
+          )
+        })}
+        <EdgeBadge
+          point={pointAtRatio(route, 0.12)}
+          onClick={() => toggleEdgeExpanded(id)}
+          title="Sammelkante wieder zusammenklappen"
+          testId={`edge-collapse-${id}`}
+        >
+          ▾ {resolved.length}
+        </EdgeBadge>
+      </EdgeLabelRenderer>
+    </>
+  )
+})
+
+function relationshipTitle(relationship: Relationship): string {
+  const style = RELATIONSHIP_KIND_STYLE_BY_ID[relationship.kind]
+  const parts = [
+    style?.label ?? relationship.kind,
+    reported(relationship.label),
+    reported(relationship.protocol) ? `Protokoll: ${relationship.protocol}` : null,
+    reported(relationship.operation) ? `Operation: ${relationship.operation}` : null,
+    reported(relationship.channel) ? `Kanal: ${relationship.channel}` : null,
+  ].filter((part): part is string => part !== null && part !== undefined)
+  return parts.join('\n')
+}
+
+/**
+ * The two arrow heads, declared once per canvas.
+ *
+ * React Flow would synthesise a marker per edge; an edge here draws several
+ * paths with different heads, so the canvas owns them instead. The arrow head
+ * is one of the three colour-independent channels that distinguish a
+ * relationship kind.
+ */
+export function EdgeMarkerDefs() {
+  return (
+    <svg className="pointer-events-none absolute size-0" aria-hidden="true">
+      <defs>
+        <marker
+          id={MARKER_IDS.arrowclosed}
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--graphite-400)" />
+        </marker>
+        <marker
+          id={MARKER_IDS.arrow}
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          markerWidth="7"
+          markerHeight="7"
+          orient="auto-start-reverse"
+        >
+          <path
+            d="M 1 1 L 9 5 L 1 9"
+            fill="none"
+            stroke="var(--graphite-400)"
+            strokeWidth="1.6"
+          />
+        </marker>
+        <marker
+          id={MARKER_IDS.arrowclosedSelected}
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ring)" />
+        </marker>
+        <marker
+          id={MARKER_IDS.arrowSelected}
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          markerWidth="7"
+          markerHeight="7"
+          orient="auto-start-reverse"
+        >
+          <path d="M 1 1 L 9 5 L 1 9" fill="none" stroke="var(--ring)" strokeWidth="1.6" />
+        </marker>
+      </defs>
+    </svg>
+  )
+}

--- a/frontend/src/canvas/cameraPolicy.test.ts
+++ b/frontend/src/canvas/cameraPolicy.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  INITIAL_CAMERA_POLICY,
+  MIN_FIT_VIEWPORT,
+  onLayoutReady,
+  onProjectChanged,
+  onUserFitRequest,
+  type CameraPolicyInput,
+} from './cameraPolicy'
+
+/** A settled 1920 × 1080 workspace: the centre pane is ~1036 × 933. */
+const SURFACE = { width: 1036, height: 933 }
+
+function input(overrides: Partial<CameraPolicyInput> = {}): CameraPolicyInput {
+  return {
+    projectId: 'visualise-ai',
+    hasLayout: true,
+    viewport: SURFACE,
+    userMovedCamera: false,
+    ...overrides,
+  }
+}
+
+describe('camera policy', () => {
+  it('fits the view once, for the first model of a project', () => {
+    const first = onLayoutReady(INITIAL_CAMERA_POLICY, input())
+    expect(first.fit).toBe('initial-model')
+
+    expect(onLayoutReady(first.state, input()).fit).toBeNull()
+  })
+
+  it('never fits again because the model changed', () => {
+    let state = onLayoutReady(INITIAL_CAMERA_POLICY, input()).state
+
+    // A component was added, one was removed, a snapshot replaced everything —
+    // every one of these produces a new layout, and none of them may move the
+    // camera the user set.
+    for (let update = 0; update < 5; update += 1) {
+      const decision = onLayoutReady(state, input())
+      expect(decision.fit).toBeNull()
+      state = decision.state
+    }
+  })
+
+  it('waits for a layout before considering a fit', () => {
+    const decision = onLayoutReady(INITIAL_CAMERA_POLICY, input({ hasLayout: false }))
+    expect(decision.fit).toBeNull()
+    expect(decision.state).toBe(INITIAL_CAMERA_POLICY)
+  })
+
+  it('waits for the surface to have a usable size', () => {
+    // The panes measure themselves asynchronously; fitting against a pane that
+    // is still a few pixels wide leaves the model at minimum zoom.
+    const tooSmall = onLayoutReady(
+      INITIAL_CAMERA_POLICY,
+      input({ viewport: { width: MIN_FIT_VIEWPORT - 1, height: 900 } }),
+    )
+    expect(tooSmall.fit).toBeNull()
+    expect(tooSmall.state.fittedProjectId).toBeNull()
+
+    // Once it has one, the first fit happens against the real size.
+    const settled = onLayoutReady(tooSmall.state, input())
+    expect(settled.fit).toBe('initial-model')
+    expect(settled.state.fittedSize).toEqual(SURFACE)
+  })
+
+  it('re-fits while the surface is still settling, but not after the user took over', () => {
+    const initial = onLayoutReady(
+      INITIAL_CAMERA_POLICY,
+      input({ viewport: { width: 400, height: 900 } }),
+    )
+    expect(initial.fit).toBe('initial-model')
+
+    // The pane grew to its real width before the user touched anything.
+    const resized = onLayoutReady(initial.state, input())
+    expect(resized.fit).toBe('surface-resized')
+    expect(resized.state.fittedSize).toEqual(SURFACE)
+
+    // The same size again changes nothing.
+    expect(onLayoutReady(resized.state, input()).fit).toBeNull()
+
+    // And once the user has panned or zoomed, even a resize leaves the camera
+    // alone: it is theirs from that moment on.
+    expect(
+      onLayoutReady(
+        resized.state,
+        input({ viewport: { width: 700, height: 933 }, userMovedCamera: true }),
+      ).fit,
+    ).toBeNull()
+  })
+
+  it('does not treat a live update as a resize', () => {
+    const state = onLayoutReady(INITIAL_CAMERA_POLICY, input()).state
+    // Same surface, new model, user has not touched anything: still no move.
+    expect(onLayoutReady(state, input()).fit).toBeNull()
+  })
+
+  it('always honours an explicit user request without consuming the initial fit', () => {
+    const request = onUserFitRequest(INITIAL_CAMERA_POLICY)
+    expect(request.fit).toBe('user-request')
+    expect(request.state).toEqual(INITIAL_CAMERA_POLICY)
+
+    expect(onUserFitRequest(onUserFitRequest(INITIAL_CAMERA_POLICY).state).fit).toBe(
+      'user-request',
+    )
+  })
+
+  it('treats the first model of another project as an initial one again', () => {
+    const fitted = onLayoutReady(
+      INITIAL_CAMERA_POLICY,
+      input({ projectId: 'project-a' }),
+    ).state
+
+    expect(onProjectChanged(fitted, 'project-a')).toBe(fitted)
+
+    const switched = onProjectChanged(fitted, 'project-b')
+    expect(switched).toEqual(INITIAL_CAMERA_POLICY)
+    expect(onLayoutReady(switched, input({ projectId: 'project-b' })).fit).toBe(
+      'initial-model',
+    )
+  })
+})

--- a/frontend/src/canvas/cameraPolicy.ts
+++ b/frontend/src/canvas/cameraPolicy.ts
@@ -1,0 +1,123 @@
+/**
+ * When the canvas is allowed to move the camera by itself.
+ *
+ * The cockpit is watched while an agent works, and events arrive while the user
+ * is reading. A canvas that re-centres itself on every incoming
+ * `component.change_applied` makes the tool unusable exactly when it matters,
+ * so the rule is deliberately narrow:
+ *
+ * > The camera moves by itself only while the surface is still settling into
+ * > its first picture of a project. After that it belongs to the user.
+ *
+ * Concretely, three things and nothing else move it:
+ *
+ * 1. the first laid-out model of a project,
+ * 2. a change of the *surface size* before the user has touched the camera —
+ *    the three panes measure themselves asynchronously, so the very first fit
+ *    can otherwise be computed against a pane that is still 100 px wide,
+ * 3. an explicit click on "Einpassen".
+ *
+ * **A live update is never one of them** — not a new component, not a new
+ * relationship, not a replacing snapshot. Data changes the model under a camera
+ * that stays exactly where it was.
+ *
+ * The rule lives in this module rather than inside the canvas component so it
+ * can be exercised directly, without a rendered React Flow.
+ */
+export type FitViewReason = 'initial-model' | 'surface-resized' | 'user-request'
+
+export interface ViewportSize {
+  width: number
+  height: number
+}
+
+export interface CameraPolicyState {
+  /** Project whose model has already been fitted, if any. */
+  fittedProjectId: string | null
+  /** Surface size that fit was computed against. */
+  fittedSize: ViewportSize | null
+}
+
+export const INITIAL_CAMERA_POLICY: CameraPolicyState = {
+  fittedProjectId: null,
+  fittedSize: null,
+}
+
+/**
+ * Smallest surface worth fitting to. Below this the pane is collapsed or has
+ * not measured itself yet, and a fit would only produce a camera the user has
+ * to undo.
+ */
+export const MIN_FIT_VIEWPORT = 240
+
+export interface CameraPolicyInput {
+  projectId: string
+  /** `true` once a layout for this project exists and could be fitted. */
+  hasLayout: boolean
+  /** Current size of the canvas surface. */
+  viewport: ViewportSize
+  /** `true` once the user panned or zoomed themselves. */
+  userMovedCamera: boolean
+}
+
+export interface CameraPolicyDecision {
+  state: CameraPolicyState
+  /** Non-null when the camera may be moved, carrying the reason why. */
+  fit: FitViewReason | null
+}
+
+/**
+ * Decides whether the arrival of a laid-out model — or a resize of the surface
+ * it is drawn on — should move the camera.
+ *
+ * Called on every render with a layout. It returns a reason at most once per
+ * project, plus while the surface is still finding its size and the user has
+ * not taken over. A model that grows, shrinks or is replaced produces `null`,
+ * which is the whole point.
+ */
+export function onLayoutReady(
+  state: CameraPolicyState,
+  input: CameraPolicyInput,
+): CameraPolicyDecision {
+  const { projectId, hasLayout, viewport, userMovedCamera } = input
+
+  if (!hasLayout) return { state, fit: null }
+  if (viewport.width < MIN_FIT_VIEWPORT || viewport.height < MIN_FIT_VIEWPORT) {
+    return { state, fit: null }
+  }
+
+  if (state.fittedProjectId !== projectId) {
+    return {
+      state: { fittedProjectId: projectId, fittedSize: viewport },
+      fit: 'initial-model',
+    }
+  }
+
+  const settling =
+    !userMovedCamera &&
+    state.fittedSize !== null &&
+    (state.fittedSize.width !== viewport.width ||
+      state.fittedSize.height !== viewport.height)
+
+  if (settling) {
+    return { state: { ...state, fittedSize: viewport }, fit: 'surface-resized' }
+  }
+
+  return { state, fit: null }
+}
+
+/** The user pressed "fit view". Always allowed, and does not change the state. */
+export function onUserFitRequest(state: CameraPolicyState): CameraPolicyDecision {
+  return { state, fit: 'user-request' }
+}
+
+/**
+ * Switching to another project makes that project's first model an initial one
+ * again — the camera of project A means nothing in project B.
+ */
+export function onProjectChanged(
+  state: CameraPolicyState,
+  projectId: string,
+): CameraPolicyState {
+  return state.fittedProjectId === projectId ? state : INITIAL_CAMERA_POLICY
+}

--- a/frontend/src/canvas/componentKinds.ts
+++ b/frontend/src/canvas/componentKinds.ts
@@ -1,0 +1,70 @@
+import {
+  Boxes,
+  Database,
+  Globe,
+  Inbox,
+  Layers,
+  Library,
+  Package,
+  Radio,
+  Server,
+  type LucideIcon,
+} from 'lucide-react'
+
+import type { Component, ComponentKind, Technology } from '@/api/types'
+
+import { reported } from './relationshipKinds'
+
+/**
+ * Display vocabulary for the nine component kinds of the contract.
+ *
+ * Like the relationship kinds, a component kind is never expressed through
+ * colour — the accent hues belong to the work states. A node carries its kind
+ * as a text badge plus a glyph, which survives greyscale and is readable at the
+ * lowest detail level, where the kind is all a node shows besides its name.
+ */
+export interface ComponentKindStyle {
+  id: ComponentKind
+  label: string
+  icon: LucideIcon
+}
+
+export const COMPONENT_KIND_STYLES: Record<ComponentKind, ComponentKindStyle> = {
+  system: { id: 'system', label: 'System', icon: Boxes },
+  service: { id: 'service', label: 'Service', icon: Server },
+  module: { id: 'module', label: 'Modul', icon: Package },
+  datastore: { id: 'datastore', label: 'Datenspeicher', icon: Database },
+  queue: { id: 'queue', label: 'Queue', icon: Inbox },
+  topic: { id: 'topic', label: 'Topic', icon: Radio },
+  ui: { id: 'ui', label: 'UI', icon: Layers },
+  external: { id: 'external', label: 'Extern', icon: Globe },
+  library: { id: 'library', label: 'Bibliothek', icon: Library },
+}
+
+export function componentKindStyle(kind: ComponentKind): ComponentKindStyle {
+  return COMPONENT_KIND_STYLES[kind] ?? { id: kind, label: kind, icon: Package }
+}
+
+/**
+ * The reported technology metadata as an ordered list of non-empty parts.
+ *
+ * Nothing is inferred and nothing is filled in: a component whose agent
+ * reported no technology simply has no technology row. The read API sends empty
+ * strings rather than omitting fields, so empties are filtered here.
+ */
+export function technologyParts(technology: Technology | undefined): string[] {
+  if (!technology) return []
+  return [
+    reported(technology.language),
+    reported(technology.framework),
+    reported(technology.runtime),
+    reported(technology.version),
+  ].filter((part): part is string => part !== null)
+}
+
+/** Reported tags with empties removed. */
+export function componentTags(component: Component): string[] {
+  return (component.tags ?? [])
+    .map((tag) => reported(tag))
+    .filter((tag): tag is string => tag !== null)
+}

--- a/frontend/src/canvas/detailLevel.test.ts
+++ b/frontend/src/canvas/detailLevel.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DETAIL_LEVEL_LABELS,
+  DETAIL_LEVEL_THRESHOLDS,
+  detailLevelForZoom,
+  showsTags,
+  showsTechnology,
+  unfoldsBundles,
+} from './detailLevel'
+import { LEAF_NODE_SIZE } from './graphProjection'
+
+describe('progressive detail levels', () => {
+  it('shows only name and kind when zoomed out', () => {
+    const level = detailLevelForZoom(0.3)
+    expect(level).toBe('overview')
+    expect(showsTechnology(level)).toBe(false)
+    expect(showsTags(level)).toBe(false)
+    expect(unfoldsBundles(level)).toBe(false)
+  })
+
+  it('adds technology at medium zoom and tags when zoomed in', () => {
+    const standard = detailLevelForZoom(DETAIL_LEVEL_THRESHOLDS.standard)
+    expect(standard).toBe('standard')
+    expect(showsTechnology(standard)).toBe(true)
+    expect(showsTags(standard)).toBe(false)
+
+    const full = detailLevelForZoom(DETAIL_LEVEL_THRESHOLDS.full)
+    expect(full).toBe('full')
+    expect(showsTechnology(full)).toBe(true)
+    expect(showsTags(full)).toBe(true)
+    expect(unfoldsBundles(full)).toBe(true)
+  })
+
+  it('is monotonic and total', () => {
+    const order = { overview: 0, standard: 1, full: 2 }
+    let previous = -1
+    for (let zoom = 0.05; zoom <= 3; zoom += 0.05) {
+      const current = order[detailLevelForZoom(zoom)]
+      expect(current).toBeGreaterThanOrEqual(previous)
+      previous = current
+    }
+    // A broken zoom value must not produce an undefined level.
+    expect(detailLevelForZoom(Number.NaN)).toBe('standard')
+    expect(DETAIL_LEVEL_LABELS[detailLevelForZoom(Number.POSITIVE_INFINITY)]).toBeTruthy()
+  })
+
+  it('does not let the level influence the node box, and therefore the layout', () => {
+    // The size is a constant, not a function of the level: if it were, zooming
+    // would re-layout the graph and move everything under the camera.
+    expect(LEAF_NODE_SIZE).toEqual({ width: 228, height: 96 })
+  })
+})

--- a/frontend/src/canvas/detailLevel.ts
+++ b/frontend/src/canvas/detailLevel.ts
@@ -1,0 +1,73 @@
+/**
+ * Progressive detail levels of the architecture canvas.
+ *
+ * A v0 model can carry a few hundred components. Rendering every technology
+ * string, every tag and every relationship label at every zoom level turns the
+ * overview into noise long before that. The canvas therefore shows strictly
+ * more the closer the user is:
+ *
+ * | level      | nodes                        | edges                                  |
+ * | ---------- | ---------------------------- | -------------------------------------- |
+ * | `overview` | name + kind                  | bundled, count badge only              |
+ * | `standard` | + technology                 | bundled, kind badge + count            |
+ * | `full`     | + tags                       | bundles fanned out, one label per edge |
+ *
+ * Two rules keep this from becoming a source of surprise:
+ *
+ * 1. The **node box size never changes** with the level (see
+ *    `LEAF_NODE_SIZE`). Only the content inside it does, so the layout — and
+ *    therefore the position of everything under the camera — is invariant.
+ * 2. The levels are a *shortcut*, not a gate. Anything hidden at `overview`
+ *    remains reachable by interaction at that same zoom level: a bundle can be
+ *    unfolded by clicking it, and the inspector always has the full detail.
+ */
+export type DetailLevel = 'overview' | 'standard' | 'full'
+
+/**
+ * Zoom thresholds. Chosen so that the default `fitView` of a mid-sized model at
+ * 1920 × 1080 lands in `standard`, a fitted large model in `overview`, and
+ * reading a single component in `full`.
+ */
+export const DETAIL_LEVEL_THRESHOLDS = {
+  /** At or above this zoom the technology metadata appears. */
+  standard: 0.62,
+  /** At or above this zoom tags appear and edge bundles fan out. */
+  full: 1.15,
+} as const
+
+export function detailLevelForZoom(zoom: number): DetailLevel {
+  if (!Number.isFinite(zoom)) return 'standard'
+  if (zoom >= DETAIL_LEVEL_THRESHOLDS.full) return 'full'
+  if (zoom >= DETAIL_LEVEL_THRESHOLDS.standard) return 'standard'
+  return 'overview'
+}
+
+export const DETAIL_LEVEL_LABELS: Record<DetailLevel, string> = {
+  overview: 'Übersicht',
+  standard: 'Standard',
+  full: 'Vollständig',
+}
+
+export const DETAIL_LEVEL_DESCRIPTIONS: Record<DetailLevel, string> = {
+  overview: 'Nur Name und Art. Parallele Beziehungen sind gebündelt.',
+  standard: 'Zusätzlich die gemeldete Technologie. Parallele Beziehungen sind gebündelt.',
+  full: 'Zusätzlich Tags. Gebündelte Beziehungen sind einzeln aufgefächert.',
+}
+
+/** `true` once the level is detailed enough to show technology metadata. */
+export function showsTechnology(level: DetailLevel): boolean {
+  return level !== 'overview'
+}
+
+/** `true` once the level is detailed enough to show tags. */
+export function showsTags(level: DetailLevel): boolean {
+  return level === 'full'
+}
+
+/**
+ * `true` once bundles are unfolded automatically. Below this level a bundle can
+ * still be unfolded by clicking it — the zoom is a shortcut, not a gate.
+ */
+export function unfoldsBundles(level: DetailLevel): boolean {
+  return level === 'full'
+}

--- a/frontend/src/canvas/edgeGeometry.test.ts
+++ b/frontend/src/canvas/edgeGeometry.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BUNDLE_FAN_SPACING,
+  fallbackRoute,
+  fanOffset,
+  fanRoute,
+  pointAtRatio,
+  roundedPolylinePath,
+} from './edgeGeometry'
+
+describe('edge geometry', () => {
+  it('turns a polyline into a path with rounded corners', () => {
+    const path = roundedPolylinePath([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ])
+    expect(path.startsWith('M 0,0')).toBe(true)
+    expect(path).toContain('Q 100,0')
+    expect(path.endsWith('L 100,100')).toBe(true)
+  })
+
+  it('degrades gracefully for short polylines', () => {
+    expect(roundedPolylinePath([])).toBe('')
+    expect(roundedPolylinePath([{ x: 3, y: 4 }])).toBe('M 3,4')
+    expect(
+      roundedPolylinePath([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ]),
+    ).toBe('M 0,0 L 10,0')
+  })
+
+  it('fans a bundle out without detaching it from its handles', () => {
+    const route = [
+      { x: 0, y: 50 },
+      { x: 200, y: 50 },
+    ]
+    const fanned = fanRoute(route, 13)
+
+    // The endpoints stay exactly on the handles…
+    expect(fanned[0]).toEqual({ x: 0, y: 50 })
+    expect(fanned[fanned.length - 1]).toEqual({ x: 200, y: 50 })
+    // …while the middle of the line moves aside.
+    expect(fanned).toHaveLength(4)
+    expect(fanned[1]?.y).toBe(63)
+    expect(fanned[2]?.y).toBe(63)
+  })
+
+  it('centres the fan around the original route', () => {
+    expect(fanOffset(0, 1)).toBe(0)
+    expect(fanOffset(0, 3)).toBe(-BUNDLE_FAN_SPACING)
+    expect(fanOffset(1, 3)).toBe(0)
+    expect(fanOffset(2, 3)).toBe(BUNDLE_FAN_SPACING)
+    // Three lines of a bundle end up on three different paths.
+    const offsets = [0, 1, 2].map((index) => fanOffset(index, 3))
+    expect(new Set(offsets).size).toBe(3)
+  })
+
+  it('finds the midpoint of a polyline for the label', () => {
+    const midpoint = pointAtRatio([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ])
+    expect(midpoint).toEqual({ x: 100, y: 0 })
+    expect(pointAtRatio([{ x: 5, y: 5 }])).toEqual({ x: 5, y: 5 })
+    expect(pointAtRatio([], 0.5)).toEqual({ x: 0, y: 0 })
+  })
+
+  it('falls back to an orthogonal connection when no route was computed', () => {
+    expect(fallbackRoute({ x: 0, y: 10 }, { x: 100, y: 10 })).toEqual([
+      { x: 0, y: 10 },
+      { x: 100, y: 10 },
+    ])
+    expect(fallbackRoute({ x: 0, y: 0 }, { x: 100, y: 60 })).toEqual([
+      { x: 0, y: 0 },
+      { x: 50, y: 0 },
+      { x: 50, y: 60 },
+      { x: 100, y: 60 },
+    ])
+  })
+})

--- a/frontend/src/canvas/edgeGeometry.ts
+++ b/frontend/src/canvas/edgeGeometry.ts
@@ -1,0 +1,148 @@
+import type { LayoutPoint } from './elkLayout'
+
+/**
+ * Path helpers for the relationship edges.
+ *
+ * ELK returns each edge as an orthogonal polyline between the exact points
+ * where React Flow draws the handles. These helpers turn that polyline into an
+ * SVG path, and fan a bundle out into visually parallel lines without letting
+ * the endpoints come off their handles.
+ */
+
+const distance = (a: LayoutPoint, b: LayoutPoint): number =>
+  Math.hypot(b.x - a.x, b.y - a.y)
+
+const lerp = (from: LayoutPoint, to: LayoutPoint, ratio: number): LayoutPoint => ({
+  x: from.x + (to.x - from.x) * ratio,
+  y: from.y + (to.y - from.y) * ratio,
+})
+
+/** Default corner radius of a routed edge. */
+export const EDGE_CORNER_RADIUS = 10
+
+/** Vertical distance between two lines of a fanned-out bundle. */
+export const BUNDLE_FAN_SPACING = 13
+
+/**
+ * Turns a polyline into an SVG path with rounded corners.
+ *
+ * Rounding is purely cosmetic but it matters at this density: a sharp
+ * right angle at every bend makes a routed graph read as a circuit diagram.
+ */
+export function roundedPolylinePath(
+  points: readonly LayoutPoint[],
+  radius = EDGE_CORNER_RADIUS,
+): string {
+  const first = points[0]
+  if (!first) return ''
+  if (points.length === 1) return `M ${first.x},${first.y}`
+
+  let path = `M ${first.x},${first.y}`
+
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const previous = points[index - 1] as LayoutPoint
+    const current = points[index] as LayoutPoint
+    const next = points[index + 1] as LayoutPoint
+
+    const inLength = distance(previous, current)
+    const outLength = distance(current, next)
+    if (inLength === 0 || outLength === 0) continue
+
+    const corner = Math.min(radius, inLength / 2, outLength / 2)
+    const entry = lerp(current, previous, corner / inLength)
+    const exit = lerp(current, next, corner / outLength)
+
+    path += ` L ${round(entry.x)},${round(entry.y)}`
+    path += ` Q ${round(current.x)},${round(current.y)} ${round(exit.x)},${round(exit.y)}`
+  }
+
+  const last = points[points.length - 1] as LayoutPoint
+  return `${path} L ${round(last.x)},${round(last.y)}`
+}
+
+/**
+ * Offsets the interior of a route so that several relationships of one bundle
+ * are drawn as visually parallel lines.
+ *
+ * The first and the last point stay untouched: they are the handles, and a line
+ * that starts next to its node instead of on it reads as a rendering bug. A
+ * two-point route gets two synthetic interior points first, otherwise a
+ * straight connection could not be fanned out at all.
+ */
+export function fanRoute(
+  points: readonly LayoutPoint[],
+  offsetY: number,
+): LayoutPoint[] {
+  if (points.length < 2 || offsetY === 0) return [...points]
+
+  let working = [...points]
+  if (working.length === 2) {
+    const start = working[0] as LayoutPoint
+    const end = working[1] as LayoutPoint
+    working = [start, lerp(start, end, 0.3), lerp(start, end, 0.7), end]
+  }
+
+  return working.map((point, index) =>
+    index === 0 || index === working.length - 1
+      ? point
+      : { x: point.x, y: point.y + offsetY },
+  )
+}
+
+/**
+ * Vertical offset of entry `index` of a bundle of `total` entries, centred
+ * around the original route.
+ */
+export function fanOffset(index: number, total: number): number {
+  if (total <= 1) return 0
+  return (index - (total - 1) / 2) * BUNDLE_FAN_SPACING
+}
+
+/** Point at a given ratio of the polyline's length. Used to place labels. */
+export function pointAtRatio(
+  points: readonly LayoutPoint[],
+  ratio = 0.5,
+): LayoutPoint {
+  const first = points[0]
+  if (!first) return { x: 0, y: 0 }
+  if (points.length === 1) return first
+
+  let total = 0
+  for (let index = 1; index < points.length; index += 1) {
+    total += distance(points[index - 1] as LayoutPoint, points[index] as LayoutPoint)
+  }
+  if (total === 0) return first
+
+  let target = total * Math.min(Math.max(ratio, 0), 1)
+  for (let index = 1; index < points.length; index += 1) {
+    const from = points[index - 1] as LayoutPoint
+    const to = points[index] as LayoutPoint
+    const segment = distance(from, to)
+    if (segment === 0) continue
+    if (target <= segment) return lerp(from, to, target / segment)
+    target -= segment
+  }
+  return points[points.length - 1] as LayoutPoint
+}
+
+/**
+ * Fallback route when ELK has none — after a node was dragged, for example.
+ * A simple three-segment orthogonal connection through the horizontal midpoint.
+ */
+export function fallbackRoute(
+  source: LayoutPoint,
+  target: LayoutPoint,
+): LayoutPoint[] {
+  if (Math.abs(source.y - target.y) < 0.5) return [source, target]
+  const middleX = (source.x + target.x) / 2
+  return [
+    source,
+    { x: middleX, y: source.y },
+    { x: middleX, y: target.y },
+    target,
+  ]
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100
+}

--- a/frontend/src/canvas/elkLayout.test.ts
+++ b/frontend/src/canvas/elkLayout.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  NESTED_COMPONENTS,
+  NESTED_RELATIONSHIPS,
+  reorder,
+} from '@/test/architectureFixtures'
+
+import { buildElkGraph, describeLayout, layoutArchitecture } from './elkLayout'
+import { projectArchitecture } from './graphProjection'
+
+const model = { components: NESTED_COMPONENTS, relationships: NESTED_RELATIONSHIPS }
+
+/** ELK is a real solver; a nested model of this size needs a moment. */
+const LAYOUT_TIMEOUT = 30_000
+
+describe('ELK layered layout', () => {
+  it(
+    'is deterministic: laying out the same model twice gives identical positions',
+    async () => {
+      const projection = projectArchitecture(model)
+
+      const first = await layoutArchitecture(projection.nodes, projection.edges)
+      const second = await layoutArchitecture(projection.nodes, projection.edges)
+
+      expect(describeLayout(second)).toBe(describeLayout(first))
+      expect(second.nodes.map((node) => node.position)).toEqual(
+        first.nodes.map((node) => node.position),
+      )
+      expect(second.bounds).toEqual(first.bounds)
+      expect(second.routes).toEqual(first.routes)
+    },
+    LAYOUT_TIMEOUT,
+  )
+
+  it(
+    'is independent of the order of the input lists',
+    async () => {
+      const straight = projectArchitecture(model)
+      const shuffled = projectArchitecture({
+        components: reorder(NESTED_COMPONENTS),
+        relationships: reorder(NESTED_RELATIONSHIPS),
+      })
+
+      const fromStraight = await layoutArchitecture(straight.nodes, straight.edges)
+      const fromShuffled = await layoutArchitecture(shuffled.nodes, shuffled.edges)
+
+      expect(describeLayout(fromShuffled)).toBe(describeLayout(fromStraight))
+      expect(fromShuffled.routes).toEqual(fromStraight.routes)
+    },
+    LAYOUT_TIMEOUT,
+  )
+
+  it(
+    'is also independent of the order the layout function is handed the arrays in',
+    async () => {
+      const projection = projectArchitecture(model)
+
+      const straight = await layoutArchitecture(projection.nodes, projection.edges)
+      const reversed = await layoutArchitecture(
+        // Reversing the node array would break React Flow's parent-before-child
+        // rule, so the layout has to re-derive the hierarchy itself — which it
+        // does, from `parentId` rather than from the array order.
+        [...projection.nodes].reverse(),
+        [...projection.edges].reverse(),
+      )
+
+      const straightById = new Map(straight.nodes.map((node) => [node.id, node.position]))
+      for (const node of reversed.nodes) {
+        expect(node.position).toEqual(straightById.get(node.id))
+      }
+    },
+    LAYOUT_TIMEOUT,
+  )
+
+  it(
+    'places children inside their container and gives containers a real size',
+    async () => {
+      const projection = projectArchitecture(model)
+      const { nodes } = await layoutArchitecture(projection.nodes, projection.edges)
+      const byId = new Map(nodes.map((node) => [node.id, node]))
+
+      const container = byId.get('platform.api.http')
+      const child = byId.get('platform.api.http.router')
+      expect(container).toBeDefined()
+      expect(child).toBeDefined()
+
+      // A container is grown by ELK beyond the minimum it started with.
+      expect(container?.width ?? 0).toBeGreaterThan(0)
+      expect(container?.height ?? 0).toBeGreaterThan(0)
+
+      // React Flow expects a child position relative to its parent, and
+      // `extent: 'parent'` requires it to be inside the parent's box.
+      expect(child?.position.x ?? -1).toBeGreaterThanOrEqual(0)
+      expect(child?.position.y ?? -1).toBeGreaterThanOrEqual(0)
+      expect((child?.position.x ?? 0) + (child?.width ?? 0)).toBeLessThanOrEqual(
+        container?.width ?? 0,
+      )
+      expect((child?.position.y ?? 0) + (child?.height ?? 0)).toBeLessThanOrEqual(
+        container?.height ?? 0,
+      )
+    },
+    LAYOUT_TIMEOUT,
+  )
+
+  it(
+    'routes every edge from the source handle to the target handle',
+    async () => {
+      const projection = projectArchitecture(model)
+      const layout = await layoutArchitecture(projection.nodes, projection.edges)
+
+      expect(layout.nodes.map((node) => node.id)).toEqual(
+        projection.nodes.map((node) => node.id),
+      )
+
+      const byId = new Map(layout.nodes.map((node) => [node.id, node]))
+      /** Absolute position of a node; React Flow stores children relative. */
+      const absolute = (id: string): { x: number; y: number } => {
+        let x = 0
+        let y = 0
+        let current = byId.get(id)
+        const guard = new Set<string>()
+        while (current && !guard.has(current.id)) {
+          guard.add(current.id)
+          x += current.position.x
+          y += current.position.y
+          current = current.parentId ? byId.get(current.parentId) : undefined
+        }
+        return { x, y }
+      }
+
+      for (const edge of projection.edges) {
+        const route = layout.routes[edge.id]
+        expect(route, `route for ${edge.id}`).toBeDefined()
+        const points = route ?? []
+        expect(points.length).toBeGreaterThanOrEqual(2)
+
+        const source = byId.get(edge.source)
+        const target = byId.get(edge.target)
+        const sourceOrigin = absolute(edge.source)
+        const targetOrigin = absolute(edge.target)
+
+        // Outgoing handle: right border, vertically centred. Incoming handle:
+        // left border, vertically centred. ELK's ports sit on exactly those
+        // points, so a route that does not start and end there would be drawn
+        // detached from its nodes — which is what happens if the coordinates of
+        // a nested edge are not shifted by their common ancestor.
+        const start = points[0]
+        const end = points[points.length - 1]
+        const expectedStart = {
+          x: sourceOrigin.x + (source?.width ?? 0),
+          y: sourceOrigin.y + (source?.height ?? 0) / 2,
+        }
+        const expectedEnd = {
+          x: targetOrigin.x,
+          y: targetOrigin.y + (target?.height ?? 0) / 2,
+        }
+
+        // One pixel of tolerance: the ELK ports are 1 × 1, not points.
+        expect(Math.abs((start?.x ?? 0) - expectedStart.x), edge.id).toBeLessThanOrEqual(1)
+        expect(Math.abs((start?.y ?? 0) - expectedStart.y), edge.id).toBeLessThanOrEqual(1)
+        expect(Math.abs((end?.x ?? 0) - expectedEnd.x), edge.id).toBeLessThanOrEqual(1)
+        expect(Math.abs((end?.y ?? 0) - expectedEnd.y), edge.id).toBeLessThanOrEqual(1)
+      }
+    },
+    LAYOUT_TIMEOUT,
+  )
+
+  it('sorts the graph it hands to ELK and drops self references', () => {
+    const projection = projectArchitecture(model)
+    const graph = buildElkGraph([...projection.nodes].reverse(), [...projection.edges].reverse())
+
+    expect(graph.children?.map((child) => child.id)).toEqual(['external.payments', 'platform'])
+    expect(graph.edges?.map((edge) => edge.id)).toEqual(
+      [...projection.edges.map((edge) => edge.id)].sort(),
+    )
+
+    // Ports sit exactly where React Flow draws the handles.
+    const platform = graph.children?.find((child) => child.id === 'platform')
+    expect(platform?.ports?.map((port) => port.id)).toEqual([
+      'platform:in',
+      'platform:out',
+    ])
+    expect(platform?.layoutOptions?.['elk.portConstraints']).toBe('FIXED_POS')
+  })
+
+  it('lays out an empty model without calling ELK', async () => {
+    const layout = await layoutArchitecture([], [])
+    expect(layout).toEqual({ nodes: [], routes: {}, bounds: { width: 0, height: 0 } })
+  })
+})

--- a/frontend/src/canvas/elkLayout.ts
+++ b/frontend/src/canvas/elkLayout.ts
@@ -1,0 +1,405 @@
+import type { ELK, ElkExtendedEdge, ElkNode, LayoutOptions } from 'elkjs/lib/elk-api'
+
+import {
+  COMPOUND_HEADER_HEIGHT,
+  COMPOUND_MIN_SIZE,
+  HANDLE_IDS,
+  LEAF_NODE_SIZE,
+  nodeHandles,
+  type ArchitectureEdge,
+  type ArchitectureNode,
+} from './graphProjection'
+
+/**
+ * Automatic layout with ELK's `layered` algorithm.
+ *
+ * `layered` (a Sugiyama-style algorithm) is the right fit because an
+ * architecture model *is* a directed, mostly acyclic graph: callers on the
+ * left, callees on the right, with a readable layer per hop. Force-directed
+ * alternatives give a pretty but arbitrary picture that changes every time, and
+ * a tree layout cannot express the cross-links an architecture is full of.
+ *
+ * **Determinism is a hard requirement here**, because the cockpit re-lays out
+ * whenever an agent reports a structural change, and a model that reshuffles
+ * itself is unreadable. Three things secure it:
+ *
+ * 1. The projection already delivers nodes and edges in canonical id order, and
+ *    this module sorts again defensively before handing them to ELK. The order
+ *    of the rows the read API happened to return therefore cannot leak into the
+ *    picture.
+ * 2. `elk.randomSeed` is pinned, so the heuristics inside `layered` start from
+ *    the same state on every run.
+ * 3. Node sizes are fixed constants, never measured from the DOM, and never
+ *    dependent on the zoom-driven detail level.
+ *
+ * Edges are declared on the root graph and `elk.hierarchyHandling:
+ * INCLUDE_CHILDREN` lets ELK route them across container boundaries; their
+ * coordinates then come back relative to the root, i.e. absolute.
+ */
+
+export interface LayoutPoint {
+  x: number
+  y: number
+}
+
+/** Absolute polyline of one edge, from the source handle to the target handle. */
+export type EdgeRoutes = Record<string, LayoutPoint[]>
+
+export interface ArchitectureLayout {
+  /** Same nodes, in the same order, with positions and container sizes. */
+  nodes: ArchitectureNode[]
+  routes: EdgeRoutes
+  /** Bounding box of the laid-out graph, in flow coordinates. */
+  bounds: { width: number; height: number }
+}
+
+export interface LayoutOptionsInput {
+  /** Layout direction. `RIGHT` reads as "calls flow to the right". */
+  direction?: 'RIGHT' | 'DOWN'
+}
+
+/**
+ * Base options of the root graph.
+ *
+ * `elk.edgeRouting: ORTHOGONAL` is not cosmetic: the layered algorithm reserves
+ * the space between two layers according to the routing style, so switching it
+ * off would change the node placement too.
+ */
+export const ROOT_LAYOUT_OPTIONS: LayoutOptions = {
+  'elk.algorithm': 'layered',
+  'elk.direction': 'RIGHT',
+  'elk.edgeRouting': 'ORTHOGONAL',
+  'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+  // Pinned seed: `layered` uses randomised tie-breaking in its heuristics.
+  'elk.randomSeed': '1',
+  // Deterministic, order-driven heuristics rather than randomised ones.
+  'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
+  'elk.layered.crossingMinimization.forceNodeModelOrder': 'true',
+  'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
+  'elk.layered.cycleBreaking.strategy': 'DEPTH_FIRST',
+  'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
+  'elk.layered.thoroughness': '10',
+  // Never collapse parallel edges: they carry separate reported relationships.
+  'elk.layered.mergeEdges': 'false',
+  'elk.layered.mergeHierarchyEdges': 'false',
+  'elk.spacing.nodeNode': '44',
+  'elk.spacing.edgeNode': '28',
+  'elk.spacing.edgeEdge': '14',
+  'elk.layered.spacing.nodeNodeBetweenLayers': '110',
+  'elk.layered.spacing.edgeNodeBetweenLayers': '32',
+  'elk.layered.spacing.edgeEdgeBetweenLayers': '14',
+  'elk.padding': '[top=24,left=24,bottom=24,right=24]',
+}
+
+/** Options of a compound node: same algorithm, plus room for its header. */
+export const COMPOUND_LAYOUT_OPTIONS: LayoutOptions = {
+  'elk.padding': `[top=${COMPOUND_HEADER_HEIGHT + 12},left=20,bottom=20,right=20]`,
+  'elk.spacing.nodeNode': '36',
+  'elk.layered.spacing.nodeNodeBetweenLayers': '90',
+  'elk.nodeSize.constraints': 'NODE_LABELS MINIMUM_SIZE',
+  'elk.nodeSize.minimum': `(${COMPOUND_MIN_SIZE.width},${COMPOUND_MIN_SIZE.height})`,
+}
+
+// ---------------------------------------------------------------------------
+// ELK instance
+// ---------------------------------------------------------------------------
+
+let elkPromise: Promise<ELK> | null = null
+
+/**
+ * Loads ELK lazily.
+ *
+ * The bundled build carries the whole GWT-compiled algorithm (~1.4 MB), which
+ * has no business in the entry chunk of a cockpit that may never open a
+ * project. The dynamic import turns it into its own chunk, fetched the first
+ * time an architecture is laid out.
+ */
+async function getElk(): Promise<ELK> {
+  elkPromise ??= import('elkjs/lib/elk.bundled.js').then(
+    (module) => new module.default(),
+  )
+  return elkPromise
+}
+
+/** Test seam: drops the cached instance. */
+export function resetElkForTests(): void {
+  elkPromise = null
+}
+
+// ---------------------------------------------------------------------------
+// Graph construction
+// ---------------------------------------------------------------------------
+
+const compareIds = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
+
+const sourcePortId = (nodeId: string): string => `${nodeId}:${HANDLE_IDS.source}`
+const targetPortId = (nodeId: string): string => `${nodeId}:${HANDLE_IDS.target}`
+
+/**
+ * Builds the ELK graph.
+ *
+ * Every node gets exactly two fixed ports at the positions where React Flow
+ * draws its handles — right-centre for outgoing, left-centre for incoming. With
+ * `elk.portConstraints: FIXED_POS` ELK routes from and to those exact points,
+ * so the polyline it returns is attached to the handle instead of merely
+ * ending near it.
+ */
+export function buildElkGraph(
+  nodes: readonly ArchitectureNode[],
+  edges: readonly ArchitectureEdge[],
+  options: LayoutOptionsInput = {},
+): ElkNode {
+  const sorted = [...nodes].sort((a, b) => compareIds(a.id, b.id))
+  const childrenOf = new Map<string, ArchitectureNode[]>()
+  const roots: ArchitectureNode[] = []
+
+  for (const node of sorted) {
+    const parentId = node.parentId
+    if (parentId === undefined || parentId === null) {
+      roots.push(node)
+      continue
+    }
+    const siblings = childrenOf.get(parentId)
+    if (siblings) siblings.push(node)
+    else childrenOf.set(parentId, [node])
+  }
+
+  const toElkNode = (node: ArchitectureNode): ElkNode => {
+    const children = childrenOf.get(node.id) ?? []
+    const width = node.width ?? LEAF_NODE_SIZE.width
+    const height = node.height ?? LEAF_NODE_SIZE.height
+
+    const elkNode: ElkNode = {
+      id: node.id,
+      width,
+      height,
+      layoutOptions: {
+        'elk.portConstraints': 'FIXED_POS',
+        ...(children.length > 0 ? COMPOUND_LAYOUT_OPTIONS : {}),
+      },
+      ports: [
+        {
+          id: targetPortId(node.id),
+          x: 0,
+          y: height / 2,
+          width: 1,
+          height: 1,
+          layoutOptions: { 'elk.port.side': 'WEST', 'elk.port.index': '0' },
+        },
+        {
+          id: sourcePortId(node.id),
+          x: width,
+          y: height / 2,
+          width: 1,
+          height: 1,
+          layoutOptions: { 'elk.port.side': 'EAST', 'elk.port.index': '1' },
+        },
+      ],
+    }
+
+    if (children.length > 0) elkNode.children = children.map(toElkNode)
+    return elkNode
+  }
+
+  // Self references are excluded from the layout: they cannot influence the
+  // placement of anything and only confuse the layered algorithm. They are
+  // still projected and rendered.
+  const elkEdges: ElkExtendedEdge[] = [...edges]
+    .filter((edge) => edge.source !== edge.target)
+    .sort((a, b) => compareIds(a.id, b.id))
+    .map((edge) => ({
+      id: edge.id,
+      sources: [sourcePortId(edge.source)],
+      targets: [targetPortId(edge.target)],
+    }))
+
+  return {
+    id: 'root',
+    layoutOptions: {
+      ...ROOT_LAYOUT_OPTIONS,
+      ...(options.direction ? { 'elk.direction': options.direction } : {}),
+    },
+    children: roots.map(toElkNode),
+    edges: elkEdges,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Layout
+// ---------------------------------------------------------------------------
+
+/**
+ * Lays out a projected architecture graph.
+ *
+ * Returns nodes in exactly the order they came in — React Flow needs parents
+ * before children, and the projection already guarantees that.
+ */
+export async function layoutArchitecture(
+  nodes: readonly ArchitectureNode[],
+  edges: readonly ArchitectureEdge[],
+  options: LayoutOptionsInput = {},
+): Promise<ArchitectureLayout> {
+  if (nodes.length === 0) {
+    return { nodes: [], routes: {}, bounds: { width: 0, height: 0 } }
+  }
+
+  const elk = await getElk()
+  const graph = buildElkGraph(nodes, edges, options)
+  const laidOut = await elk.layout(graph)
+
+  const positions = new Map<string, { x: number; y: number; width: number; height: number }>()
+  const absolute = new Map<string, { x: number; y: number }>()
+  const elkEdgesById = new Map<string, ElkExtendedEdge>()
+
+  // ELK reports a child's coordinates relative to its container. Walking the
+  // tree with an accumulated offset keeps the node positions relative — which
+  // is what React Flow wants for a node inside a parent — while recording the
+  // absolute position of every node for the edge conversion below.
+  const walk = (elkNode: ElkNode, offsetX: number, offsetY: number): void => {
+    const absoluteX = offsetX + (elkNode.x ?? 0)
+    const absoluteY = offsetY + (elkNode.y ?? 0)
+    absolute.set(elkNode.id, { x: absoluteX, y: absoluteY })
+
+    for (const child of elkNode.children ?? []) {
+      positions.set(child.id, {
+        x: child.x ?? 0,
+        y: child.y ?? 0,
+        width: child.width ?? LEAF_NODE_SIZE.width,
+        height: child.height ?? LEAF_NODE_SIZE.height,
+      })
+      walk(child, absoluteX, absoluteY)
+    }
+
+    for (const edge of elkNode.edges ?? []) {
+      elkEdgesById.set(edge.id, edge as ElkExtendedEdge)
+    }
+  }
+
+  walk(laidOut, 0, 0)
+
+  // Edge sections are **not** relative to the container the edge was declared
+  // in: with `hierarchyHandling: INCLUDE_CHILDREN`, ELK reports them relative to
+  // the lowest common ancestor of the two endpoints. Declaring all edges on the
+  // root graph therefore does not make their coordinates absolute — each one has
+  // to be shifted by the absolute position of that ancestor. Getting this wrong
+  // detaches every edge between two nested components from its handles by the
+  // offset of the container they share.
+  const parentOf = new Map<string, string | undefined>(
+    nodes.map((node) => [node.id, node.parentId]),
+  )
+  const routes: EdgeRoutes = {}
+
+  for (const edge of edges) {
+    const elkEdge = elkEdgesById.get(edge.id)
+    if (!elkEdge) continue
+
+    const container = lowestCommonAncestor(parentOf, edge.source, edge.target)
+    const origin = (container ? absolute.get(container) : undefined) ?? { x: 0, y: 0 }
+
+    const points: LayoutPoint[] = []
+    for (const section of elkEdge.sections ?? []) {
+      points.push({
+        x: origin.x + section.startPoint.x,
+        y: origin.y + section.startPoint.y,
+      })
+      for (const bend of section.bendPoints ?? []) {
+        points.push({ x: origin.x + bend.x, y: origin.y + bend.y })
+      }
+      points.push({
+        x: origin.x + section.endPoint.x,
+        y: origin.y + section.endPoint.y,
+      })
+    }
+    if (points.length >= 2) routes[edge.id] = dedupePoints(points)
+  }
+
+  const positioned = nodes.map((node) => {
+    const layout = positions.get(node.id)
+    if (!layout) return node
+    const width = round(layout.width)
+    const height = round(layout.height)
+    return {
+      ...node,
+      position: { x: round(layout.x), y: round(layout.y) },
+      width,
+      height,
+      measured: { width, height },
+      // Re-declared for the size ELK settled on — a container grows around its
+      // children, and its handles have to follow.
+      handles: nodeHandles(width, height),
+      style: { ...node.style, width, height },
+    }
+  })
+
+  return {
+    nodes: positioned,
+    routes,
+    bounds: {
+      width: round(laidOut.width ?? 0),
+      height: round(laidOut.height ?? 0),
+    },
+  }
+}
+
+/**
+ * Rounds to whole pixels.
+ *
+ * ELK works in floating point, and comparing two runs bit for bit is only
+ * meaningful once the result is quantised the same way the renderer quantises
+ * it. Rounding here is what makes "the same model lays out identically" a
+ * checkable statement rather than an approximate one.
+ */
+function round(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+/**
+ * The deepest node that contains both endpoints, or `undefined` when they only
+ * share the root graph. A node counts as containing itself, so an edge from a
+ * container to one of its own children resolves to that container.
+ */
+function lowestCommonAncestor(
+  parentOf: ReadonlyMap<string, string | undefined>,
+  source: string,
+  target: string,
+): string | undefined {
+  const ancestorsOf = (id: string): string[] => {
+    const chain: string[] = []
+    let current: string | undefined = id
+    const guard = new Set<string>()
+    while (current !== undefined && !guard.has(current)) {
+      guard.add(current)
+      chain.push(current)
+      current = parentOf.get(current)
+    }
+    return chain
+  }
+
+  const sourceChain = new Set(ancestorsOf(source))
+  for (const candidate of ancestorsOf(target)) {
+    if (sourceChain.has(candidate)) return candidate
+  }
+  return undefined
+}
+
+/** Drops consecutive duplicates that ELK emits at section boundaries. */
+function dedupePoints(points: LayoutPoint[]): LayoutPoint[] {
+  const result: LayoutPoint[] = []
+  for (const point of points) {
+    const previous = result[result.length - 1]
+    const rounded = { x: round(point.x), y: round(point.y) }
+    if (previous && previous.x === rounded.x && previous.y === rounded.y) continue
+    result.push(rounded)
+  }
+  return result
+}
+
+/** Compact, comparable description of a layout. Used by the determinism tests. */
+export function describeLayout(layout: ArchitectureLayout): string {
+  return layout.nodes
+    .map(
+      (node) =>
+        `${node.id}@${node.position.x},${node.position.y} ${node.width}x${node.height}`,
+    )
+    .join('\n')
+}

--- a/frontend/src/canvas/flowRegistry.ts
+++ b/frontend/src/canvas/flowRegistry.ts
@@ -1,0 +1,26 @@
+import type { EdgeTypes, NodeTypes } from '@xyflow/react'
+
+import { ComponentNode, CompoundNode } from './ComponentNode'
+import { RelationshipEdge } from './RelationshipEdge'
+import {
+  COMPONENT_NODE_TYPE,
+  COMPOUND_NODE_TYPE,
+  RELATIONSHIP_EDGE_TYPE,
+} from './graphProjection'
+
+/**
+ * The React Flow type registries.
+ *
+ * They live in their own module because React Flow compares them by identity:
+ * a map rebuilt on every render would remount every node and edge on every
+ * render. Declaring them once, next to the type constants the projection
+ * assigns, also keeps the two from drifting apart.
+ */
+export const ARCHITECTURE_NODE_TYPES: NodeTypes = {
+  [COMPONENT_NODE_TYPE]: ComponentNode,
+  [COMPOUND_NODE_TYPE]: CompoundNode,
+}
+
+export const ARCHITECTURE_EDGE_TYPES: EdgeTypes = {
+  [RELATIONSHIP_EDGE_TYPE]: RelationshipEdge,
+}

--- a/frontend/src/canvas/graphProjection.test.ts
+++ b/frontend/src/canvas/graphProjection.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Component, Relationship } from '@/api/types'
+import {
+  ALL_RELATIONSHIP_KINDS,
+  BUNDLED_TOPIC_CHANNELS,
+  NESTED_COMPONENTS,
+  NESTED_RELATIONSHIPS,
+  reorder,
+} from '@/test/architectureFixtures'
+
+import {
+  COMPONENT_NODE_TYPE,
+  COMPOUND_NODE_TYPE,
+  bundleEdgeId,
+  countRelationships,
+  diagnosticsCount,
+  isProjectionClean,
+  projectArchitecture,
+  projectionSignature,
+  resolveEdgeBundle,
+  type ArchitectureEdge,
+} from './graphProjection'
+
+const model = { components: NESTED_COMPONENTS, relationships: NESTED_RELATIONSHIPS }
+
+function edgeById(edges: ArchitectureEdge[], id: string): ArchitectureEdge {
+  const edge = edges.find((candidate) => candidate.id === id)
+  if (!edge) throw new Error(`edge ${id} missing; have ${edges.map((e) => e.id).join(', ')}`)
+  return edge
+}
+
+describe('projectArchitecture — nested snapshot', () => {
+  it('translates every component and every relationship without losing anything', () => {
+    const { nodes, edges, diagnostics } = projectArchitecture(model)
+
+    expect(isProjectionClean(diagnostics)).toBe(true)
+    expect(diagnosticsCount(diagnostics)).toBe(0)
+
+    // Every component became exactly one node.
+    expect(nodes).toHaveLength(NESTED_COMPONENTS.length)
+    expect(nodes.map((node) => node.id).sort()).toEqual(
+      NESTED_COMPONENTS.map((component) => component.componentId).sort(),
+    )
+
+    // Every relationship is carried by exactly one edge, and none was merged
+    // away: eight relationships on six edges, because three NATS topics share
+    // a node pair.
+    expect(countRelationships(edges)).toBe(NESTED_RELATIONSHIPS.length)
+    expect(edges).toHaveLength(6)
+
+    const carried = edges
+      .flatMap((edge) => edge.data?.relationships ?? [])
+      .map((relationship) => relationship.relationshipId)
+      .sort()
+    expect(carried).toEqual(
+      NESTED_RELATIONSHIPS.map((relationship) => relationship.relationshipId).sort(),
+    )
+
+    // All six kinds of the contract survive the projection.
+    const kinds = new Set(
+      edges.flatMap((edge) => edge.data?.relationships ?? []).map((r) => r.kind),
+    )
+    expect([...kinds].sort()).toEqual([...ALL_RELATIONSHIP_KINDS].sort())
+  })
+
+  it('builds the compound structure over four levels', () => {
+    const { nodes } = projectArchitecture(model)
+    const byId = new Map(nodes.map((node) => [node.id, node]))
+
+    expect(byId.get('platform')?.parentId).toBeUndefined()
+    expect(byId.get('platform.api')?.parentId).toBe('platform')
+    expect(byId.get('platform.api.http')?.parentId).toBe('platform.api')
+    expect(byId.get('platform.api.http.router')?.parentId).toBe('platform.api.http')
+
+    expect(byId.get('platform')?.data.depth).toBe(0)
+    expect(byId.get('platform.api')?.data.depth).toBe(1)
+    expect(byId.get('platform.api.http')?.data.depth).toBe(2)
+    expect(byId.get('platform.api.http.router')?.data.depth).toBe(3)
+
+    // Containers are compound nodes, everything else is a leaf.
+    expect(byId.get('platform')?.type).toBe(COMPOUND_NODE_TYPE)
+    expect(byId.get('platform.api.http')?.type).toBe(COMPOUND_NODE_TYPE)
+    expect(byId.get('platform.api.http.router')?.type).toBe(COMPONENT_NODE_TYPE)
+    expect(byId.get('platform.db')?.type).toBe(COMPONENT_NODE_TYPE)
+
+    expect(byId.get('platform')?.data.childCount).toBe(4)
+    expect(byId.get('platform.api.http.router')?.data.childCount).toBe(0)
+
+    // Children are constrained to their container and, as React Flow requires,
+    // always appear after it in the node list.
+    for (const node of nodes) {
+      if (node.parentId === undefined) continue
+      expect(node.extent).toBe('parent')
+      const parentIndex = nodes.findIndex((candidate) => candidate.id === node.parentId)
+      const ownIndex = nodes.findIndex((candidate) => candidate.id === node.id)
+      expect(parentIndex).toBeGreaterThanOrEqual(0)
+      expect(parentIndex).toBeLessThan(ownIndex)
+    }
+  })
+
+  it('produces the same graph regardless of the input order', () => {
+    const straight = projectArchitecture(model)
+    const shuffled = projectArchitecture({
+      components: reorder(NESTED_COMPONENTS),
+      relationships: reorder(NESTED_RELATIONSHIPS),
+    })
+
+    expect(shuffled.nodes.map((node) => node.id)).toEqual(
+      straight.nodes.map((node) => node.id),
+    )
+    expect(shuffled.edges.map((edge) => edge.id)).toEqual(
+      straight.edges.map((edge) => edge.id),
+    )
+    expect(projectionSignature(shuffled)).toBe(projectionSignature(straight))
+  })
+})
+
+describe('projectArchitecture — bundling and NATS topics', () => {
+  it('bundles parallel relationships into one edge that stays resolvable', () => {
+    const { edges } = projectArchitecture(model)
+    const bundle = edgeById(edges, bundleEdgeId('platform.core.orders', 'platform.bus'))
+
+    expect(bundle.data?.bundled).toBe(true)
+    expect(bundle.data?.relationships).toHaveLength(3)
+
+    // The individual relationships are reachable and identifiable — each with
+    // its own channel and operation, which is what makes the bundle a rendering
+    // rather than a merge.
+    const resolved = resolveEdgeBundle(bundle)
+    expect(resolved).toHaveLength(3)
+    // Ordered by `relationshipId`, so the order is stable across refetches.
+    expect(resolved.map((entry) => entry.relationship.relationshipId)).toEqual([
+      'r-05',
+      'r-06',
+      'r-07',
+    ])
+    expect(resolved.map((entry) => entry.relationship.channel).sort()).toEqual([
+      ...BUNDLED_TOPIC_CHANNELS,
+    ])
+    expect(resolved.map((entry) => entry.discriminator).sort()).toEqual([
+      ...BUNDLED_TOPIC_CHANNELS,
+    ])
+    for (const entry of resolved) {
+      expect(entry.relationship.operation).toBe('publish')
+      expect(entry.displayName).toBe(`NATS · ${entry.relationship.channel}`)
+      expect(entry.total).toBe(3)
+    }
+    expect(resolved.map((entry) => entry.index)).toEqual([0, 1, 2])
+  })
+
+  it('keeps separate NATS topics as separate relationships', () => {
+    const { edges } = projectArchitecture(model)
+    const topics = edges
+      .flatMap((edge) => edge.data?.relationships ?? [])
+      .filter((relationship) => relationship.kind === 'nats_topic')
+
+    // Three reported topics stay three relationships with three distinct ids
+    // and three distinct channels. Nothing is aggregated.
+    expect(topics).toHaveLength(3)
+    expect(new Set(topics.map((topic) => topic.relationshipId)).size).toBe(3)
+    expect(topics.map((topic) => topic.channel).sort()).toEqual([...BUNDLED_TOPIC_CHANNELS])
+  })
+
+  it('leaves a single relationship unbundled', () => {
+    const { edges } = projectArchitecture(model)
+    const single = edgeById(edges, bundleEdgeId('platform.core.orders', 'platform.db'))
+
+    expect(single.data?.bundled).toBe(false)
+    expect(resolveEdgeBundle(single)).toHaveLength(1)
+    expect(resolveEdgeBundle(single)[0]?.relationship.relationshipId).toBe('r-03')
+  })
+
+  it('does not bundle across directions', () => {
+    const components: Component[] = [
+      { componentId: 'a', name: 'A', kind: 'service', parentComponentId: null },
+      { componentId: 'b', name: 'B', kind: 'service', parentComponentId: null },
+    ]
+    const relationships: Relationship[] = [
+      {
+        relationshipId: 'x',
+        sourceComponentId: 'a',
+        targetComponentId: 'b',
+        kind: 'http',
+      },
+      {
+        relationshipId: 'y',
+        sourceComponentId: 'b',
+        targetComponentId: 'a',
+        kind: 'http',
+      },
+    ]
+
+    const { edges } = projectArchitecture({ components, relationships })
+    expect(edges).toHaveLength(2)
+    expect(edges.every((edge) => edge.data?.bundled === false)).toBe(true)
+  })
+})
+
+describe('projectArchitecture — robustness', () => {
+  it('renders a component with a missing parent as a root instead of dropping it', () => {
+    const components: Component[] = [
+      { componentId: 'root', name: 'Root', kind: 'system', parentComponentId: null },
+      {
+        componentId: 'orphan',
+        name: 'Orphan',
+        kind: 'service',
+        parentComponentId: 'gone-in-this-snapshot',
+      },
+    ]
+
+    const { nodes, diagnostics } = projectArchitecture({ components, relationships: [] })
+
+    expect(nodes).toHaveLength(2)
+    const orphan = nodes.find((node) => node.id === 'orphan')
+    expect(orphan?.parentId).toBeUndefined()
+    expect(orphan?.data.depth).toBe(0)
+    expect(diagnostics.orphanedParents).toEqual([
+      { componentId: 'orphan', missingParentComponentId: 'gone-in-this-snapshot' },
+    ])
+  })
+
+  it('breaks a hierarchy cycle deterministically instead of looping forever', () => {
+    const components: Component[] = [
+      { componentId: 'c-b', name: 'B', kind: 'module', parentComponentId: 'c-a' },
+      { componentId: 'c-a', name: 'A', kind: 'module', parentComponentId: 'c-c' },
+      { componentId: 'c-c', name: 'C', kind: 'module', parentComponentId: 'c-b' },
+      { componentId: 'c-leaf', name: 'Leaf', kind: 'module', parentComponentId: 'c-c' },
+    ]
+
+    const { nodes, diagnostics } = projectArchitecture({ components, relationships: [] })
+
+    // Every component is still rendered exactly once.
+    expect(nodes).toHaveLength(4)
+    expect(nodes.map((node) => node.id).sort()).toEqual(['c-a', 'c-b', 'c-c', 'c-leaf'])
+
+    expect(diagnostics.hierarchyCycles).toEqual([['c-a', 'c-b', 'c-c']])
+
+    // The alphabetically first member of the cycle is cut loose, which turns
+    // the cycle into a chain and gives every node exactly one path to a root.
+    const byId = new Map(nodes.map((node) => [node.id, node]))
+    expect(byId.get('c-a')?.parentId).toBeUndefined()
+    expect(byId.get('c-b')?.parentId).toBe('c-a')
+    expect(byId.get('c-c')?.parentId).toBe('c-b')
+    expect(byId.get('c-leaf')?.parentId).toBe('c-c')
+
+    // …and the same repair happens whatever order the rows arrive in.
+    const shuffled = projectArchitecture({
+      components: reorder(components),
+      relationships: [],
+    })
+    expect(shuffled.nodes.map((node) => `${node.id}<${node.parentId ?? ''}`)).toEqual(
+      nodes.map((node) => `${node.id}<${node.parentId ?? ''}`),
+    )
+    expect(shuffled.diagnostics.hierarchyCycles).toEqual([['c-a', 'c-b', 'c-c']])
+  })
+
+  it('handles a component that is its own parent', () => {
+    const components: Component[] = [
+      { componentId: 'self', name: 'Self', kind: 'module', parentComponentId: 'self' },
+    ]
+
+    const { nodes, diagnostics } = projectArchitecture({ components, relationships: [] })
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.parentId).toBeUndefined()
+    expect(diagnostics.hierarchyCycles).toEqual([['self']])
+  })
+
+  it('drops relationships with an endpoint outside the snapshot and reports them', () => {
+    const components: Component[] = [
+      { componentId: 'a', name: 'A', kind: 'service', parentComponentId: null },
+    ]
+    const relationships: Relationship[] = [
+      { relationshipId: 'r1', sourceComponentId: 'a', targetComponentId: 'b', kind: 'http' },
+      { relationshipId: 'r2', sourceComponentId: 'z', targetComponentId: 'a', kind: 'grpc' },
+    ]
+
+    const { edges, diagnostics } = projectArchitecture({ components, relationships })
+
+    expect(edges).toHaveLength(0)
+    expect(diagnostics.danglingRelationships).toEqual([
+      { relationshipId: 'r1', missingComponentId: 'b', endpoint: 'target' },
+      { relationshipId: 'r2', missingComponentId: 'z', endpoint: 'source' },
+    ])
+  })
+
+  it('keeps the first of two components sharing an id', () => {
+    const components: Component[] = [
+      { componentId: 'dup', name: 'First', kind: 'service', parentComponentId: null },
+      { componentId: 'dup', name: 'Second', kind: 'module', parentComponentId: null },
+    ]
+
+    const { nodes, diagnostics } = projectArchitecture({ components, relationships: [] })
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.data.component.name).toBe('First')
+    expect(diagnostics.duplicateComponentIds).toEqual(['dup'])
+  })
+
+  it('returns an empty graph for an empty snapshot', () => {
+    const projection = projectArchitecture({ components: [], relationships: [] })
+    expect(projection.nodes).toEqual([])
+    expect(projection.edges).toEqual([])
+    expect(isProjectionClean(projection.diagnostics)).toBe(true)
+  })
+})

--- a/frontend/src/canvas/graphProjection.ts
+++ b/frontend/src/canvas/graphProjection.ts
@@ -1,0 +1,503 @@
+import type { Edge, Node, NodeHandle, Position } from '@xyflow/react'
+
+import type { Component, ComponentId, Identifier, Relationship } from '@/api/types'
+
+import { relationshipDiscriminator, relationshipDisplayName } from './relationshipKinds'
+
+/**
+ * The graph projection adapter: domain model → React Flow graph.
+ *
+ * This module is deliberately free of React and of React Flow *runtime* code —
+ * the only import from `@xyflow/react` is a type import, which the compiler
+ * erases. It can therefore be exercised in isolation, which matters because it
+ * is the one place where the hierarchy, the edge bundling and the robustness
+ * rules live.
+ *
+ * Three properties it guarantees:
+ *
+ * 1. **Nothing is invented and nothing is dropped silently.** Every component
+ *    and every relationship of the snapshot ends up either in the graph or in
+ *    `diagnostics`, never nowhere.
+ * 2. **Separate relationships stay separate.** Parallel relationships between
+ *    the same pair of components share one *rendered* edge, but the edge keeps
+ *    the full, individually addressable list. NATS topics are the reason this
+ *    rule exists: the server never merges them, and neither does this adapter.
+ * 3. **It is total.** A `parentComponentId` pointing at a component that is not
+ *    in the snapshot, or a cycle in the hierarchy, produces a defined graph and
+ *    a diagnostic — never an endless loop and never a throw.
+ *
+ * The output order is canonical (sorted by id, parents before children), which
+ * is what makes the downstream ELK layout independent of the order the read API
+ * happened to serialise its rows in.
+ */
+
+// ---------------------------------------------------------------------------
+// Node and edge types
+// ---------------------------------------------------------------------------
+
+/** React Flow node type of a component without children. */
+export const COMPONENT_NODE_TYPE = 'architectureComponent'
+/** React Flow node type of a component that contains other components. */
+export const COMPOUND_NODE_TYPE = 'architectureGroup'
+/** React Flow edge type of one (possibly bundled) relationship edge. */
+export const RELATIONSHIP_EDGE_TYPE = 'architectureRelationship'
+
+export type ArchitectureNodeType = typeof COMPONENT_NODE_TYPE | typeof COMPOUND_NODE_TYPE
+
+/** Handle ids. Fixed so the ELK ports and the React Flow handles agree. */
+export const HANDLE_IDS = { source: 'out', target: 'in' } as const
+
+/**
+ * Declares the two handles of a node on the node itself.
+ *
+ * React Flow can measure handles from the DOM, but then edge geometry depends
+ * on a rendered layout — which makes it different in a browser and in a test,
+ * and different again before and after the first measurement. Declaring the
+ * handles explicitly makes the geometry a pure function of the layout: incoming
+ * on the left edge, outgoing on the right edge, both vertically centred, which
+ * is exactly where the ELK ports sit.
+ */
+export function nodeHandles(width: number, height: number): NodeHandle[] {
+  return [
+    {
+      id: HANDLE_IDS.target,
+      type: 'target',
+      position: 'left' as Position,
+      x: 0,
+      y: height / 2,
+      width: 1,
+      height: 1,
+    },
+    {
+      id: HANDLE_IDS.source,
+      type: 'source',
+      position: 'right' as Position,
+      x: width,
+      y: height / 2,
+      width: 1,
+      height: 1,
+    },
+  ]
+}
+
+export interface ComponentNodeData extends Record<string, unknown> {
+  component: Component
+  /** 0 for a root component, 1 for its children, and so on. */
+  depth: number
+  /** Number of direct children rendered inside this node. */
+  childCount: number
+  /** `true` when this node is a compound container. */
+  isCompound: boolean
+}
+
+export type ArchitectureNode = Node<ComponentNodeData, ArchitectureNodeType>
+
+export interface RelationshipEdgeData extends Record<string, unknown> {
+  sourceComponentId: ComponentId
+  targetComponentId: ComponentId
+  /**
+   * Every relationship the agent reported for this ordered node pair, sorted by
+   * `relationshipId`. Always at least one entry — this is the list the UI
+   * resolves a bundle back into.
+   */
+  relationships: Relationship[]
+  /** `true` when more than one relationship shares this pair of components. */
+  bundled: boolean
+  /**
+   * Absolute polyline computed by ELK, attached by the canvas after the layout.
+   * Absent while no layout exists or after one of the endpoints was dragged;
+   * the edge then falls back to a plain orthogonal connection.
+   */
+  route?: { x: number; y: number }[]
+}
+
+export type ArchitectureEdge = Edge<RelationshipEdgeData, typeof RELATIONSHIP_EDGE_TYPE>
+
+// ---------------------------------------------------------------------------
+// Geometry defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed size of a leaf node.
+ *
+ * The size must not depend on the zoom-driven detail level: if it did, zooming
+ * would change the layout and therefore move the camera relative to the model —
+ * exactly the kind of unexpected motion the cockpit must not produce. The
+ * progressive detail levels only change what is rendered *inside* this box.
+ */
+export const LEAF_NODE_SIZE = { width: 228, height: 96 } as const
+
+/** Minimum size of a compound container; ELK grows it around its children. */
+export const COMPOUND_MIN_SIZE = { width: 260, height: 120 } as const
+
+/** Room ELK must leave at the top of a container for its header row. */
+export const COMPOUND_HEADER_HEIGHT = 40
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+export interface OrphanedParentDiagnostic {
+  componentId: ComponentId
+  /** The `parentComponentId` that is not part of this snapshot. */
+  missingParentComponentId: ComponentId
+}
+
+export interface DanglingRelationshipDiagnostic {
+  relationshipId: Identifier
+  /** The endpoint that is not part of this snapshot. */
+  missingComponentId: ComponentId
+  endpoint: 'source' | 'target'
+}
+
+/**
+ * Everything the adapter had to repair. The canvas surfaces the counts so a
+ * broken snapshot is visible instead of silently half-rendered.
+ */
+export interface ProjectionDiagnostics {
+  /** Components whose parent is not in the snapshot; rendered as roots. */
+  orphanedParents: OrphanedParentDiagnostic[]
+  /**
+   * Cycles found while walking the hierarchy, each as the sorted list of its
+   * members. The alphabetically first member of a cycle is cut loose and
+   * rendered as a root, which breaks the cycle deterministically.
+   */
+  hierarchyCycles: ComponentId[][]
+  /** Relationships with an endpoint that is not in the snapshot; not rendered. */
+  danglingRelationships: DanglingRelationshipDiagnostic[]
+  /** Component ids that appeared more than once; the first occurrence wins. */
+  duplicateComponentIds: ComponentId[]
+  /** Relationship ids that appeared more than once; the first occurrence wins. */
+  duplicateRelationshipIds: Identifier[]
+  /** Relationships whose source and target are the same component. */
+  selfReferences: Identifier[]
+}
+
+export function isProjectionClean(diagnostics: ProjectionDiagnostics): boolean {
+  return (
+    diagnostics.orphanedParents.length === 0 &&
+    diagnostics.hierarchyCycles.length === 0 &&
+    diagnostics.danglingRelationships.length === 0 &&
+    diagnostics.duplicateComponentIds.length === 0 &&
+    diagnostics.duplicateRelationshipIds.length === 0
+  )
+}
+
+/** Number of problems the adapter had to repair. */
+export function diagnosticsCount(diagnostics: ProjectionDiagnostics): number {
+  return (
+    diagnostics.orphanedParents.length +
+    diagnostics.hierarchyCycles.length +
+    diagnostics.danglingRelationships.length +
+    diagnostics.duplicateComponentIds.length +
+    diagnostics.duplicateRelationshipIds.length
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Projection
+// ---------------------------------------------------------------------------
+
+export interface ArchitectureModel {
+  components: readonly Component[]
+  relationships: readonly Relationship[]
+}
+
+export interface ArchitectureProjection {
+  /** Canonically ordered: parents before their children, siblings by id. */
+  nodes: ArchitectureNode[]
+  /** One edge per ordered node pair, sorted by edge id. */
+  edges: ArchitectureEdge[]
+  diagnostics: ProjectionDiagnostics
+  /** Components by id, for lookups that would otherwise re-scan the list. */
+  componentsById: Map<ComponentId, Component>
+}
+
+export const EMPTY_DIAGNOSTICS: ProjectionDiagnostics = {
+  orphanedParents: [],
+  hierarchyCycles: [],
+  danglingRelationships: [],
+  duplicateComponentIds: [],
+  duplicateRelationshipIds: [],
+  selfReferences: [],
+}
+
+/** Builds the id of the edge that carries the relationships of one node pair. */
+export function bundleEdgeId(source: ComponentId, target: ComponentId): string {
+  return `rel:${source}~>${target}`
+}
+
+const compareIds = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
+
+/**
+ * Projects one architecture snapshot into a React Flow graph.
+ *
+ * Pure: the same input always produces the same output, including the order of
+ * every array.
+ */
+export function projectArchitecture(model: ArchitectureModel): ArchitectureProjection {
+  const diagnostics: ProjectionDiagnostics = {
+    orphanedParents: [],
+    hierarchyCycles: [],
+    danglingRelationships: [],
+    duplicateComponentIds: [],
+    duplicateRelationshipIds: [],
+    selfReferences: [],
+  }
+
+  // ---- 1. canonical component index ---------------------------------------
+  const componentsById = new Map<ComponentId, Component>()
+  const sortedComponents = [...model.components].sort((a, b) =>
+    compareIds(a.componentId, b.componentId),
+  )
+  for (const component of sortedComponents) {
+    if (componentsById.has(component.componentId)) {
+      if (!diagnostics.duplicateComponentIds.includes(component.componentId)) {
+        diagnostics.duplicateComponentIds.push(component.componentId)
+      }
+      continue
+    }
+    componentsById.set(component.componentId, component)
+  }
+
+  // ---- 2. resolve parents, cutting links that point nowhere ---------------
+  const parentOf = new Map<ComponentId, ComponentId | null>()
+  for (const [componentId, component] of componentsById) {
+    const parentId = component.parentComponentId
+    if (parentId === null || parentId === undefined || parentId === '') {
+      parentOf.set(componentId, null)
+      continue
+    }
+    if (!componentsById.has(parentId)) {
+      diagnostics.orphanedParents.push({
+        componentId,
+        missingParentComponentId: parentId,
+      })
+      parentOf.set(componentId, null)
+      continue
+    }
+    parentOf.set(componentId, parentId)
+  }
+
+  // ---- 3. break hierarchy cycles ------------------------------------------
+  // Walking up from every component in id order. The walk is bounded by the
+  // set of already visited ancestors, so it terminates even for a component
+  // that is its own parent. When a cycle is found, the alphabetically first of
+  // its members is cut loose; that choice does not depend on the input order,
+  // so the repaired hierarchy is deterministic.
+  for (const componentId of [...parentOf.keys()]) {
+    const path: ComponentId[] = [componentId]
+    const seen = new Set<ComponentId>([componentId])
+    let current = parentOf.get(componentId) ?? null
+
+    while (current !== null) {
+      if (seen.has(current)) {
+        const cycleStart = path.indexOf(current)
+        const members = path.slice(cycleStart === -1 ? 0 : cycleStart).sort(compareIds)
+        diagnostics.hierarchyCycles.push(members)
+        const cutLoose = members[0]
+        if (cutLoose !== undefined) parentOf.set(cutLoose, null)
+        break
+      }
+      seen.add(current)
+      path.push(current)
+      current = parentOf.get(current) ?? null
+    }
+  }
+
+  // ---- 4. children index (already in id order) ----------------------------
+  const childrenOf = new Map<ComponentId, ComponentId[]>()
+  const roots: ComponentId[] = []
+  for (const [componentId, parentId] of parentOf) {
+    if (parentId === null) {
+      roots.push(componentId)
+      continue
+    }
+    const siblings = childrenOf.get(parentId)
+    if (siblings) siblings.push(componentId)
+    else childrenOf.set(parentId, [componentId])
+  }
+
+  // ---- 5. nodes in pre-order (React Flow needs parents first) -------------
+  const nodes: ArchitectureNode[] = []
+  const stack: { componentId: ComponentId; depth: number }[] = roots
+    .map((componentId) => ({ componentId, depth: 0 }))
+    .reverse()
+
+  while (stack.length > 0) {
+    const entry = stack.pop()
+    if (!entry) break
+    const component = componentsById.get(entry.componentId)
+    if (!component) continue
+
+    const children = childrenOf.get(entry.componentId) ?? []
+    const isCompound = children.length > 0
+    const parentId = parentOf.get(entry.componentId) ?? null
+
+    const size = isCompound ? COMPOUND_MIN_SIZE : LEAF_NODE_SIZE
+    const node: ArchitectureNode = {
+      id: entry.componentId,
+      type: isCompound ? COMPOUND_NODE_TYPE : COMPONENT_NODE_TYPE,
+      position: { x: 0, y: 0 },
+      width: size.width,
+      height: size.height,
+      // `measured` is what React Flow fits the view to and what it uses to
+      // decide a node is ready. The layout is the authority on the size — the
+      // DOM box is rendered *from* it — so reporting it here rather than
+      // waiting for a `ResizeObserver` is the honest answer, and it makes the
+      // canvas behave identically before and after the first paint.
+      measured: { width: size.width, height: size.height },
+      handles: nodeHandles(size.width, size.height),
+      data: {
+        component,
+        depth: entry.depth,
+        childCount: children.length,
+        isCompound,
+      },
+      ...(parentId !== null ? { parentId, extent: 'parent' as const } : {}),
+    }
+    nodes.push(node)
+
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      const childId = children[index]
+      if (childId !== undefined) stack.push({ componentId: childId, depth: entry.depth + 1 })
+    }
+  }
+
+  // ---- 6. relationships -> bundled edges ----------------------------------
+  const relationshipsById = new Map<Identifier, Relationship>()
+  const sortedRelationships = [...model.relationships].sort((a, b) =>
+    compareIds(a.relationshipId, b.relationshipId),
+  )
+  for (const relationship of sortedRelationships) {
+    if (relationshipsById.has(relationship.relationshipId)) {
+      if (!diagnostics.duplicateRelationshipIds.includes(relationship.relationshipId)) {
+        diagnostics.duplicateRelationshipIds.push(relationship.relationshipId)
+      }
+      continue
+    }
+    relationshipsById.set(relationship.relationshipId, relationship)
+  }
+
+  const bundles = new Map<string, Relationship[]>()
+  for (const relationship of relationshipsById.values()) {
+    const { sourceComponentId, targetComponentId, relationshipId } = relationship
+
+    if (!componentsById.has(sourceComponentId)) {
+      diagnostics.danglingRelationships.push({
+        relationshipId,
+        missingComponentId: sourceComponentId,
+        endpoint: 'source',
+      })
+      continue
+    }
+    if (!componentsById.has(targetComponentId)) {
+      diagnostics.danglingRelationships.push({
+        relationshipId,
+        missingComponentId: targetComponentId,
+        endpoint: 'target',
+      })
+      continue
+    }
+    if (sourceComponentId === targetComponentId) {
+      diagnostics.selfReferences.push(relationshipId)
+    }
+
+    const key = bundleEdgeId(sourceComponentId, targetComponentId)
+    const existing = bundles.get(key)
+    if (existing) existing.push(relationship)
+    else bundles.set(key, [relationship])
+  }
+
+  const edges: ArchitectureEdge[] = [...bundles.keys()]
+    .sort(compareIds)
+    .map((edgeId) => {
+      // Non-null: the key came from this very map.
+      const relationships = bundles.get(edgeId) as Relationship[]
+      const first = relationships[0] as Relationship
+      return {
+        id: edgeId,
+        type: RELATIONSHIP_EDGE_TYPE,
+        source: first.sourceComponentId,
+        target: first.targetComponentId,
+        sourceHandle: HANDLE_IDS.source,
+        targetHandle: HANDLE_IDS.target,
+        data: {
+          sourceComponentId: first.sourceComponentId,
+          targetComponentId: first.targetComponentId,
+          relationships,
+          bundled: relationships.length > 1,
+        },
+      }
+    })
+
+  return { nodes, edges, diagnostics, componentsById }
+}
+
+// ---------------------------------------------------------------------------
+// Resolving a bundle back into its individual relationships
+// ---------------------------------------------------------------------------
+
+export interface ResolvedRelationship {
+  relationship: Relationship
+  /** Index within the bundle, used for the fan-out offset. */
+  index: number
+  /** Number of relationships in the bundle this one belongs to. */
+  total: number
+  /**
+   * What identifies this relationship among its siblings — the topic name for
+   * `nats_topic`, otherwise the operation or the label. `null` when the agent
+   * reported none of them.
+   */
+  discriminator: string | null
+  /** Abbreviation plus discriminator, e.g. `NATS · orders.created`. */
+  displayName: string
+}
+
+/**
+ * Resolves a rendered edge back into the individual relationships it carries.
+ *
+ * This is the counterpart of the bundling in `projectArchitecture` and the
+ * reason bundling is allowed at all: a bundle is a *rendering* of several
+ * relationships, never a merge of them. Every single NATS topic stays reachable
+ * and identifiable through this function, at any zoom level.
+ */
+export function resolveEdgeBundle(edge: ArchitectureEdge): ResolvedRelationship[] {
+  return resolveRelationships(edge.data?.relationships ?? [])
+}
+
+/** Same as `resolveEdgeBundle`, for callers that already hold the list. */
+export function resolveRelationships(
+  relationships: readonly Relationship[],
+): ResolvedRelationship[] {
+  return relationships.map((relationship, index) => ({
+    relationship,
+    index,
+    total: relationships.length,
+    discriminator: relationshipDiscriminator(relationship),
+    displayName: relationshipDisplayName(relationship),
+  }))
+}
+
+/** Total number of relationships carried by a set of edges. */
+export function countRelationships(edges: readonly ArchitectureEdge[]): number {
+  return edges.reduce((total, edge) => total + (edge.data?.relationships.length ?? 0), 0)
+}
+
+/**
+ * A structural fingerprint of the projection.
+ *
+ * The ELK layout depends on exactly this information — node ids, their nesting,
+ * their fixed sizes and the edges between them. Two projections with the same
+ * signature therefore have the same layout, which is what lets the canvas skip
+ * a re-layout after a refetch that changed nothing structural.
+ */
+export function projectionSignature(projection: ArchitectureProjection): string {
+  const nodes = projection.nodes
+    .map((node) => `${node.id}<${node.parentId ?? ''}>${node.width}x${node.height}`)
+    .join('|')
+  const edges = projection.edges
+    .map((edge) => `${edge.id}#${edge.data?.relationships.length ?? 0}`)
+    .join('|')
+  return `${nodes}||${edges}`
+}

--- a/frontend/src/canvas/relationshipKinds.ts
+++ b/frontend/src/canvas/relationshipKinds.ts
@@ -1,0 +1,168 @@
+import type { Relationship, RelationshipKind } from '@/api/types'
+
+/**
+ * The visual vocabulary of a typed relationship.
+ *
+ * **Colour is not a channel here — by design.** `src/index.css` reserves the
+ * accent hues for the four work states (`src/state/workStates.ts`), because in
+ * this product colour carries the meaning "phase of work". Spending six more
+ * hues on relationship kinds would either collide with that or force the reader
+ * to learn two unrelated colour languages at once.
+ *
+ * So every edge is drawn in the same graphite ramp and the kind is carried by
+ * three colour-independent channels instead:
+ *
+ * 1. a **stroke pattern** that is unique per kind,
+ * 2. an **arrow head** (open or filled),
+ * 3. a **badge** with the kind's abbreviation, rendered as text.
+ *
+ * A greyscale screenshot of the canvas therefore loses no information about
+ * what kind of relationship an edge is.
+ */
+export interface RelationshipKindStyle {
+  id: RelationshipKind
+  /** Badge text. The strongest colour-independent channel: it is just text. */
+  abbreviation: string
+  /** Full German label used in tooltips and the legend. */
+  label: string
+  /** One sentence explaining what the kind means. */
+  description: string
+  /**
+   * SVG `stroke-dasharray`. Unique across all kinds, so the line alone already
+   * distinguishes them.
+   */
+  strokeDasharray: string
+  /** Arrow head. `arrowclosed` is filled, `arrow` is an open chevron. */
+  marker: 'arrow' | 'arrowclosed'
+  /**
+   * Which reported field identifies one relationship among its siblings on the
+   * same node pair. For `nats_topic` that is the topic name in `channel`.
+   */
+  discriminatorField: keyof Pick<Relationship, 'channel' | 'operation' | 'label'>
+}
+
+export const RELATIONSHIP_KIND_STYLES: readonly RelationshipKindStyle[] = [
+  {
+    id: 'http',
+    abbreviation: 'HTTP',
+    label: 'HTTP-Aufruf',
+    description: 'Synchroner HTTP-Aufruf von der Quelle zum Ziel.',
+    strokeDasharray: '0',
+    marker: 'arrowclosed',
+    discriminatorField: 'operation',
+  },
+  {
+    id: 'grpc',
+    abbreviation: 'gRPC',
+    label: 'gRPC-Aufruf',
+    description: 'Synchroner gRPC-Aufruf von der Quelle zum Ziel.',
+    strokeDasharray: '11 4',
+    marker: 'arrowclosed',
+    discriminatorField: 'operation',
+  },
+  {
+    id: 'data',
+    abbreviation: 'DATA',
+    label: 'Datenzugriff',
+    description: 'Lesender oder schreibender Zugriff auf einen Datenspeicher.',
+    strokeDasharray: '2 4',
+    marker: 'arrow',
+    discriminatorField: 'operation',
+  },
+  {
+    id: 'async',
+    abbreviation: 'ASYNC',
+    label: 'Asynchrone Nachricht',
+    description: 'Asynchroner Nachrichtenfluss ohne unmittelbare Antwort.',
+    strokeDasharray: '14 4 2 4',
+    marker: 'arrow',
+    discriminatorField: 'channel',
+  },
+  {
+    id: 'nats_topic',
+    abbreviation: 'NATS',
+    label: 'NATS-Topic',
+    description:
+      'Ein einzelnes NATS-Topic. Jedes Topic bleibt eine eigene Beziehung und wird nie zusammengefasst.',
+    strokeDasharray: '6 3',
+    marker: 'arrowclosed',
+    discriminatorField: 'channel',
+  },
+  {
+    id: 'dependency',
+    abbreviation: 'DEP',
+    label: 'Abhängigkeit',
+    description: 'Strukturelle Abhängigkeit ohne konkretes Laufzeitprotokoll.',
+    strokeDasharray: '1 6',
+    marker: 'arrow',
+    discriminatorField: 'label',
+  },
+]
+
+export const RELATIONSHIP_KIND_STYLE_BY_ID: Record<
+  RelationshipKind,
+  RelationshipKindStyle
+> = Object.fromEntries(
+  RELATIONSHIP_KIND_STYLES.map((style) => [style.id, style]),
+) as Record<RelationshipKind, RelationshipKindStyle>
+
+/**
+ * Ids of the two shared SVG markers. They are declared once per canvas so that
+ * an edge component can point several paths at them without React Flow having
+ * to synthesise one marker per path.
+ */
+export const MARKER_IDS = {
+  arrow: 'vai-edge-marker-arrow',
+  arrowclosed: 'vai-edge-marker-arrowclosed',
+  /** Highlighted variant used for the selected relationship. */
+  arrowSelected: 'vai-edge-marker-arrow-selected',
+  arrowclosedSelected: 'vai-edge-marker-arrowclosed-selected',
+} as const
+
+export function markerUrl(
+  marker: RelationshipKindStyle['marker'],
+  selected = false,
+): string {
+  if (selected) {
+    return marker === 'arrow'
+      ? `url(#${MARKER_IDS.arrowSelected})`
+      : `url(#${MARKER_IDS.arrowclosedSelected})`
+  }
+  return marker === 'arrow' ? `url(#${MARKER_IDS.arrow})` : `url(#${MARKER_IDS.arrowclosed})`
+}
+
+/** Trims a reported string field; an empty string means "not reported". */
+export function reported(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * The value that identifies one relationship among the parallel relationships
+ * of the same node pair — the topic name for `nats_topic`, the operation for a
+ * call, the label otherwise. `null` when the agent reported none of them.
+ */
+export function relationshipDiscriminator(relationship: Relationship): string | null {
+  const style = RELATIONSHIP_KIND_STYLE_BY_ID[relationship.kind]
+  const preferred = style ? reported(relationship[style.discriminatorField]) : null
+  return (
+    preferred ??
+    reported(relationship.channel) ??
+    reported(relationship.operation) ??
+    reported(relationship.label) ??
+    null
+  )
+}
+
+/**
+ * Short human-readable name of a relationship: the abbreviation of its kind
+ * plus whatever identifies it. Never invents a value — a relationship without
+ * any reported detail is shown by its kind alone.
+ */
+export function relationshipDisplayName(relationship: Relationship): string {
+  const style = RELATIONSHIP_KIND_STYLE_BY_ID[relationship.kind]
+  const abbreviation = style?.abbreviation ?? relationship.kind
+  const discriminator = relationshipDiscriminator(relationship)
+  return discriminator ? `${abbreviation} · ${discriminator}` : abbreviation
+}

--- a/frontend/src/canvas/useArchitectureGraph.test.ts
+++ b/frontend/src/canvas/useArchitectureGraph.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { NESTED_COMPONENTS, NESTED_RELATIONSHIPS } from '@/test/architectureFixtures'
+
+import { projectArchitecture } from './graphProjection'
+import {
+  applyTemporaryPositions,
+  routesInvalidatedByDrag,
+} from './useArchitectureGraph'
+
+const projection = projectArchitecture({
+  components: NESTED_COMPONENTS,
+  relationships: NESTED_RELATIONSHIPS,
+})
+
+describe('applyTemporaryPositions', () => {
+  it('moves a node on screen without touching the domain model behind it', () => {
+    const before = structuredClone(NESTED_COMPONENTS)
+
+    const moved = applyTemporaryPositions(
+      projection.nodes,
+      { 'platform.db': { x: 999, y: 111 } },
+      null,
+    )
+
+    const node = moved.find((candidate) => candidate.id === 'platform.db')
+    expect(node?.position).toEqual({ x: 999, y: 111 })
+    // The component the node carries is the very object the read API returned,
+    // unchanged — the drag lives in the node, never in the model.
+    expect(node?.data.component).toEqual(
+      NESTED_COMPONENTS.find((component) => component.componentId === 'platform.db'),
+    )
+    expect(NESTED_COMPONENTS).toEqual(before)
+
+    // Untouched nodes keep their identity, so React Flow does not remount them.
+    const untouched = moved.find((candidate) => candidate.id === 'platform.bus')
+    expect(untouched).toBe(
+      projection.nodes.find((candidate) => candidate.id === 'platform.bus'),
+    )
+  })
+
+  it('returns the input untouched when nothing was dragged or selected', () => {
+    expect(applyTemporaryPositions(projection.nodes, {}, null)).toBe(projection.nodes)
+  })
+
+  it('marks exactly the selected node', () => {
+    const marked = applyTemporaryPositions(projection.nodes, {}, 'platform.core.orders')
+    expect(marked.filter((node) => node.selected)).toHaveLength(1)
+    expect(marked.find((node) => node.selected)?.id).toBe('platform.core.orders')
+  })
+})
+
+describe('routesInvalidatedByDrag', () => {
+  it('drops the computed route only for edges of a moved node', () => {
+    const invalidated = routesInvalidatedByDrag(projection.edges, {
+      'platform.bus': { x: 10, y: 10 },
+    })
+
+    expect([...invalidated].sort()).toEqual([
+      'rel:platform.core.billing~>platform.bus',
+      'rel:platform.core.orders~>platform.bus',
+    ])
+  })
+
+  it('keeps every route while nothing was dragged', () => {
+    expect(routesInvalidatedByDrag(projection.edges, {}).size).toBe(0)
+  })
+})

--- a/frontend/src/canvas/useArchitectureGraph.ts
+++ b/frontend/src/canvas/useArchitectureGraph.ts
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type { ComponentId } from '@/api/types'
+
+import { layoutArchitecture, type EdgeRoutes } from './elkLayout'
+import {
+  EMPTY_DIAGNOSTICS,
+  projectArchitecture,
+  projectionSignature,
+  type ArchitectureEdge,
+  type ArchitectureModel,
+  type ArchitectureNode,
+  type ProjectionDiagnostics,
+} from './graphProjection'
+
+/** Positions the user dragged nodes to. Local, temporary, never persisted. */
+export type TemporaryPositions = Record<ComponentId, { x: number; y: number }>
+
+export interface ArchitectureGraph {
+  nodes: ArchitectureNode[]
+  edges: ArchitectureEdge[]
+  routes: EdgeRoutes
+  diagnostics: ProjectionDiagnostics
+  /** `true` while no layout exists yet — the canvas shows its loading state. */
+  isInitialLayout: boolean
+  /** `true` while a re-layout is running over an already visible graph. */
+  isRelayouting: boolean
+  /** Non-null when ELK failed; the last good graph stays on screen. */
+  error: unknown
+  /** Structural fingerprint of the model currently laid out. */
+  signature: string
+}
+
+const EMPTY_MODEL: ArchitectureModel = { components: [], relationships: [] }
+
+/**
+ * Projects an architecture snapshot and lays it out with ELK.
+ *
+ * Two things this hook is careful about:
+ *
+ * * **It does not re-layout when nothing structural changed.** TanStack Query's
+ *   structural sharing keeps the same object identity for a refetch that
+ *   returned equal data, and the projection signature catches the rest. A
+ *   refetch therefore does not make the graph flicker.
+ * * **It never blanks the canvas.** While a re-layout runs, the previous graph
+ *   stays on screen and only a quiet indicator changes. A layout that fails
+ *   leaves the last good graph visible and reports the error.
+ */
+export function useArchitectureGraph(
+  model: ArchitectureModel | undefined,
+): ArchitectureGraph {
+  const projection = useMemo(
+    () => projectArchitecture(model ?? EMPTY_MODEL),
+    [model],
+  )
+  const signature = useMemo(() => projectionSignature(projection), [projection])
+
+  const [laidOut, setLaidOut] = useState<LayoutState | null>(null)
+  const [error, setError] = useState<unknown>(null)
+  const runIdRef = useRef(0)
+
+  useEffect(() => {
+    // An empty model needs no solver run; the derived result below already
+    // describes it. Returning here also keeps this effect free of a synchronous
+    // `setState`, which would cost a cascading render on every refetch.
+    if (projection.nodes.length === 0) return
+
+    const runId = runIdRef.current + 1
+    runIdRef.current = runId
+
+    let cancelled = false
+    void layoutArchitecture(projection.nodes, projection.edges)
+      .then((layout) => {
+        if (cancelled || runIdRef.current !== runId) return
+        setLaidOut({ signature, nodes: layout.nodes, routes: layout.routes })
+        setError(null)
+      })
+      .catch((cause: unknown) => {
+        if (cancelled || runIdRef.current !== runId) return
+        setError(cause)
+      })
+
+    return () => {
+      cancelled = true
+    }
+    // `signature` is derived from `projection`; both are listed so a projection
+    // that is structurally identical after a refetch does not re-run ELK.
+  }, [projection, signature])
+
+  // The edges always come from the current projection — an incoming update must
+  // show up immediately, even if its layout is still being computed. Only the
+  // node positions wait for ELK.
+  return useMemo<ArchitectureGraph>(() => {
+    const isEmpty = projection.nodes.length === 0
+    const isCurrent = laidOut !== null && laidOut.signature === signature
+
+    return {
+      nodes: isEmpty ? [] : isCurrent ? laidOut.nodes : (laidOut?.nodes ?? []),
+      edges: projection.edges,
+      routes: isCurrent ? laidOut.routes : {},
+      diagnostics: projection.diagnostics ?? EMPTY_DIAGNOSTICS,
+      isInitialLayout: !isEmpty && laidOut === null,
+      isRelayouting: !isEmpty && !isCurrent,
+      error,
+      signature,
+    }
+  }, [laidOut, projection, signature, error])
+}
+
+interface LayoutState {
+  signature: string
+  nodes: ArchitectureNode[]
+  routes: EdgeRoutes
+}
+
+/**
+ * Applies the temporary drag positions and the current selection to the laid-out
+ * nodes.
+ *
+ * Pure on purpose. It is the boundary between the two kinds of state: the
+ * argument `nodes` is derived from the server model, `positions` is local UI
+ * state, and the result exists only for rendering. Nothing here writes back —
+ * a dragged node moves on screen and nowhere else, so a refetch of the
+ * architecture can never mistake a drag for a reported change.
+ */
+export function applyTemporaryPositions(
+  nodes: readonly ArchitectureNode[],
+  positions: TemporaryPositions,
+  selectedComponentId: ComponentId | null,
+): ArchitectureNode[] {
+  const hasPositions = Object.keys(positions).length > 0
+  if (!hasPositions && selectedComponentId === null) {
+    return nodes as ArchitectureNode[]
+  }
+
+  return nodes.map((node) => {
+    const dragged = positions[node.id]
+    const selected = node.id === selectedComponentId
+    if (!dragged && !selected) return node
+    return {
+      ...node,
+      ...(dragged ? { position: { x: dragged.x, y: dragged.y } } : {}),
+      selected,
+    }
+  })
+}
+
+/**
+ * Ids of the edges whose ELK route is no longer valid because one of their
+ * endpoints was dragged away from where the layout put it.
+ */
+export function routesInvalidatedByDrag(
+  edges: readonly ArchitectureEdge[],
+  positions: TemporaryPositions,
+): Set<string> {
+  const moved = new Set(Object.keys(positions))
+  if (moved.size === 0) return new Set()
+  const invalid = new Set<string>()
+  for (const edge of edges) {
+    if (moved.has(edge.source) || moved.has(edge.target)) invalid.add(edge.id)
+  }
+  return invalid
+}

--- a/frontend/src/canvas/useDetailLevel.ts
+++ b/frontend/src/canvas/useDetailLevel.ts
@@ -1,0 +1,16 @@
+import { useStore } from '@xyflow/react'
+
+import { detailLevelForZoom, type DetailLevel } from './detailLevel'
+
+/**
+ * The current detail level, derived from the canvas zoom.
+ *
+ * The selector deliberately returns the *level* and not the zoom: React Flow's
+ * store notifies on every zoom frame, and a node that re-rendered 60 times a
+ * second while the user scrolls would make a large model crawl. Selecting the
+ * derived string means a node only re-renders when it actually has to show
+ * something different.
+ */
+export function useDetailLevel(): DetailLevel {
+  return useStore((state) => detailLevelForZoom(state.transform[2]))
+}

--- a/frontend/src/components/workspace/ArchitecturePane.tsx
+++ b/frontend/src/components/workspace/ArchitecturePane.tsx
@@ -1,14 +1,20 @@
-import { Boxes } from 'lucide-react'
+import { useMemo } from 'react'
 
 import { useArchitecture } from '@/api/queries'
-import type { ProjectId } from '@/api/types'
+import type { ComponentId, ProjectId } from '@/api/types'
+import { ArchitectureCanvas } from '@/canvas/ArchitectureCanvas'
 import { AsyncState } from '@/components/AsyncState'
 import { StatusLegend } from '@/components/StatusLegend'
 import { PaneHeader } from '@/components/workspace/PaneHeader'
+import { RelationshipLegend } from '@/components/workspace/RelationshipLegend'
 import { Badge } from '@/components/ui/badge'
 
 export interface ArchitecturePaneProps {
   projectId: ProjectId
+  /** Selection from the URL; the canvas mirrors it, it never owns it. */
+  selectedComponentId?: ComponentId | undefined
+  /** Writes the selection back into the `component` search param. */
+  onSelectComponent: (componentId: ComponentId | null) => void
 }
 
 /**
@@ -16,17 +22,30 @@ export interface ArchitecturePaneProps {
  *
  * It stays the visually dominant area at 1920 × 1080 — it gets the largest
  * default share of the layout, the brightest surface and the only unbounded
- * region of the workspace. The interactive React Flow canvas with the ELK layout
- * is built in #9; this pane provides the named, correctly sized region, the
- * loading/error/empty states of the architecture read model and the accessible
- * work-state legend the overlays (#10) will use.
+ * region of the workspace. The pane itself only owns the read model, the
+ * loading/error/empty states and the two legends; the interactive graph lives
+ * in `src/canvas`.
  */
-export function ArchitecturePane({ projectId }: ArchitecturePaneProps) {
+export function ArchitecturePane({
+  projectId,
+  selectedComponentId,
+  onSelectComponent,
+}: ArchitecturePaneProps) {
   const architecture = useArchitecture(projectId)
 
   const componentCount = architecture.data?.components.length ?? 0
   const relationshipCount = architecture.data?.relationships.length ?? 0
   const activeChangeCount = architecture.data?.activeChanges.length ?? 0
+
+  // Kept stable across refetches: TanStack Query's structural sharing returns
+  // the same arrays when nothing changed, so the canvas does not re-layout.
+  const model = useMemo(
+    () => ({
+      components: architecture.data?.components ?? [],
+      relationships: architecture.data?.relationships ?? [],
+    }),
+    [architecture.data?.components, architecture.data?.relationships],
+  )
 
   return (
     <section
@@ -54,54 +73,37 @@ export function ArchitecturePane({ projectId }: ArchitecturePaneProps) {
         }
       />
 
-      {/* The canvas region owns its own overflow: wide graphs scroll here, the
-          page itself never gets a horizontal scrollbar. */}
-      <div className="relative min-h-0 min-w-0 flex-1 overflow-auto p-4">
-        <div
-          className="pointer-events-none absolute inset-0 opacity-60"
-          aria-hidden="true"
-          style={{
-            backgroundImage:
-              'linear-gradient(to right, var(--canvas-grid) 1px, transparent 1px),' +
-              'linear-gradient(to bottom, var(--canvas-grid) 1px, transparent 1px)',
-            backgroundSize: '32px 32px',
-          }}
-        />
-        <div className="relative flex h-full min-h-64 items-center justify-center">
-          <AsyncState
-            isPending={architecture.isPending}
-            isError={architecture.isError}
-            error={architecture.error}
-            isEmpty={componentCount === 0}
-            emptyTitle="Noch kein Architekturmodell gemeldet"
-            emptyDescription="Das Modell erscheint, sobald ein Agent architecture.snapshot_published sendet."
-            onRetry={() => void architecture.refetch()}
-            skeletonRows={5}
-            className="w-full max-w-2xl"
-          >
-            <div
-              className="border-border/70 bg-card/60 text-muted-foreground max-w-2xl rounded-lg border border-dashed p-6 text-center"
-              data-testid="architecture-canvas-placeholder"
+      {/* The canvas region owns its own overflow: a wide graph pans inside the
+          React Flow viewport, the page itself never gets a scrollbar. */}
+      <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
+        {architecture.isPending || architecture.isError || componentCount === 0 ? (
+          <div className="flex h-full items-center justify-center p-4">
+            <AsyncState
+              isPending={architecture.isPending}
+              isError={architecture.isError}
+              error={architecture.error}
+              isEmpty={componentCount === 0}
+              emptyTitle="Noch kein Architekturmodell gemeldet"
+              emptyDescription="Das Modell erscheint, sobald ein Agent architecture.snapshot_published sendet."
+              onRetry={() => void architecture.refetch()}
+              skeletonRows={5}
+              className="w-full max-w-2xl"
             >
-              <Boxes className="mx-auto mb-2 size-6" aria-hidden="true" />
-              <p className="text-foreground/80 font-medium">
-                Interaktiver Architekturcanvas folgt
-              </p>
-              <p className="mt-1 text-xs">
-                Der hierarchische React-Flow-Canvas mit deterministischem ELK-Layout wird in
-                einem eigenen Arbeitspaket ergänzt. Das Modell wird hier bereits geladen und
-                bei Live-Ereignissen gezielt invalidiert.
-              </p>
-              <p className="mt-3 font-mono text-xs">
-                {componentCount} Komponenten · {relationshipCount} Beziehungen ·{' '}
-                {activeChangeCount} aktive Änderungen
-              </p>
-            </div>
-          </AsyncState>
-        </div>
+              {null}
+            </AsyncState>
+          </div>
+        ) : (
+          <ArchitectureCanvas
+            projectId={projectId}
+            model={model}
+            selectedComponentId={selectedComponentId}
+            onSelectComponent={onSelectComponent}
+          />
+        )}
       </div>
 
-      <div className="border-border bg-card/80 shrink-0 border-t px-3 py-2">
+      <div className="border-border bg-card/80 shrink-0 space-y-1.5 border-t px-3 py-2">
+        <RelationshipLegend />
         <StatusLegend />
       </div>
     </section>

--- a/frontend/src/components/workspace/RelationshipLegend.tsx
+++ b/frontend/src/components/workspace/RelationshipLegend.tsx
@@ -1,0 +1,101 @@
+import { RELATIONSHIP_KIND_STYLES } from '@/canvas/relationshipKinds'
+import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+/**
+ * Legend for the six relationship kinds of the contract.
+ *
+ * The canvas encodes a kind through its stroke pattern, its arrow head and a
+ * text badge — never through colour, because the accent hues belong to the work
+ * states. This legend shows exactly those three channels, so it stays readable
+ * in greyscale and matches what is drawn on the canvas one for one.
+ */
+export function RelationshipLegend({ className }: { className?: string }) {
+  return (
+    <div className={cn('flex flex-wrap items-center gap-x-4 gap-y-1.5', className)}>
+      <span className="pane-heading">Beziehungsarten</span>
+      <ul
+        className="flex flex-wrap items-center gap-x-4 gap-y-1.5"
+        data-testid="relationship-legend"
+      >
+        {RELATIONSHIP_KIND_STYLES.map((style) => (
+          <li key={style.id}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="flex items-center gap-1.5"
+                  data-testid={`relationship-legend-${style.id}`}
+                  data-dasharray={style.strokeDasharray}
+                  data-marker={style.marker}
+                >
+                  <RelationshipLine
+                    dasharray={style.strokeDasharray}
+                    marker={style.marker}
+                  />
+                  <span className="font-mono text-[11px]">{style.abbreviation}</span>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="font-medium">{style.label}</p>
+                <p className="text-xs">{style.description}</p>
+              </TooltipContent>
+            </Tooltip>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+/** The two colour-independent line channels, drawn at legend size. */
+function RelationshipLine({
+  dasharray,
+  marker,
+}: {
+  dasharray: string
+  marker: 'arrow' | 'arrowclosed'
+}) {
+  const markerId = `legend-marker-${marker}`
+  return (
+    <svg
+      aria-hidden="true"
+      width="30"
+      height="8"
+      viewBox="0 0 30 8"
+      className="text-muted-foreground shrink-0"
+    >
+      <defs>
+        <marker
+          id={markerId}
+          viewBox="0 0 10 10"
+          refX={marker === 'arrow' ? 8 : 9}
+          refY="5"
+          markerWidth="5"
+          markerHeight="5"
+          orient="auto-start-reverse"
+        >
+          {marker === 'arrowclosed' ? (
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+          ) : (
+            <path
+              d="M 1 1 L 9 5 L 1 9"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+            />
+          )}
+        </marker>
+      </defs>
+      <line
+        x1="0"
+        y1="4"
+        x2="24"
+        y2="4"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeDasharray={dasharray === '0' ? undefined : dasharray}
+        markerEnd={`url(#${markerId})`}
+      />
+    </svg>
+  )
+}

--- a/frontend/src/routes/pages/WorkspacePage.tsx
+++ b/frontend/src/routes/pages/WorkspacePage.tsx
@@ -56,6 +56,19 @@ export function WorkspacePage() {
     [navigate],
   )
 
+  // Canvas selection -> URL. The canvas never keeps a selection of its own: a
+  // click and a deep link go through the same `component` search parameter, so
+  // an incoming live update cannot change what is selected.
+  const setSelectedComponent = useCallback(
+    (componentId: string | null) => {
+      void navigate({
+        search: (previous) => ({ ...previous, component: componentId ?? undefined }),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
+
   const setHistoryMode = useCallback(
     (enabled: boolean) => {
       void navigate({
@@ -85,7 +98,13 @@ export function WorkspacePage() {
       />
       <WorkspaceLayout
         left={<RunAgentPane projectId={projectId} runId={runId} />}
-        center={<ArchitecturePane projectId={projectId} />}
+        center={
+          <ArchitecturePane
+            projectId={projectId}
+            selectedComponentId={search.component}
+            onSelectComponent={setSelectedComponent}
+          />
+        }
         right={
           <InspectorPane
             projectId={projectId}

--- a/frontend/src/state/uiStore.ts
+++ b/frontend/src/state/uiStore.ts
@@ -100,6 +100,13 @@ export interface UiState {
   selectedComponentId: ComponentId | null
   selectedRelationshipId: Identifier | null
   hoveredComponentId: ComponentId | null
+  /**
+   * Relationship bundles the user unfolded by clicking them. Purely a way of
+   * looking at the graph — the bundle itself is a rendering, never a merge.
+   */
+  expandedEdgeIds: string[]
+  /** `false` hides the canvas minimap. */
+  minimapVisible: boolean
   deepFocus: DeepFocusTarget | null
   /** Pane arrangement to restore when deep focus ends. */
   paneStateBeforeDeepFocus: PaneArrangement | null
@@ -121,6 +128,10 @@ export interface UiState {
   setSelectedRelationshipId: (relationshipId: Identifier | null) => void
   setHoveredComponentId: (componentId: ComponentId | null) => void
 
+  toggleEdgeExpanded: (edgeId: string) => void
+  clearExpandedEdges: () => void
+  setMinimapVisible: (visible: boolean) => void
+
   setAgentCollapsed: (agentId: string, collapsed: boolean) => void
   toggleAgentCollapsed: (agentId: string) => void
 
@@ -134,6 +145,7 @@ const transientDefaults = {
   selectedComponentId: null,
   selectedRelationshipId: null,
   hoveredComponentId: null,
+  expandedEdgeIds: [],
   deepFocus: null,
   paneStateBeforeDeepFocus: null,
 } satisfies Partial<UiState>
@@ -145,6 +157,7 @@ export const useUiStore = create<UiState>()(
       leftCollapsed: false,
       rightCollapsed: false,
       collapsedAgentIds: [],
+      minimapVisible: true,
       ...transientDefaults,
 
       setLayout: (layout) => set({ layout }),
@@ -165,6 +178,15 @@ export const useUiStore = create<UiState>()(
       setSelectedRelationshipId: (selectedRelationshipId) =>
         set({ selectedRelationshipId }),
       setHoveredComponentId: (hoveredComponentId) => set({ hoveredComponentId }),
+
+      toggleEdgeExpanded: (edgeId) =>
+        set((s) => ({
+          expandedEdgeIds: s.expandedEdgeIds.includes(edgeId)
+            ? s.expandedEdgeIds.filter((id) => id !== edgeId)
+            : [...s.expandedEdgeIds, edgeId],
+        })),
+      clearExpandedEdges: () => set({ expandedEdgeIds: [] }),
+      setMinimapVisible: (minimapVisible) => set({ minimapVisible }),
 
       setAgentCollapsed: (agentId, collapsed) =>
         set((s) => {
@@ -222,7 +244,11 @@ export const useUiStore = create<UiState>()(
           leftCollapsed: state.leftCollapsed,
           rightCollapsed: state.rightCollapsed,
         }
-        return { ...persistedPanes, collapsedAgentIds: state.collapsedAgentIds }
+        return {
+          ...persistedPanes,
+          collapsedAgentIds: state.collapsedAgentIds,
+          minimapVisible: state.minimapVisible,
+        }
       },
     },
   ),

--- a/frontend/src/test/architectureFixtures.ts
+++ b/frontend/src/test/architectureFixtures.ts
@@ -1,0 +1,247 @@
+import type {
+  ArchitectureResponse,
+  Component,
+  Relationship,
+  RelationshipKind,
+} from '@/api/types'
+
+/**
+ * A nested architecture snapshot used by the canvas tests.
+ *
+ * It is deliberately not minimal — it is the smallest snapshot that still
+ * exercises everything the canvas has to get right:
+ *
+ * * **four hierarchy levels** (`platform` → `platform.api` → `platform.api.http`
+ *   → `platform.api.http.router`) plus a second root, so compound nesting is
+ *   more than one level deep,
+ * * **all six relationship kinds** of the contract,
+ * * **three separate NATS topics between the same pair of components**, which
+ *   is the case that must be bundled visually and stay individually resolvable,
+ * * fields that the read API reports as empty strings rather than omitting them.
+ *
+ * It is test data only and never reaches application code.
+ */
+
+export const NESTED_COMPONENTS: Component[] = [
+  {
+    componentId: 'platform',
+    name: 'Shop Platform',
+    kind: 'system',
+    parentComponentId: null,
+    description: 'Gesamtsystem des Shops.',
+    tags: ['core'],
+  },
+  {
+    componentId: 'platform.api',
+    name: 'API Gateway',
+    kind: 'service',
+    parentComponentId: 'platform',
+    technology: { language: 'Go', framework: 'chi', runtime: 'container', version: '1.24' },
+    tags: ['edge', 'public'],
+  },
+  {
+    componentId: 'platform.api.http',
+    name: 'HTTP Layer',
+    kind: 'module',
+    parentComponentId: 'platform.api',
+    technology: { language: 'Go' },
+    tags: [],
+  },
+  {
+    componentId: 'platform.api.http.router',
+    name: 'Router',
+    kind: 'module',
+    parentComponentId: 'platform.api.http',
+    technology: { language: 'Go', framework: 'chi' },
+    tags: ['routing'],
+  },
+  {
+    componentId: 'platform.api.grpc',
+    name: 'gRPC Layer',
+    kind: 'module',
+    parentComponentId: 'platform.api',
+    technology: { language: 'Go', framework: 'grpc-go', version: '1.68' },
+  },
+  {
+    componentId: 'platform.core',
+    name: 'Core Services',
+    kind: 'service',
+    parentComponentId: 'platform',
+    technology: {},
+    tags: [],
+  },
+  {
+    componentId: 'platform.core.orders',
+    name: 'Orders',
+    kind: 'module',
+    parentComponentId: 'platform.core',
+    technology: { language: 'Go', runtime: 'container' },
+    tags: ['domain', 'orders'],
+  },
+  {
+    componentId: 'platform.core.billing',
+    name: 'Billing',
+    kind: 'module',
+    parentComponentId: 'platform.core',
+    technology: { language: 'Go' },
+    tags: ['domain'],
+  },
+  {
+    componentId: 'platform.db',
+    name: 'Orders DB',
+    kind: 'datastore',
+    parentComponentId: 'platform',
+    technology: { runtime: 'PostgreSQL', version: '17' },
+    tags: ['stateful'],
+  },
+  {
+    componentId: 'platform.bus',
+    name: 'Message Bus',
+    kind: 'queue',
+    parentComponentId: 'platform',
+    technology: { runtime: 'NATS', version: '2.10' },
+  },
+  {
+    componentId: 'external.payments',
+    name: 'Payment Provider',
+    kind: 'external',
+    parentComponentId: null,
+    description: 'Externer Zahlungsdienstleister.',
+  },
+]
+
+export const NESTED_RELATIONSHIPS: Relationship[] = [
+  {
+    relationshipId: 'r-01',
+    sourceComponentId: 'platform.api.http.router',
+    targetComponentId: 'platform.core.orders',
+    kind: 'http',
+    label: 'Bestellung anlegen',
+    protocol: 'HTTP/1.1',
+    operation: 'POST /orders',
+    channel: '',
+  },
+  {
+    relationshipId: 'r-02',
+    sourceComponentId: 'platform.api.grpc',
+    targetComponentId: 'platform.core.billing',
+    kind: 'grpc',
+    label: '',
+    protocol: 'gRPC',
+    operation: 'Billing/Charge',
+    channel: '',
+  },
+  {
+    relationshipId: 'r-03',
+    sourceComponentId: 'platform.core.orders',
+    targetComponentId: 'platform.db',
+    kind: 'data',
+    label: 'Bestellungen lesen und schreiben',
+    protocol: 'SQL',
+    operation: 'SELECT/INSERT',
+  },
+  {
+    relationshipId: 'r-04',
+    sourceComponentId: 'platform.core.billing',
+    targetComponentId: 'platform.bus',
+    kind: 'async',
+    protocol: 'NATS',
+    channel: 'billing.events',
+  },
+  {
+    relationshipId: 'r-05',
+    sourceComponentId: 'platform.core.orders',
+    targetComponentId: 'platform.bus',
+    kind: 'nats_topic',
+    protocol: 'NATS',
+    channel: 'orders.created',
+    operation: 'publish',
+  },
+  {
+    relationshipId: 'r-06',
+    sourceComponentId: 'platform.core.orders',
+    targetComponentId: 'platform.bus',
+    kind: 'nats_topic',
+    protocol: 'NATS',
+    channel: 'orders.cancelled',
+    operation: 'publish',
+  },
+  {
+    relationshipId: 'r-07',
+    sourceComponentId: 'platform.core.orders',
+    targetComponentId: 'platform.bus',
+    kind: 'nats_topic',
+    protocol: 'NATS',
+    channel: 'orders.shipped',
+    operation: 'publish',
+  },
+  {
+    relationshipId: 'r-08',
+    sourceComponentId: 'platform.core.billing',
+    targetComponentId: 'external.payments',
+    kind: 'dependency',
+    label: 'SDK',
+  },
+]
+
+/** The three topics that share the `orders → bus` node pair. */
+export const BUNDLED_TOPIC_CHANNELS = [
+  'orders.cancelled',
+  'orders.created',
+  'orders.shipped',
+] as const
+
+export const ALL_RELATIONSHIP_KINDS: readonly RelationshipKind[] = [
+  'http',
+  'grpc',
+  'data',
+  'async',
+  'nats_topic',
+  'dependency',
+]
+
+export const nestedArchitectureResponse: ArchitectureResponse = {
+  projectPosition: 42,
+  components: NESTED_COMPONENTS,
+  relationships: NESTED_RELATIONSHIPS,
+  activeChanges: [],
+}
+
+/**
+ * The same model with one additional leaf component — used to simulate a live
+ * update that really changes the architecture.
+ */
+export const grownArchitectureResponse: ArchitectureResponse = {
+  projectPosition: 43,
+  components: [
+    ...NESTED_COMPONENTS,
+    {
+      componentId: 'platform.core.shipping',
+      name: 'Shipping',
+      kind: 'module',
+      parentComponentId: 'platform.core',
+      technology: { language: 'Go' },
+      tags: ['domain'],
+    },
+  ],
+  relationships: [
+    ...NESTED_RELATIONSHIPS,
+    {
+      relationshipId: 'r-09',
+      sourceComponentId: 'platform.core.shipping',
+      targetComponentId: 'platform.bus',
+      kind: 'nats_topic',
+      protocol: 'NATS',
+      channel: 'shipping.dispatched',
+    },
+  ],
+  activeChanges: [],
+}
+
+/** Shuffles deterministically, so a re-ordered input list is reproducible. */
+export function reorder<T>(items: readonly T[]): T[] {
+  const reversed = [...items].reverse()
+  const front = reversed.filter((_, index) => index % 2 === 0)
+  const back = reversed.filter((_, index) => index % 2 === 1)
+  return [...back, ...front]
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -11,6 +11,11 @@ import { resetUiStore } from '@/state/uiStore'
  * react-resizable-panels and Radix rely on. The stubs are inert: they satisfy
  * the API surface without pretending to report sizes, so no test can
  * accidentally depend on a fake layout measurement.
+ *
+ * React Flow deliberately needs no measurement stub here: the architecture
+ * canvas declares node sizes and handle positions on the nodes themselves (see
+ * `src/canvas/graphProjection.ts`), so its geometry comes from the ELK layout
+ * rather than from a rendered DOM.
  */
 class ResizeObserverStub implements ResizeObserver {
   observe(): void {}


### PR DESCRIPTION
Der mittlere Pane zeigt das gemeldete Architekturmodell jetzt als interaktiven,
hierarchischen Graphen statt als Platzhalter — React Flow für die Darstellung,
ELK `layered` für ein deterministisches Layout.

Closes #9

## Aufbau

Vier Schichten, damit jede Regel für sich prüfbar bleibt und nicht in einer
Komponente verschwindet:

| Modul | Aufgabe |
| --- | --- |
| `canvas/graphProjection.ts` | Domainmodell → React-Flow-Graph. Rein, ohne React-Laufzeitcode. |
| `canvas/elkLayout.ts` | ELK `layered`, deterministisch, mit gerouteten Kanten. |
| `canvas/cameraPolicy.ts` | Wann die Kamera sich von selbst bewegen darf. |
| `canvas/RelationshipEdge.tsx` | Kantendarstellung inkl. auflösbarer Bündelung. |

### Graph-Projection-Adapter

Baut aus `parentComponentId` die Compound-Struktur (`parentId` +
`extent: 'parent'`) und ist **total** — gemeldete Daten können falsch sein:

| Eingabe | Verhalten | Diagnose |
| --- | --- | --- |
| `parentComponentId` nicht im Snapshot | Komponente wird Wurzel | `orphanedParents` |
| Zyklus in der Hierarchie | alphabetisch erstes Mitglied wird gelöst | `hierarchyCycles` |
| Beziehungsende nicht im Snapshot | Beziehung wird nicht gezeichnet | `danglingRelationships` |
| doppelte ID | erste Meldung gewinnt | `duplicate*Ids` |

Nichts verschwindet still: die Anzahl der Reparaturen steht als Hinweis auf der
Fläche. Dass der *alphabetisch erste* Knoten eines Zyklus gelöst wird und nicht
der zuerst gefundene, macht die Reparatur unabhängig von der Zeilenreihenfolge
der API.

### Determinismus

Auf drei Ebenen abgesichert, jede mit einem Test:

1. **Kanonische Eingabe** — Projektion und Layout sortieren Knoten und Kanten
   nach ID. Die Serialisierungsreihenfolge der Read API erreicht den Solver nie.
2. **Fixierter Zufall** — `elk.randomSeed` gepinnt, `LAYER_SWEEP`,
   `considerModelOrder: NODES_AND_EDGES` und `BRANDES_KOEPF` explizit gewählt.
3. **Feste Größen** — Knotengrößen sind Konstanten, nie aus dem DOM gemessen
   und nie von der Detailstufe abhängig. Auch die Handles sind auf dem Knoten
   deklariert statt gemessen, damit die Kantengeometrie eine reine Funktion des
   Layouts ist.

### Beziehungsarten ohne Farbe

`src/index.css` reserviert die Akzenttöne für die vier Arbeitszustände. Sechs
weitere Farben würden entweder damit kollidieren oder zwei Farbsprachen
nebeneinander erzwingen — deshalb tragen Beziehungsarten **gar keine Farbe**.
Jede Art hat ein eigenes Strichmuster, eine offene oder gefüllte Pfeilspitze und
ein Text-Badge. Im Browser gemessen:

| Art | `stroke-dasharray` | Marker | Badge |
| --- | --- | --- | --- |
| `http` | durchgezogen | gefüllt | HTTP |
| `grpc` | `11 4` | gefüllt | gRPC |
| `data` | `2 4` | offen | DATA |
| `async` | `14 4 2 4` | offen | ASYNC |
| `nats_topic` | `6 3` | gefüllt | NATS |
| `dependency` | `1 6` | offen | DEP |

Alle Kanten zeichnen mit `stroke="currentColor"` im selben Graphit.

### Auflösbare Bündelung

Parallele Beziehungen eines Knotenpaars teilen sich eine gezeichnete Kante, die
die **vollständige Liste behält**. Ob eine oder mehrere Linien gezeichnet
werden, ist eine Darstellungsentscheidung, nie eine Zusammenfassung:

* zugeklappt (niedriger Zoom): eine Linie plus Badge `3 × NATS`
* aufgeklappt (Zoom ≥ 1,15 **oder** Klick auf das Badge): eine Linie je
  Beziehung, jede mit ihrem `channel`/`operation`

Gebündelt wird nach *gerichtetem* Paar — `A → B` und `B → A` bleiben zwei
Kanten. Das Layout läuft immer auf dem zugeklappten Graphen, damit das
Aufklappen keinen Knoten bewegt.

### Kamera und Auswahl

`fitView` läuft beim ersten gelayouteten Modell eines Projekts, bei einer
Größenänderung der Fläche **bevor** die Nutzerin die Kamera angefasst hat, und
auf ausdrücklichen Klick. Ein Live-Event ist keiner dieser Fälle.

Der Resize-Fall ist kein Schlupfloch, sondern die Behebung eines echten Fehlers:
die drei Panes messen sich asynchron, das erste Layout kann eintreffen, während
der mittlere Pane noch ein paar hundert Pixel breit ist — das Modell blieb dann
auf minimalem Zoom stehen. React Flow meldet bei einer programmatischen
Bewegung `null` als Event und bei einer Nutzerbewegung das echte Input-Event;
genau daran unterscheidet die Policy „setzt sich noch" von „die Nutzerin fährt".

Auswahl ist kein Canvas-State: ein Klick schreibt den `component`-Search-Param
über die typisierte Route aus #7, der Canvas liest ihn zurück. Deep Link und
Klick erzeugen denselben Zustand.

### Temporäres Dragging

Landet ausschließlich in `uiStore.nodePositions` — nicht im Query-Cache, nicht
im Domainmodell, nicht in `localStorage`. `applyTemporaryPositions` ist die
Grenze: Server-Knoten rein, lokale Positionen rein, ein reines Renderergebnis
raus. Kanten eines verschobenen Knotens verlieren ihre ELK-Route und fallen auf
eine orthogonale Verbindung zurück.

## Tests

```
$ npm test
 ✓ src/canvas/cameraPolicy.test.ts (8 tests)
 ✓ src/canvas/edgeGeometry.test.ts (6 tests)
 ✓ src/api/fetchJson.test.ts (6 tests)
 ✓ src/canvas/detailLevel.test.ts (4 tests)
 ✓ src/canvas/graphProjection.test.ts (13 tests)
 ✓ src/canvas/useArchitectureGraph.test.ts (5 tests)
 ✓ src/state/workStates.test.ts (6 tests)
 ✓ src/routes/searchParams.test.ts (7 tests)
 ✓ src/api/liveStream.test.ts (11 tests)
 ✓ src/canvas/elkLayout.test.ts (7 tests)
 ✓ src/components/StatusLegend.test.tsx (4 tests)
 ✓ src/routes/router.test.tsx (7 tests)
 ✓ src/components/workspace/WorkspaceLayout.test.tsx (5 tests)
 ✓ src/canvas/ArchitectureCanvas.test.tsx (12 tests)

 Test Files  14 passed (14)
      Tests  101 passed (101)
```

Die geforderten zehn Kriterien:

| # | Kriterium | Test |
| --- | --- | --- |
| 1 | Verschachtelter Snapshot (4 Ebenen, alle 6 Arten) vollständig übersetzt | `graphProjection.test.ts` |
| 2 | Verwaister Parent und Hierarchiezyklus definiert behandelt | `graphProjection.test.ts` |
| 3 | Zweimaliges Layouten liefert identische Positionen | `elkLayout.test.ts` |
| 4 | Umsortierte Eingaben liefern identische Positionen | `elkLayout.test.ts` |
| 5 | Bündelung auflösbar, `channel`/`operation` einzeln erreichbar | `graphProjection.test.ts`, `ArchitectureCanvas.test.tsx` |
| 6 | Separate NATS-Topics bleiben separate Beziehungen | `graphProjection.test.ts` |
| 7 | Klick setzt den `component`-Search-Param | `ArchitectureCanvas.test.tsx` |
| 8 | Live-Update verändert weder Kamera noch Auswahl | `ArchitectureCanvas.test.tsx`, `cameraPolicy.test.ts` |
| 9 | Dragging nicht im Server-State, überlebt keinen Refetch | `ArchitectureCanvas.test.tsx`, `useArchitectureGraph.test.ts` |
| 10 | Kanten tragen ihre Art nicht-farblich | `ArchitectureCanvas.test.tsx` |

Zusätzlich prüft `elkLayout.test.ts`, dass jede Route am Quell-Handle beginnt
und am Ziel-Handle endet. Dieser Test hat einen echten Fehler gefunden: ELK gibt
Kantenkoordinaten relativ zum **niedrigsten gemeinsamen Vorfahren** der beiden
Enden zurück, nicht relativ zum Container, in dem die Kante deklariert wurde.
Jede Kante zwischen zwei verschachtelten Komponenten war dadurch um den Versatz
ihres gemeinsamen Containers von den Knoten gelöst.

```
$ npm run lint      # eslint . — keine Ausgabe
$ npm run typecheck # tsc --build --force — keine Ausgabe
$ npm run build
dist/index.html                    0.61 kB │ gzip:   0.40 kB
dist/assets/index-*.css           57.97 kB │ gzip:  10.21 kB
dist/assets/index-BTQZ-IAR.js    791.97 kB │ gzip: 251.40 kB
dist/assets/elk.bundled-*.js   1,441.13 kB │ gzip: 439.11 kB
✓ built in 15.97s

$ docker build -t vai-frontend-check ./frontend   # DONE, Image danach entfernt
```

ELK wird dynamisch nachgeladen und bildet einen eigenen Chunk — das Code
Splitting, das ADR 0003 für diesen Zeitpunkt vorgesehen hat. Der Einstiegs-Chunk
liegt weiter über der 500-kB-Warnschwelle, was ADR 0003 für ein Desktop-Cockpit
im lokalen Netz bereits als vertretbar festgehalten hat.

## Visuelle Prüfung

Chromium, Viewport **exakt 1920 × 1080**, Compose-Stack auf Port 8092, Daten aus
dem Simulator (#13, `npm run simulate -- --base http://localhost:8092 --speed 0`,
62 Events) plus zwei weitere `relationship.change_applied`, damit ein echtes
paralleles Bündel auf einem Knotenpaar entsteht.

**Flächenaufteilung**

| Bereich | Größe | Fläche | Anteil |
| --- | --- | --- | --- |
| Run/Agents links | 345 × 1036 | 357 668 px² | 24,4 % |
| **Architektur Mitte** | **1036 × 1036** | **1 073 005 px²** | **54,0 %** |
| Inspector rechts | 537 × 1036 | 556 375 px² | 25,3 % |

Die Zeichenfläche selbst misst 1036 × 933 px. `document.documentElement.scrollWidth`
= 1920 bei `innerWidth` = 1920 — **kein horizontaler Seiten-Scrollbar**.

**Minimap** — 168 × 112 px oben rechts, 18 816 px² = **1,95 %** der
Zeichenfläche, über leerem Raum statt über dem Graphen, weil das Layout von der
Ursprungsecke nach rechts unten wächst. Für ein Modell, das ab etwa 20
Komponenten nicht mehr auf den Schirm passt, ist das ein fairer Preis; sie ist
abschaltbar und der Schalter wird mit dem übrigen Layout-State persistiert.

**Erstes Laden**

```
nodeCount 17 · edgeCount 11 · renderedNodes 17 · renderedEdgePaths 11
transform  translate(37.0212px, 291.871px) scale(0.399153)
fitViewCount 1 · nodesOutsideCanvas [] · detail "overview"
```

Alle 17 Knoten liegen nach dem einen automatischen Fit vollständig in der
Fläche. Geometrieprüfung über alle 18 Knoten: **keine Überlappung zwischen
nicht verwandten Knoten, kein Kind außerhalb seines Containers.**

**Bündelung, aufgelöst per Klick bei Übersichtszoom**

```
zugeklappt: "3 × NATS ▸"
aufgeklappt:
  NATS · orders.order.cancelled   (Kanal orders.order.cancelled, Operation publish)
  NATS · orders.order.created     (Kanal orders.order.created)
  NATS · orders.order.shipped     (Kanal orders.order.shipped, Operation publish)
drei eigene Pfadgeometrien, Kamera unverändert
```

**Live-Update über echtes SSE** — `component.change_applied` eingespielt,
während eine Komponente ausgewählt und die Kamera vom Nutzer verstellt war:

```
vorher : transform translate(-59.1465px, 256.962px) scale(0.478983) · fitViewCount 1
         ?component=shop-platform.orders.domain.pricing
nachher: nodeCount 17 → 18, neue Komponente sichtbar
         transform translate(-59.1465px, 256.962px) scale(0.478983) · fitViewCount 1
         ?component=shop-platform.orders.domain.pricing · weiterhin ausgewählt
```

Byte-identische Transform, unveränderte Auswahl, kein zusätzlicher Fit.

**Dragging** — Knoten von `translate(2157px, 347.5px)` nach
`translate(2026.29px, 504.082px)` gezogen. `localStorage` enthält danach nur
`layout`, `leftCollapsed`, `rightCollapsed`, `collapsedAgentIds` und
`minimapVisible` — keine Positionen. Das Read Model trägt keine
Canvas-Koordinaten. „Positionen zurücksetzen" stellt exakt
`translate(2157px, 347.5px)` wieder her.

**Progressive Detailstufen** — bei Zoom 0,40 nur Name und Art; ab 0,62
zusätzlich die gemeldete Technologie; ab 1,15 zusätzlich Tags und automatisch
aufgefächerte Bündel (im Browser bei Zoom 1,35 bestätigt).

Aufgeräumt mit `docker compose -p visualise-ai-issue-9 down -v`.

## ADR

`docs/decisions/0008-architecture-canvas-layout-and-edge-bundling.md` hält fest,
warum ELK `layered`, wie Determinismus gesichert wird, warum die Bündelung
auflösbar sein **muss**, warum temporäre Positionen lokal bleiben und warum es
keine datengetriebene Kamerafahrt gibt.

## Abgrenzung

Nicht Teil dieses PRs und bewusst offen gelassen: die Live-Overlays für
geplant/aktiv/angewandt (#10), Agentbaum-Inhalte (#11) und Inspector-Inhalte
(#12). Der Canvas liefert die Struktur, auf der #10 aufsetzt — ein
Arbeitszustand wird dort zu Rahmenstil und Icon auf einem bestehenden Knoten
und zu einer Strichfarbe auf einer bestehenden Kante. Keins davon ändert die
Boxgröße eines Knotens, also kann auch keins das Layout verschieben.
