### PR TITLE
Frontend-Read-Model-Typen aus dem OpenAPI-Vertrag generieren

### DIFF
--- a/docs/decisions/0009-generated-frontend-contract-types.md
+++ b/docs/decisions/0009-generated-frontend-contract-types.md
@@ -1,0 +1,120 @@
+# 9. Frontend read-model types are generated from the contract, not written by hand
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context:** contract correction inside the v0 epic #1; unblocks #10, #11, #12
+- **Builds on:** [0004 — Contract-driven ingestion validation](./0004-contract-driven-ingestion-validation.md),
+  [0005 — Read API shape and run scoping](./0005-read-api-shape-and-run-scoping.md)
+
+## Context
+
+`frontend/src/api/types.ts` used to state, in its own header, that the types
+were "derived by hand from `api/openapi.yaml`" and that there was "deliberately
+no code generation step". That was an honest description of how the file was
+written — and it was wrong within one work package.
+
+The frontend shell (#7) and the read API (#8) were built in parallel against the
+same issue text rather than against the finished document. The hand-written
+read models therefore described the read API somebody *expected*, and nothing
+ever compared the two. TypeScript could not notice: nothing in the frontend ever
+saw a real response at compile time. The drift only surfaced when the canvas
+(#9) started reading fields.
+
+What had actually diverged:
+
+| hand-written | `api/openapi.yaml` |
+| --- | --- |
+| `ActiveChange.target`, `componentId`, `relationshipId` | `targetKind`, `targetId` |
+| `ActiveChange.reportedAt` | `plannedAt`, `appliedAt`, `retractedAt` |
+| `ActiveChange.state: planned \| applied` | `planned \| applied \| retracted` |
+| — missing — | `ActiveChange.snapshot`, the reported descriptor verbatim |
+| `Component`, `Relationship` as read models | `AppliedComponent`, `AppliedRelationship`, with provenance |
+| `Agent` (`capabilities`, `summary`, `statusReportedAt`) | `RunAgent` (none of those; `finishedOutcome`) |
+| `ProjectSummary.name`, `runCount` | neither exists; `firstSeenAt`, `lastPosition`, `counts` do |
+| `RunSummary.agentCount`, `projectId`, `lastEventAt` | `rootAgentId`, `isOpen`, `isCurrent`, `position` |
+| `Plan`, `WorkStep`, `Feedback`, `Diff`, `Risk`, `HistoryEntry` | `RunPlan`, `InspectorWorkStep`, `FeedbackEntry`, `ReportedDiff`, `ReportedRisk`, `ComponentHistoryEntry` |
+
+Three of these were not merely different names: `ProjectsPage`, `WorkspaceHeader`
+and `RunAgentPane` rendered `project.name`, `project.runCount` and
+`run.agentCount` — fields the API has never sent. They displayed `undefined`
+against a real backend.
+
+## Decision
+
+**The contract generates the types.** `openapi-typescript` turns
+`api/openapi.yaml` into `frontend/src/api/generated/contract.ts`, and
+`frontend/src/api/types.ts` no longer describes a single shape: every export is
+an alias into that module. The aliases still exist so application code writes
+`ActiveChange` rather than `components['schemas']['ActiveChange']`, and so a
+renamed schema fails to compile in exactly one file.
+
+**The contract's names win, always.** Where a frontend name and a contract name
+disagreed, the frontend name was retired and the call sites were changed —
+never the other way round, and never by adding a field to the contract to keep
+frontend code alive. Where a rendered field did not exist at all, the rendering
+was corrected: the project list and the workspace header now show the project
+slug, because the contract carries no display name for a project and the cockpit
+does not invent one; the run list shows `rootAgentId`, because `RunSummary` has
+no agent count (only `RunDetail.counts` does, on a different endpoint).
+
+**The generated file is committed.** The frontend image builds with
+`frontend/` as its Docker context, so `../api` does not exist during
+`npm ci && npm run build`. This is the same constraint, and the same resolution,
+as the embedded contract copy in the backend (ADR 0004): commit the artefact,
+and guard it.
+
+**The guard is a test, and it was verified to fail.**
+`src/api/contractDrift.test.ts` runs `scripts/generate-contract.mjs --check`,
+which regenerates in memory and compares byte for byte, and separately asserts
+that the sha256 recorded in the generated header is the sha256 of
+`api/openapi.yaml` as it is on disk. Both failure modes were reproduced before
+this was accepted: adding a property to `ActiveChange` in the contract turned
+both assertions red, and editing one line of the generated file turned the
+byte comparison red. A guard that has only ever been green proves nothing.
+
+**Empty objects generate as `unknown`, not `Record<string, never>`.** The
+contract types `ActiveChange.snapshot` and every event `payload` as a free-form
+object on purpose — they carry what the agent reported, unchanged. The
+generator's default would claim the opposite (an object that can never have a
+property), which makes every narrowing of them `never`. `changeSnapshot()` in
+`types.ts` narrows a snapshot by the contract's own `targetKind` discriminator
+instead, and is the only hand-written line of logic left in that file.
+
+**One list stays hand-written: `EVENT_TYPES`.** The SSE client needs the
+catalogue at runtime — the server sets `event:` to the event type, so a
+`message` listener never fires and every type must be subscribed individually —
+and types are erased at runtime. It is declared
+`satisfies readonly EventType[]` and paired with a type-level exhaustiveness
+check, so a type added to the contract and not to the list fails `tsc`.
+
+**The generated types were checked against a running system, not just the
+spec.** The full stack was started, the simulator replayed its 62-event
+scenario, and every read response was validated with Ajv against the schema it
+claims to satisfy — `/projects`, `/projects/{id}`, `/architecture`, `/runs`,
+`/runs/current`, `/runs/{id}`, `/agents`, `/plans`, and the inspector plus
+history of all 17 components of the applied model. 42 responses, all valid. The
+spec and the implementation agree; only the frontend had been out of step.
+
+## Consequences
+
+- Changing the contract is now a two-step change for the frontend:
+  `npm run generate:contract`, then commit the result. The test names the
+  command when it is missed.
+- `src/api/generated/` is excluded from ESLint. It is not excluded from
+  `tsc` — the generated module compiles under the project's full strictness
+  (`exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`), which is worth
+  more than the noise it would otherwise cause.
+- Test fixtures now build read models through `appliedComponent` /
+  `appliedRelationship`, so a fixture cannot describe a response the API does
+  not serve. That is why the canvas fixtures grew provenance fields.
+- `graphProjection` no longer treats an empty string as "not reported" for
+  `parentComponentId`. The contract types it `ComponentId | null` with
+  `minLength: 1`, so the empty-string branch was guarding against a value the
+  API cannot produce.
+- `resolveWorkState` gained an explicit `retracted` branch. A withdrawn proposal
+  now contributes nothing to the overlay instead of falling through an
+  unconsidered path — it is neither planned nor applied, and a fifth colour for
+  work no longer claimed would mislead the reviewer.
+- The generated file is ~2 600 lines of version-controlled artefact. It is only
+  defensible while the drift test exists; deleting that test removes the entire
+  justification for committing it.

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,7 +5,12 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist', 'node_modules'] },
+  {
+    // `src/api/generated/` is written by `npm run generate:contract` out of
+    // `api/openapi.yaml`. Linting a generated artefact only produces findings
+    // nobody may fix in place — the fix always belongs in the contract.
+    ignores: ['dist', 'node_modules', 'src/api/generated'],
+  },
   {
     files: ['**/*.{ts,tsx}'],
     extends: [js.configs.recommended, ...tseslint.configs.recommended],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^28.0.0",
+        "openapi-typescript": "^7.13.0",
         "tailwindcss": "^4.3.3",
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.9.0",
@@ -2850,6 +2851,105 @@
       "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
       "license": "MIT"
     },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.18",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.18.tgz",
+      "integrity": "sha512-UyKIm0wTPw5BcY7Z2PkbK1Ma260um96LSBWXHrdSMe+ZV0EPMyDfAcUcjjm3qEiGST9OK/1TriekdPCZkn4Q3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.3.0",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -4447,6 +4547,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4663,6 +4773,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -4717,6 +4834,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -5592,6 +5716,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5646,6 +5783,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {
@@ -6206,6 +6353,40 @@
         "node": ">=18"
       }
     },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6267,6 +6448,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -6337,6 +6536,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss": {
@@ -7043,6 +7252,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -7138,6 +7360,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
@@ -7476,6 +7705,23 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview",
     "typecheck": "tsc --build --force",
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "generate:contract": "node scripts/generate-contract.mjs",
+    "check:contract": "node scripts/generate-contract.mjs --check"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
@@ -42,6 +44,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^28.0.0",
+    "openapi-typescript": "^7.13.0",
     "tailwindcss": "^4.3.3",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.9.0",

--- a/frontend/scripts/generate-contract.mjs
+++ b/frontend/scripts/generate-contract.mjs
@@ -1,0 +1,87 @@
+/**
+ * Generates `src/api/generated/contract.ts` from `api/openapi.yaml`.
+ *
+ *   node scripts/generate-contract.mjs           # (re)write the file
+ *   node scripts/generate-contract.mjs --check   # fail when it is stale
+ *
+ * The generated module is committed. The frontend image builds from the
+ * `frontend/` directory alone (`docker-compose.yml` sets that build context),
+ * so `../api` does not exist inside the Docker build — the same reason the
+ * backend commits its contract copy, see
+ * `docs/decisions/0004-contract-driven-ingestion-validation.md`.
+ *
+ * A committed generated artefact is only safe while something proves it still
+ * matches the authority. That is `--check`, which `src/api/generated/contract.drift.test.ts`
+ * runs as part of the normal test suite.
+ */
+import { createHash } from 'node:crypto'
+import { readFile, mkdir, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import openapiTS, { astToString } from 'openapi-typescript'
+
+const SPEC_URL = new URL('../../api/openapi.yaml', import.meta.url)
+const OUTPUT_URL = new URL('../src/api/generated/contract.ts', import.meta.url)
+
+/** Marks the file as generated and pins the exact authority it came from. */
+function header(specHash) {
+  return `/**
+ * GENERATED FILE — DO NOT EDIT.
+ *
+ * Produced from \`api/openapi.yaml\` by \`npm run generate:contract\`
+ * (openapi-typescript). Edit the contract, then regenerate.
+ *
+ * authority: api/openapi.yaml
+ * sha256:    ${specHash}
+ *
+ * \`npm run check:contract\` — also run by the Vitest suite — fails when this
+ * file no longer matches the authority above.
+ */
+`
+}
+
+/** sha256 of the authority document, over its raw bytes. */
+export async function specSha256() {
+  return createHash('sha256').update(await readFile(SPEC_URL)).digest('hex')
+}
+
+/** The exact content `src/api/generated/contract.ts` must have. */
+export async function buildContractModule() {
+  const ast = await openapiTS(SPEC_URL, {
+    // `type: object` without properties is a free-form object in the contract
+    // (`ActiveChange.snapshot`, every event `payload`). The default
+    // `Record<string, never>` would claim the opposite — that it can never
+    // carry a property — and make every narrowing of it `never`.
+    emptyObjectsUnknown: true,
+  })
+  return `${header(await specSha256())}${astToString(ast)}`
+}
+
+const expected = await buildContractModule()
+const check = process.argv.includes('--check')
+
+if (check) {
+  let actual = null
+  try {
+    actual = await readFile(OUTPUT_URL, 'utf8')
+  } catch {
+    // stays null — reported below
+  }
+
+  if (actual === expected) {
+    console.log(`✓ ${fileURLToPath(OUTPUT_URL)} matches api/openapi.yaml`)
+    process.exit(0)
+  }
+
+  console.error(
+    `✗ src/api/generated/contract.ts does not match api/openapi.yaml.\n` +
+      `  The contract is the authority. Run:\n\n` +
+      `      npm run generate:contract\n\n` +
+      `  and commit the regenerated file.`,
+  )
+  process.exit(1)
+}
+
+await mkdir(new URL('.', OUTPUT_URL), { recursive: true })
+await writeFile(OUTPUT_URL, expected, 'utf8')
+console.log(`✓ wrote ${fileURLToPath(OUTPUT_URL)}`)

--- a/frontend/src/api/contractDrift.test.ts
+++ b/frontend/src/api/contractDrift.test.ts
@@ -1,0 +1,60 @@
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The drift guard for the committed contract types.
+ *
+ * `src/api/generated/contract.ts` is a generated artefact under version
+ * control. That is only defensible while something proves it still describes
+ * `api/openapi.yaml` — the same arrangement, and the same argument, as
+ * `TestEmbeddedContractMatchesTheAuthority` in the backend
+ * (`backend/internal/ingest/contract_test.go`).
+ *
+ * The check runs the generator itself and compares byte for byte, so it fails
+ * for either cause of drift:
+ *
+ * * the contract changed and nobody regenerated, and
+ * * the generated file was edited by hand.
+ *
+ * The second assertion pins the same fact from the other side: the sha256 in
+ * the file's header must be the sha256 of the contract as it is on disk now.
+ *
+ * Vitest runs with the frontend package as its working directory, so the paths
+ * below are resolved from there rather than from `import.meta.url`, which is a
+ * transformed module URL inside the jsdom environment.
+ */
+
+const FRONTEND_ROOT = process.cwd()
+const SPEC = resolve(FRONTEND_ROOT, '../api/openapi.yaml')
+const GENERATED = resolve(FRONTEND_ROOT, 'src/api/generated/contract.ts')
+
+/** Generation walks the whole contract; give it room on a cold cache. */
+const GENERATE_TIMEOUT = 60_000
+
+describe('generated contract types', () => {
+  it(
+    'are up to date with api/openapi.yaml',
+    () => {
+      expect(() =>
+        execFileSync(process.execPath, ['scripts/generate-contract.mjs', '--check'], {
+          cwd: FRONTEND_ROOT,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      ).not.toThrow()
+    },
+    GENERATE_TIMEOUT,
+  )
+
+  it('record the sha256 of the contract they were generated from', () => {
+    const specHash = createHash('sha256').update(readFileSync(SPEC)).digest('hex')
+    const header = readFileSync(GENERATED, 'utf8').slice(0, 600)
+
+    expect(header).toContain('GENERATED FILE — DO NOT EDIT.')
+    expect(header).toContain(`sha256:    ${specHash}`)
+  })
+})

--- a/frontend/src/api/generated/contract.ts
+++ b/frontend/src/api/generated/contract.ts
@@ -1,0 +1,2650 @@
+/**
+ * GENERATED FILE — DO NOT EDIT.
+ *
+ * Produced from `api/openapi.yaml` by `npm run generate:contract`
+ * (openapi-typescript). Edit the contract, then regenerate.
+ *
+ * authority: api/openapi.yaml
+ * sha256:    dc6b2426da195c0b6f220a3226c8229f2f575142f5ff5315222e68fd670ce0ee
+ *
+ * `npm run check:contract` — also run by the Vitest suite — fails when this
+ * file no longer matches the authority above.
+ */
+export interface paths {
+    "/api/v1/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Ingest a single agent event
+         * @description Accepts exactly one event. The request body is a discriminated union over the closed
+         *     v0 event catalogue; the `type` field selects the concrete envelope schema and therefore
+         *     the concrete payload schema.
+         *
+         *     The endpoint is idempotent on `clientEventId` within a project:
+         *
+         *     * first delivery -> `201 Created`, `duplicate: false`
+         *     * byte-identical redelivery -> `200 OK`, `duplicate: true`, original `position`
+         *     * same `clientEventId` with different content -> `409 Conflict`
+         *
+         *     Requests larger than the configured limit (default 2 MiB / 2097152 bytes,
+         *     `MAX_EVENT_BYTES`) are rejected with `413`.
+         */
+        post: operations["ingestEvent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{projectId}/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream project events via Server-Sent Events
+         * @description Opens a Server-Sent Events stream for one project. The stream first replays every
+         *     committed event after the requested position and then continues seamlessly with live
+         *     events. Each committed event is delivered **exactly once, in position order, without
+         *     duplicates and without gaps**.
+         *
+         *     ## Choosing the start position
+         *
+         *     1. `Last-Event-ID` request header (the standard SSE reconnect path). It carries the
+         *        server-side project `position` of the last event the client processed.
+         *     2. `lastEventPosition` query parameter, for clients that persist the cursor themselves.
+         *     3. Neither given -> the stream starts with the live tail only, no replay.
+         *
+         *     If both are present, `lastEventPosition` wins. Replay starts at
+         *     `lastEventPosition + 1`.
+         *
+         *     ## Frame format
+         *
+         *     OpenAPI cannot describe SSE frames structurally, so the wire format is documented here.
+         *     The response schema describes the JSON object carried in a single `data:` line.
+         *
+         *     * `id:` — server-side project `position` (an integer). Browsers echo it back as
+         *       `Last-Event-ID` on reconnect.
+         *     * `event:` — the event `type` from the catalogue, so clients can subscribe per type.
+         *     * `data:` — one line of compact JSON, a `StreamedEvent`.
+         *     * Keepalives are sent as SSE comment lines (`: keepalive`) and carry no `id:`.
+         *
+         *     ```text
+         *     id: 41
+         *     event: agent.status_reported
+         *     data: {"schemaVersion":"1.0","clientEventId":"9a1f...","projectId":"visualise-ai","runId":"run-2026-08-04-0001","agentId":"subagent-openapi-contract","parentAgentId":"orchestrator-root","occurredAt":"2026-08-04T09:31:02Z","type":"agent.status_reported","payload":{"status":"working","note":"Writing the OpenAPI document."},"position":41,"serverEventId":"1d2c...","receivedAt":"2026-08-04T09:31:02.117Z"}
+         *
+         *     : keepalive
+         *
+         *     id: 42
+         *     event: diff.reported
+         *     data: {"schemaVersion":"1.0", ...}
+         *
+         *     ```
+         *
+         *     A full reconnect walkthrough is documented in
+         *     [`examples/sse-reconnect.md`](./examples/sse-reconnect.md).
+         */
+        get: operations["streamProjectEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List every known project
+         * @description Lists every project the backend has accepted an event for, ordered by `projectId`.
+         *
+         *     This is the only read endpoint that is not scoped to a single project, so its
+         *     `projectPosition` is the highest position across the listed projects. The value a
+         *     client needs for reconciling one project is repeated on every entry as `lastPosition`.
+         */
+        get: operations["listProjects"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{projectId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get one project with the sizes of its read models
+         * @description Returns the project head row together with the sizes of its read models, so the shell
+         *     can render its navigation without fetching every collection first.
+         *
+         *     `counts.activeChanges` counts pending proposals only — see the architecture endpoint.
+         */
+        get: operations["getProject"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{projectId}/architecture": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the applied architecture model and the pending proposals
+         * @description Returns the **applied** architecture model — every component and every relationship the
+         *     project currently has — plus the change proposals that are still pending.
+         *
+         *     The two are kept strictly apart:
+         *
+         *     * `components` and `relationships` are what `architecture.snapshot_published` and the
+         *       `*.change_applied` events produced. Every NATS topic keeps its own relationship; edges
+         *       are never aggregated server side.
+         *     * `activeChanges` holds the changes in state `planned`. An applied change *is* the model
+         *       and a retracted change was withdrawn, so neither is active any more. A planned change
+         *       never modifies `components` or `relationships`.
+         *
+         *     The component hierarchy is expressed exclusively through `parentComponentId`; the list
+         *     itself is flat and ordered by `componentId`, which makes the layout deterministic.
+         */
+        get: operations["getProjectArchitecture"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{projectId}/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List current and historical runs
+         * @description Lists the runs of one project, descending by reported start time. Current and
+         *     historical runs appear in the same list; `isOpen` and `isCurrent` distinguish them.
+         *
+         *     A run stays open until an explicit `run.finished` closes it — silence never produces a
+         *     terminal state, so an abandoned run keeps `isOpen: true` and its last reported values.
+         */
+        get: operations["listProjectRuns"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{projectId}/runs/{runId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get one run, or the current one
+         * @description Returns one run together with the sizes of the collections hanging off it.
+         *
+         *     The literal `current` resolves to the run a root orchestrator opened last. A project
+         *     that never saw a root orchestrator has no current run, which is reported as `404` with
+         *     the distinct code `current_run_not_found` — "no run yet" is not the same failure as
+         *     "this run id is wrong".
+         */
+        get: operations["getProjectRun"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{projectId}/runs/{runId}/agents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the agent tree of one run
+         * @description Returns every agent of one run as a **flat list**; the tree is expressed through
+         *     `parentAgentId`. A flat list keeps arbitrarily deep spawn chains renderable without the
+         *     server committing to a nesting depth.
+         *
+         *     Entries are ordered by start time, so a parent always precedes the subagents it
+         *     spawned and a consumer can build the tree in a single pass.
+         *
+         *     Reported values stay where they were reported: `status` is empty until the agent sent
+         *     `agent.status_reported`, `progress` is `null` until it reported a number itself, and
+         *     `finishedOutcome` is `null` until it sent `agent.finished`. Nothing is derived from
+         *     silence. `progress.scope` separates a subagent's own task from an orchestrator's
+         *     overall estimate.
+         */
+        get: operations["listRunAgents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{projectId}/runs/{runId}/plans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get every plan of one run with all of its revisions
+         * @description Returns every plan of one run together with **all** of its revisions and their steps.
+         *
+         *     Revisions are append-only: publishing a new revision never rewrites an earlier one, and
+         *     a `plan.step_updated` only reaches the revision that was current when it was reported.
+         *     An earlier revision therefore keeps exactly the step states it was last seen with,
+         *     which is what makes a plan change reviewable rather than invisible.
+         */
+        get: operations["listRunPlans"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{projectId}/components/{componentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the component inspector for one run
+         * @description Returns everything the inspector shows for one component: the applied descriptor, the
+         *     responsible agent, the current work step and the component scoped feedback, unified
+         *     diffs, risks, problems and pending proposals.
+         *
+         *     The response carries the evidence of **exactly one run** — the one named by `runId`, or
+         *     the current run when the parameter is omitted. Evidence of other runs is never mixed
+         *     in; the run spanning view is `…/history`.
+         *
+         *     `component` is `null` when the component left the applied model, for example after a
+         *     `remove` or a snapshot that no longer lists it. Its evidence and its history survive,
+         *     which is why that case is a body with `component: null` and not a `404`. A component
+         *     the project never mentioned at all is a `404`.
+         *
+         *     `responsibleAgent` is read from evidence rather than guessed: it is the agent of
+         *     `currentWorkStep`, or — when no work step named this component in this run — the agent
+         *     that applied the component in this run. Otherwise it is `null`.
+         *
+         *     Unified diffs are paged, because one component can accumulate more of them than a
+         *     single response should carry; every other collection is complete. See `diffLimit` and
+         *     `diffCursor`.
+         */
+        get: operations["getComponentInspector"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{projectId}/components/{componentId}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Page through everything ever reported about one component
+         * @description Returns every event that touched one component, **across all runs** of the project,
+         *     descending by project position. Each entry names the run it belongs to, so the UI can
+         *     separate the current run from older evidence without a second request.
+         *
+         *     Entries are the reported events as they were stored. Corrections and retractions appear
+         *     as their own entries: the log is append-only and nothing is ever overwritten, so a
+         *     withdrawn statement stays visible as history rather than disappearing.
+         *
+         *     The list is served from the component index the backend maintains for exactly this
+         *     purpose; it is not a scan over event payloads.
+         */
+        get: operations["getComponentHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Liveness probe (internal)
+         * @description Internal liveness probe of the Go backend container. It reports only that the process
+         *     is running and answering; it never touches PostgreSQL. Not routed through the Nginx
+         *     frontend and therefore not reachable from outside the Compose network.
+         */
+        get: operations["getLiveness"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/readyz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Readiness probe (internal)
+         * @description Internal readiness probe of the Go backend container. It reports whether the backend
+         *     can serve traffic, which includes a reachable PostgreSQL and applied migrations. Not
+         *     routed through the Nginx frontend.
+         */
+        get: operations["getReadiness"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        /**
+         * @description Stable, human-readable project slug. Lowercase alphanumerics and hyphens,
+         *     3 to 64 characters, must start and end with an alphanumeric character.
+         * @example visualise-ai
+         */
+        ProjectId: string;
+        /**
+         * @description Identifier of one agent run inside a project. Same character rules as `ProjectId`.
+         *     A run groups every agent, plan and work event of a single orchestrated session.
+         * @example run-2026-08-04-0001
+         */
+        RunId: string;
+        /**
+         * @description Identifier of the reporting agent, unique within a run. Same character rules as
+         *     `ProjectId`.
+         * @example subagent-openapi-contract
+         */
+        AgentId: string;
+        /**
+         * @description Identifier of an architecture component, stable across snapshots. Lowercase
+         *     alphanumerics plus `.`, `_` and `-`; must start and end with an alphanumeric
+         *     character. Dotted paths are a convention, not a hierarchy: the hierarchy is expressed
+         *     exclusively through `parentComponentId`.
+         * @example shop-platform.orders.domain
+         */
+        ComponentId: string;
+        /**
+         * @description Opaque, agent-assigned identifier for a domain object such as a plan, work step,
+         *     feedback item, diff, risk or relationship. Stable for the lifetime of the run.
+         * @example plan-2026-08-04-0001
+         */
+        Identifier: string;
+        /**
+         * Format: uuid
+         * @description RFC 4122 UUID.
+         * @example 3f2504e0-4f89-41d3-9a0c-0305e82c3301
+         */
+        Uuid: string;
+        /**
+         * Format: date-time
+         * @description RFC 3339 timestamp. Agents must report in UTC (`Z` suffix).
+         * @example 2026-08-04T09:12:00Z
+         */
+        Timestamp: string;
+        /**
+         * @description Version of the payload schema of the reported event type. v0 accepts `1.0` only; any
+         *     other value is rejected with `400` and code `unsupported_schema_version`.
+         * @enum {string}
+         */
+        SchemaVersion: "1.0";
+        /**
+         * @description Repository-relative POSIX path of exactly one file. Must not start with `/`, must not
+         *     contain a `.` or `..` path segment, must not contain backslashes and must not end with
+         *     a slash. Absolute paths and traversal are rejected by the pattern itself.
+         * @example internal/ingest/handler.go
+         */
+        RepositoryFilePath: string;
+        /**
+         * @description The closed v0 event catalogue. There is no free-form or fallback event type; anything
+         *     outside this enumeration is rejected with `400` and code `unsupported_event_type`.
+         *     Low-level tool, terminal and file-read events are intentionally absent.
+         * @enum {string}
+         */
+        EventType: "agent.started" | "agent.status_reported" | "agent.progress_reported" | "agent.finished" | "plan.published" | "plan.step_updated" | "work.step_started" | "work.step_completed" | "feedback.published" | "architecture.snapshot_published" | "component.change_planned" | "component.change_applied" | "relationship.change_planned" | "relationship.change_applied" | "diff.reported" | "risk.reported" | "problem.reported" | "correction.issued" | "retraction.issued" | "run.finished";
+        /**
+         * @description Kind of change applied to a component or relationship of the architecture model.
+         * @enum {string}
+         */
+        ChangeOperation: "add" | "modify" | "remove";
+        /**
+         * @description Terminal outcome reported by an agent or for a run.
+         * @enum {string}
+         */
+        Outcome: "completed" | "failed" | "cancelled";
+        /**
+         * @description Reported state of a single plan step.
+         * @enum {string}
+         */
+        PlanStepState: "pending" | "in_progress" | "done" | "skipped";
+        /**
+         * @description Technology metadata of a component. Every field is optional; agents report what they
+         *     know and omit the rest.
+         */
+        Technology: {
+            /** @description Primary implementation language, for example `Go` or `TypeScript`. */
+            language?: string;
+            /** @description Dominant framework or library, for example `React` or `chi`. */
+            framework?: string;
+            /** @description Execution runtime, for example `Node.js`, `JVM` or `PostgreSQL`. */
+            runtime?: string;
+            /** @description Version of the language, framework or runtime, as reported. */
+            version?: string;
+        };
+        /**
+         * @description One node of the application architecture. Components form a tree through
+         *     `parentComponentId`; the root of a tree has `parentComponentId: null`. Arbitrary
+         *     nesting depth is allowed, for example system -> service -> module -> module.
+         */
+        Component: {
+            componentId: components["schemas"]["ComponentId"];
+            /** @description Human-readable display name shown on the architecture canvas. */
+            name: string;
+            /**
+             * @description Structural role of the component. `topic` models a single message topic as its own
+             *     node so that topic-level relationships stay visible.
+             * @enum {string}
+             */
+            kind: "system" | "service" | "module" | "datastore" | "queue" | "topic" | "ui" | "external" | "library";
+            /**
+             * @description Parent node in the component hierarchy, or `null` for a root component. The value
+             *     must reference a `componentId` contained in the same architecture model.
+             */
+            parentComponentId: components["schemas"]["ComponentId"] | null;
+            /** @description Short explanation of the component's responsibility. */
+            description?: string;
+            technology?: components["schemas"]["Technology"];
+            /** @description Free-form labels for filtering and grouping on the canvas. */
+            tags?: string[];
+        };
+        /**
+         * @description A typed, directed edge between two components.
+         *
+         *     Message topics are never aggregated server-side: **every NATS topic is its own
+         *     relationship** with its own `relationshipId`, `kind: nats_topic` and the topic name in
+         *     `channel`. Two producers publishing to two topics therefore yield two relationships,
+         *     not one merged "messaging" edge.
+         */
+        Relationship: {
+            relationshipId: components["schemas"]["Identifier"];
+            sourceComponentId: components["schemas"]["ComponentId"];
+            targetComponentId: components["schemas"]["ComponentId"];
+            /**
+             * @description Interaction type of the edge. `nats_topic` denotes exactly one topic, named in
+             *     `channel`.
+             * @enum {string}
+             */
+            kind: "http" | "grpc" | "data" | "async" | "nats_topic" | "dependency";
+            /** @description Short human-readable edge label for the canvas. */
+            label?: string;
+            /** @description Concrete protocol, for example `HTTPS`, `gRPC/HTTP2` or `postgresql`. */
+            protocol?: string;
+            /**
+             * @description Concrete operation carried by the edge, for example `GET /orders` or
+             *     `orders.v1.OrderService/PlaceOrder`.
+             */
+            operation?: string;
+            /**
+             * @description Channel name for message-based edges. For `kind: nats_topic` this is the NATS
+             *     topic name and identifies the relationship semantically.
+             */
+            channel?: string;
+        };
+        /** @description One step of a published plan revision. */
+        PlanStep: {
+            stepId: components["schemas"]["Identifier"];
+            /** @description Zero-based position of the step within the plan revision. */
+            order: number;
+            /** @description Short description of what the step achieves. */
+            title: string;
+            state: components["schemas"]["PlanStepState"];
+            /** @description Architecture components the step touches. */
+            componentIds?: components["schemas"]["ComponentId"][];
+        };
+        /**
+         * @description An agent has begun working. Root orchestrators report `role: orchestrator` and send
+         *     `parentAgentId: null`; subagents report `role: subagent` and set `parentAgentId`.
+         */
+        AgentStartedPayload: {
+            /**
+             * @description Position of the agent in the run hierarchy.
+             * @enum {string}
+             */
+            role: "orchestrator" | "subagent";
+            /** @description Name shown for this agent in the cockpit. */
+            displayName: string;
+            /** @description The task the agent was given, in the agent's own words. */
+            assignedTask: string;
+            /** @description Self-declared capabilities, used for grouping and filtering only. */
+            capabilities?: string[];
+        };
+        /**
+         * @description Explicitly reported agent status. The system never derives status from silence,
+         *     timeouts or event frequency; the last reported status stays valid until the agent
+         *     reports a new one.
+         */
+        AgentStatusReportedPayload: {
+            /**
+             * @description Status as stated by the agent itself.
+             * @enum {string}
+             */
+            status: "working" | "waiting" | "blocked" | "idle" | "done";
+            /** @description Optional one-line explanation, for example what the agent waits for. */
+            note?: string;
+        };
+        /**
+         * @description Self-assessed progress of the reporting agent. This is a claim, not a measurement; the
+         *     cockpit displays it as reported and performs no plausibility check.
+         */
+        AgentProgressReportedPayload: {
+            /** @description Reported completion in percent. */
+            percent: number;
+            /**
+             * @description What the percentage refers to: the agent's own assigned task, or the agent's
+             *     estimate for the overall run.
+             * @enum {string}
+             */
+            scope: "own_task" | "overall_estimate";
+            /**
+             * @description How the number was derived: a free estimate by the agent, or the ratio of completed
+             *     plan or work steps.
+             * @enum {string}
+             */
+            basis: "reported_estimate" | "completed_steps";
+            /** @description Optional explanation of the reported number. */
+            note?: string;
+        };
+        /** @description The reporting agent has finished. Terminal for this agent, not for the run. */
+        AgentFinishedPayload: {
+            outcome: components["schemas"]["Outcome"];
+            /** @description Short closing summary of what the agent achieved. */
+            summary?: string;
+        };
+        /**
+         * @description A complete plan revision. Revisions are append-only: a changed plan is published as a
+         *     new `revision` of the same `planId` and replaces the previously displayed revision.
+         *     Earlier revisions stay in the event log and remain inspectable.
+         */
+        PlanPublishedPayload: {
+            planId: components["schemas"]["Identifier"];
+            /** @description Revision number, starting at 1 and strictly increasing per `planId`. */
+            revision: number;
+            /** @description All steps of this revision, in full. Partial plans are not supported. */
+            steps: components["schemas"]["PlanStep"][];
+        };
+        /**
+         * @description State change of a single step of the currently published plan revision. Used instead of
+         *     republishing the whole plan when only a step state changes.
+         */
+        PlanStepUpdatedPayload: {
+            planId: components["schemas"]["Identifier"];
+            stepId: components["schemas"]["Identifier"];
+            state: components["schemas"]["PlanStepState"];
+            /** @description Optional explanation of the state change. */
+            note?: string;
+        };
+        /**
+         * @description The agent has started a concrete unit of work. A work step is what actually happens;
+         *     `planStepId` links it back to the plan when the work follows a planned step.
+         */
+        WorkStepStartedPayload: {
+            workStepId: components["schemas"]["Identifier"];
+            /** @description Short description of the work being started. */
+            title: string;
+            /** @description Architecture components affected by this work step. */
+            componentIds: components["schemas"]["ComponentId"][];
+            planStepId?: components["schemas"]["Identifier"];
+        };
+        /** @description The work step identified by `workStepId` has been completed. */
+        WorkStepCompletedPayload: {
+            workStepId: components["schemas"]["Identifier"];
+            /** @description Short summary of the result. */
+            summary?: string;
+        };
+        /**
+         * @description Component-scoped feedback written by the agent. v0 supports markdown only; the body is
+         *     rendered as untrusted markdown in the inspector.
+         */
+        FeedbackPublishedPayload: {
+            feedbackId: components["schemas"]["Identifier"];
+            /** @description Components the feedback refers to. At least one is required. */
+            componentIds: components["schemas"]["ComponentId"][];
+            /**
+             * @description Body format. v0 accepts markdown only.
+             * @enum {string}
+             */
+            format: "markdown";
+            /** @description The feedback text. */
+            body: string;
+            /** @description Optional short headline. */
+            title?: string;
+        };
+        /**
+         * @description A complete architecture model. The snapshot **replaces the applied model entirely**:
+         *     components and relationships not contained in the snapshot no longer exist in the
+         *     current model. Use it for the initial model and for full re-syncs; use
+         *     `component.change_*` and `relationship.change_*` for incremental updates.
+         */
+        ArchitectureSnapshotPublishedPayload: {
+            snapshotId: components["schemas"]["Identifier"];
+            /** @description All components of the model, including nested children. */
+            components: components["schemas"]["Component"][];
+            /** @description All relationships of the model. One entry per NATS topic. */
+            relationships: components["schemas"]["Relationship"][];
+        };
+        /**
+         * @description The agent intends to change a component. Planned changes are shown as proposals and do
+         *     not modify the applied architecture model.
+         */
+        ComponentChangePlannedPayload: {
+            changeId: components["schemas"]["Identifier"];
+            operation: components["schemas"]["ChangeOperation"];
+            component: components["schemas"]["Component"];
+            /** @description Why the change is planned. */
+            rationale?: string;
+        };
+        /**
+         * @description A component change has been carried out and is merged into the applied architecture
+         *     model. `changeId` references the corresponding `component.change_planned` event when
+         *     the change was planned beforehand; unplanned changes omit it.
+         */
+        ComponentChangeAppliedPayload: {
+            changeId?: components["schemas"]["Identifier"];
+            operation: components["schemas"]["ChangeOperation"];
+            component: components["schemas"]["Component"];
+        };
+        /**
+         * @description The agent intends to change a relationship. Planned changes are shown as proposals and
+         *     do not modify the applied architecture model.
+         */
+        RelationshipChangePlannedPayload: {
+            changeId: components["schemas"]["Identifier"];
+            operation: components["schemas"]["ChangeOperation"];
+            relationship: components["schemas"]["Relationship"];
+            /** @description Why the change is planned. */
+            rationale?: string;
+        };
+        /**
+         * @description A relationship change has been carried out and is merged into the applied architecture
+         *     model. `changeId` references the corresponding `relationship.change_planned` event when
+         *     the change was planned beforehand.
+         */
+        RelationshipChangeAppliedPayload: {
+            changeId?: components["schemas"]["Identifier"];
+            operation: components["schemas"]["ChangeOperation"];
+            relationship: components["schemas"]["Relationship"];
+        };
+        /**
+         * @description A unified diff for **exactly one repository file**. Multi-file changes are reported as
+         *     one `diff.reported` event per file, each with its own `diffId`. The backend never
+         *     splits or merges diffs, and v0 has no repository access: `unifiedDiff` is taken as
+         *     reported.
+         */
+        DiffReportedPayload: {
+            diffId: components["schemas"]["Identifier"];
+            changeId?: components["schemas"]["Identifier"];
+            /** @description Components the changed file belongs to. At least one is required. */
+            componentIds: components["schemas"]["ComponentId"][];
+            filePath: components["schemas"]["RepositoryFilePath"];
+            /** @description Unified diff of this one file, including the `---`, `+++` and `@@` markers. */
+            unifiedDiff: string;
+        };
+        /**
+         * @description A risk **as reported by the agent**. This is an agent statement, not a quality or drift
+         *     assessment produced by the system. The cockpit displays it verbatim and never derives,
+         *     scores or aggregates risks on its own; the human reviewer judges it.
+         */
+        RiskReportedPayload: {
+            riskId: components["schemas"]["Identifier"];
+            /** @description Components the risk applies to. */
+            componentIds: components["schemas"]["ComponentId"][];
+            /** @description Short headline of the risk. */
+            title: string;
+            /** @description Longer explanation of the risk. */
+            detail?: string;
+            /**
+             * @description Severity as assessed by the reporting agent.
+             * @enum {string}
+             */
+            severity: "low" | "medium" | "high";
+        };
+        /**
+         * @description A concrete problem the agent has run into, as reported by the agent. Like
+         *     `risk.reported`, this is an agent statement and never a system-side evaluation.
+         */
+        ProblemReportedPayload: {
+            problemId: components["schemas"]["Identifier"];
+            /** @description Components the problem applies to. */
+            componentIds: components["schemas"]["ComponentId"][];
+            /** @description Short headline of the problem. */
+            title: string;
+            /** @description Longer explanation of the problem. */
+            detail?: string;
+        };
+        /**
+         * @description Corrects the content of a previously accepted event. The event log stays append-only:
+         *     the original event is never mutated, the correction is appended and the cockpit renders
+         *     the corrected content while keeping the original inspectable.
+         */
+        CorrectionIssuedPayload: {
+            correctsClientEventId: components["schemas"]["Uuid"];
+            /** @description Why the original event was wrong. */
+            reason: string;
+            correctedType: components["schemas"]["EventType"];
+            /**
+             * @description Payload of the corrected event, valid for the corrected event type. It must satisfy
+             *     the payload schema selected by `correctedType`.
+             */
+            correctedPayload: Record<string, unknown>;
+        };
+        /**
+         * @description Withdraws a previously accepted event without replacing it. The original event is kept
+         *     in the log and marked as retracted in the cockpit.
+         */
+        RetractionIssuedPayload: {
+            retractsClientEventId: components["schemas"]["Uuid"];
+            /** @description Why the original event is withdrawn. */
+            reason: string;
+        };
+        /**
+         * @description Optional terminal event for the whole run, reported by the orchestrator only.
+         *
+         *     * It is optional. A run may simply stop emitting events.
+         *     * No state is derived from silence: without `run.finished` the run keeps its last
+         *       reported state and is never auto-completed or auto-failed.
+         *     * After `run.finished`, further work events of that run are rejected with `422` and
+         *       code `run_already_finished`.
+         */
+        RunFinishedPayload: {
+            outcome: components["schemas"]["Outcome"];
+            /** @description Closing summary of the run. */
+            summary?: string;
+        };
+        /**
+         * @description Common envelope of every event. It is a base schema only: the concrete event schemas
+         *     below narrow `type` to a single value and `payload` to the matching payload schema.
+         *     `additionalProperties: false` closes the envelope, so unknown top-level fields are
+         *     rejected for every event type.
+         */
+        EventEnvelope: {
+            schemaVersion: components["schemas"]["SchemaVersion"];
+            /**
+             * @description Agent-assigned idempotency key, unique per project. Retries must reuse the same
+             *     value; distinct events must never share one.
+             */
+            clientEventId: components["schemas"]["Uuid"];
+            projectId: components["schemas"]["ProjectId"];
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /**
+             * @description The delegating agent. Set for subagents, `null` (or omitted) for the root
+             *     orchestrator. The value must reference an agent that already reported
+             *     `agent.started` in the same run, otherwise the event is rejected with `422` and
+             *     code `parent_agent_unknown`.
+             */
+            parentAgentId?: components["schemas"]["AgentId"] | null;
+            /**
+             * @description When the reported step happened, as observed by the agent. Independent of the
+             *     server-side `receivedAt`.
+             */
+            occurredAt: components["schemas"]["Timestamp"];
+            type: components["schemas"]["EventType"];
+            /**
+             * @description Type-specific payload. The effective schema is fixed by `type`; see the concrete
+             *     event schemas.
+             */
+            payload: Record<string, unknown>;
+        };
+        /** @description An agent started working. */
+        AgentStartedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "agent.started";
+            payload?: components["schemas"]["AgentStartedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "agent.started";
+        };
+        /** @description An agent explicitly reported its status. */
+        AgentStatusReportedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "agent.status_reported";
+            payload?: components["schemas"]["AgentStatusReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "agent.status_reported";
+        };
+        /** @description An agent reported self-assessed progress. */
+        AgentProgressReportedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "agent.progress_reported";
+            payload?: components["schemas"]["AgentProgressReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "agent.progress_reported";
+        };
+        /** @description An agent finished its assigned task. */
+        AgentFinishedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "agent.finished";
+            payload?: components["schemas"]["AgentFinishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "agent.finished";
+        };
+        /** @description A plan revision was published. */
+        PlanPublishedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "plan.published";
+            payload?: components["schemas"]["PlanPublishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "plan.published";
+        };
+        /** @description The state of a single plan step changed. */
+        PlanStepUpdatedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "plan.step_updated";
+            payload?: components["schemas"]["PlanStepUpdatedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "plan.step_updated";
+        };
+        /** @description A concrete work step started. */
+        WorkStepStartedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "work.step_started";
+            payload?: components["schemas"]["WorkStepStartedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "work.step_started";
+        };
+        /** @description A concrete work step completed. */
+        WorkStepCompletedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "work.step_completed";
+            payload?: components["schemas"]["WorkStepCompletedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "work.step_completed";
+        };
+        /** @description Component-scoped markdown feedback was published. */
+        FeedbackPublishedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "feedback.published";
+            payload?: components["schemas"]["FeedbackPublishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "feedback.published";
+        };
+        /** @description A complete architecture model was published and replaces the applied model. */
+        ArchitectureSnapshotPublishedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "architecture.snapshot_published";
+            payload?: components["schemas"]["ArchitectureSnapshotPublishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "architecture.snapshot_published";
+        };
+        /** @description A component change was planned. */
+        ComponentChangePlannedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "component.change_planned";
+            payload?: components["schemas"]["ComponentChangePlannedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "component.change_planned";
+        };
+        /** @description A component change was applied. */
+        ComponentChangeAppliedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "component.change_applied";
+            payload?: components["schemas"]["ComponentChangeAppliedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "component.change_applied";
+        };
+        /** @description A relationship change was planned. */
+        RelationshipChangePlannedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "relationship.change_planned";
+            payload?: components["schemas"]["RelationshipChangePlannedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "relationship.change_planned";
+        };
+        /** @description A relationship change was applied. */
+        RelationshipChangeAppliedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "relationship.change_applied";
+            payload?: components["schemas"]["RelationshipChangeAppliedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "relationship.change_applied";
+        };
+        /** @description A unified diff for exactly one repository file was reported. */
+        DiffReportedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "diff.reported";
+            payload?: components["schemas"]["DiffReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "diff.reported";
+        };
+        /** @description The agent reported a risk. */
+        RiskReportedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "risk.reported";
+            payload?: components["schemas"]["RiskReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "risk.reported";
+        };
+        /** @description The agent reported a problem. */
+        ProblemReportedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "problem.reported";
+            payload?: components["schemas"]["ProblemReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "problem.reported";
+        };
+        /** @description A previously accepted event was corrected. */
+        CorrectionIssuedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "correction.issued";
+            payload?: components["schemas"]["CorrectionIssuedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "correction.issued";
+        };
+        /** @description A previously accepted event was retracted. */
+        RetractionIssuedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "retraction.issued";
+            payload?: components["schemas"]["RetractionIssuedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "retraction.issued";
+        };
+        /** @description Optional terminal event of the run, orchestrator only. */
+        RunFinishedEvent: components["schemas"]["EventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "run.finished";
+            payload?: components["schemas"]["RunFinishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "run.finished";
+        };
+        /**
+         * @description The closed union of all v0 events. `type` acts as the discriminator and selects exactly
+         *     one envelope schema, which in turn fixes the payload schema. A body whose `type` is not
+         *     in the mapping cannot match any branch and is rejected.
+         */
+        IngestEventRequest: components["schemas"]["AgentStartedEvent"] | components["schemas"]["AgentStatusReportedEvent"] | components["schemas"]["AgentProgressReportedEvent"] | components["schemas"]["AgentFinishedEvent"] | components["schemas"]["PlanPublishedEvent"] | components["schemas"]["PlanStepUpdatedEvent"] | components["schemas"]["WorkStepStartedEvent"] | components["schemas"]["WorkStepCompletedEvent"] | components["schemas"]["FeedbackPublishedEvent"] | components["schemas"]["ArchitectureSnapshotPublishedEvent"] | components["schemas"]["ComponentChangePlannedEvent"] | components["schemas"]["ComponentChangeAppliedEvent"] | components["schemas"]["RelationshipChangePlannedEvent"] | components["schemas"]["RelationshipChangeAppliedEvent"] | components["schemas"]["DiffReportedEvent"] | components["schemas"]["RiskReportedEvent"] | components["schemas"]["ProblemReportedEvent"] | components["schemas"]["CorrectionIssuedEvent"] | components["schemas"]["RetractionIssuedEvent"] | components["schemas"]["RunFinishedEvent"];
+        /**
+         * @description Envelope of a streamed event: the ingested envelope plus the server-assigned metadata
+         *     `position`, `serverEventId` and `receivedAt`. Base schema only; the concrete streamed
+         *     event schemas narrow `type` and `payload`.
+         */
+        StreamedEventEnvelope: {
+            schemaVersion: components["schemas"]["SchemaVersion"];
+            /** @description Idempotency key as reported by the agent. */
+            clientEventId: components["schemas"]["Uuid"];
+            projectId: components["schemas"]["ProjectId"];
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /** @description The delegating agent, or `null` for the root orchestrator. */
+            parentAgentId?: components["schemas"]["AgentId"] | null;
+            /** @description When the reported step happened, as observed by the agent. */
+            occurredAt: components["schemas"]["Timestamp"];
+            type: components["schemas"]["EventType"];
+            /** @description Type-specific payload, fixed by `type`. */
+            payload: Record<string, unknown>;
+            /**
+             * Format: int64
+             * @description Server-assigned, strictly increasing position of the event within the project. This
+             *     is the value sent as the SSE `id:` field and the cursor for replay.
+             */
+            position: number;
+            /** @description Server-assigned identity of the stored event. */
+            serverEventId: components["schemas"]["Uuid"];
+            /** @description When the backend accepted and committed the event. */
+            receivedAt: components["schemas"]["Timestamp"];
+        };
+        /** @description Streamed `agent.started` event. */
+        StreamedAgentStartedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "agent.started";
+            payload?: components["schemas"]["AgentStartedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "agent.started";
+        };
+        /** @description Streamed `agent.status_reported` event. */
+        StreamedAgentStatusReportedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "agent.status_reported";
+            payload?: components["schemas"]["AgentStatusReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "agent.status_reported";
+        };
+        /** @description Streamed `agent.progress_reported` event. */
+        StreamedAgentProgressReportedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "agent.progress_reported";
+            payload?: components["schemas"]["AgentProgressReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "agent.progress_reported";
+        };
+        /** @description Streamed `agent.finished` event. */
+        StreamedAgentFinishedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "agent.finished";
+            payload?: components["schemas"]["AgentFinishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "agent.finished";
+        };
+        /** @description Streamed `plan.published` event. */
+        StreamedPlanPublishedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "plan.published";
+            payload?: components["schemas"]["PlanPublishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "plan.published";
+        };
+        /** @description Streamed `plan.step_updated` event. */
+        StreamedPlanStepUpdatedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "plan.step_updated";
+            payload?: components["schemas"]["PlanStepUpdatedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "plan.step_updated";
+        };
+        /** @description Streamed `work.step_started` event. */
+        StreamedWorkStepStartedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "work.step_started";
+            payload?: components["schemas"]["WorkStepStartedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "work.step_started";
+        };
+        /** @description Streamed `work.step_completed` event. */
+        StreamedWorkStepCompletedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "work.step_completed";
+            payload?: components["schemas"]["WorkStepCompletedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "work.step_completed";
+        };
+        /** @description Streamed `feedback.published` event. */
+        StreamedFeedbackPublishedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "feedback.published";
+            payload?: components["schemas"]["FeedbackPublishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "feedback.published";
+        };
+        /** @description Streamed `architecture.snapshot_published` event. */
+        StreamedArchitectureSnapshotPublishedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "architecture.snapshot_published";
+            payload?: components["schemas"]["ArchitectureSnapshotPublishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "architecture.snapshot_published";
+        };
+        /** @description Streamed `component.change_planned` event. */
+        StreamedComponentChangePlannedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "component.change_planned";
+            payload?: components["schemas"]["ComponentChangePlannedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "component.change_planned";
+        };
+        /** @description Streamed `component.change_applied` event. */
+        StreamedComponentChangeAppliedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "component.change_applied";
+            payload?: components["schemas"]["ComponentChangeAppliedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "component.change_applied";
+        };
+        /** @description Streamed `relationship.change_planned` event. */
+        StreamedRelationshipChangePlannedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "relationship.change_planned";
+            payload?: components["schemas"]["RelationshipChangePlannedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "relationship.change_planned";
+        };
+        /** @description Streamed `relationship.change_applied` event. */
+        StreamedRelationshipChangeAppliedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "relationship.change_applied";
+            payload?: components["schemas"]["RelationshipChangeAppliedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "relationship.change_applied";
+        };
+        /** @description Streamed `diff.reported` event. */
+        StreamedDiffReportedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "diff.reported";
+            payload?: components["schemas"]["DiffReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "diff.reported";
+        };
+        /** @description Streamed `risk.reported` event. */
+        StreamedRiskReportedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "risk.reported";
+            payload?: components["schemas"]["RiskReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "risk.reported";
+        };
+        /** @description Streamed `problem.reported` event. */
+        StreamedProblemReportedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "problem.reported";
+            payload?: components["schemas"]["ProblemReportedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "problem.reported";
+        };
+        /** @description Streamed `correction.issued` event. */
+        StreamedCorrectionIssuedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "correction.issued";
+            payload?: components["schemas"]["CorrectionIssuedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "correction.issued";
+        };
+        /** @description Streamed `retraction.issued` event. */
+        StreamedRetractionIssuedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "retraction.issued";
+            payload?: components["schemas"]["RetractionIssuedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "retraction.issued";
+        };
+        /** @description Streamed `run.finished` event. */
+        StreamedRunFinishedEvent: components["schemas"]["StreamedEventEnvelope"] & {
+            /** @enum {unknown} */
+            type?: "run.finished";
+            payload?: components["schemas"]["RunFinishedPayload"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "run.finished";
+        };
+        /**
+         * @description JSON object carried in a single SSE `data:` line. Same closed union as ingestion, plus
+         *     the server-assigned `position`, `serverEventId` and `receivedAt`. The SSE `event:`
+         *     field always equals the `type` of the object.
+         */
+        StreamedEvent: components["schemas"]["StreamedAgentStartedEvent"] | components["schemas"]["StreamedAgentStatusReportedEvent"] | components["schemas"]["StreamedAgentProgressReportedEvent"] | components["schemas"]["StreamedAgentFinishedEvent"] | components["schemas"]["StreamedPlanPublishedEvent"] | components["schemas"]["StreamedPlanStepUpdatedEvent"] | components["schemas"]["StreamedWorkStepStartedEvent"] | components["schemas"]["StreamedWorkStepCompletedEvent"] | components["schemas"]["StreamedFeedbackPublishedEvent"] | components["schemas"]["StreamedArchitectureSnapshotPublishedEvent"] | components["schemas"]["StreamedComponentChangePlannedEvent"] | components["schemas"]["StreamedComponentChangeAppliedEvent"] | components["schemas"]["StreamedRelationshipChangePlannedEvent"] | components["schemas"]["StreamedRelationshipChangeAppliedEvent"] | components["schemas"]["StreamedDiffReportedEvent"] | components["schemas"]["StreamedRiskReportedEvent"] | components["schemas"]["StreamedProblemReportedEvent"] | components["schemas"]["StreamedCorrectionIssuedEvent"] | components["schemas"]["StreamedRetractionIssuedEvent"] | components["schemas"]["StreamedRunFinishedEvent"];
+        /**
+         * @description Acknowledgement of an ingested event. Returned with `201` for a first delivery and with
+         *     `200` for an idempotent retry, in which case the originally assigned `position` and
+         *     `serverEventId` are repeated unchanged.
+         */
+        EventAccepted: {
+            projectId: components["schemas"]["ProjectId"];
+            /**
+             * Format: int64
+             * @description Server-assigned, strictly increasing position of the event within the project.
+             */
+            position: number;
+            /** @description Server-assigned identity of the stored event. */
+            serverEventId: components["schemas"]["Uuid"];
+            /** @description The idempotency key echoed back from the request. */
+            clientEventId: components["schemas"]["Uuid"];
+            /** @description `false` for a newly appended event (`201`), `true` for an idempotent retry (`200`). */
+            duplicate: boolean;
+            /** @description When the backend accepted and committed the event. */
+            receivedAt: components["schemas"]["Timestamp"];
+        };
+        /**
+         * @description Error object following RFC 9457, served as `application/problem+json`. `code` is the
+         *     stable, machine-readable discriminator that clients should branch on; `type`, `title`
+         *     and `detail` are for humans.
+         */
+        Problem: {
+            /**
+             * Format: uri
+             * @description URI identifying the problem type.
+             */
+            type: string;
+            /** @description Short, human-readable summary of the problem type. */
+            title: string;
+            /** @description HTTP status code, repeated for convenience. */
+            status: number;
+            /** @description Human-readable explanation specific to this occurrence. */
+            detail: string;
+            /**
+             * @description Stable machine-readable error code, for example `invalid_field`,
+             *     `unsupported_event_type`, `unsupported_schema_version`,
+             *     `client_event_id_conflict`, `event_too_large`, `unsupported_media_type`,
+             *     `unknown_agent`, `run_already_finished`, `run_not_started`,
+             *     `run_already_started`, `parent_agent_unknown`, `terminal_event_not_allowed`,
+             *     `correction_target_unknown`, `project_not_found`, `run_not_found`,
+             *     `current_run_not_found`, `component_not_found`, `invalid_query_parameter` or
+             *     `not_ready`.
+             */
+            code: string;
+            /**
+             * Format: uri-reference
+             * @description URI reference identifying this specific occurrence.
+             */
+            instance?: string;
+        };
+        /** @description One field-level violation inside a `ValidationProblem`. */
+        ValidationError: {
+            /**
+             * @description RFC 6901 JSON Pointer into the rejected request body, for example
+             *     `/payload/percent`. Read requests have no body, so there the pointer names the
+             *     rejected query parameter, for example `/limit`.
+             */
+            field: string;
+            /**
+             * @description Machine-readable violation code, for example `required`, `out_of_range`,
+             *     `pattern_mismatch`, `unknown_property` or `invalid_format`.
+             */
+            code: string;
+            /** @description Human-readable explanation of this single violation. */
+            message: string;
+        };
+        /**
+         * @description RFC 9457 problem extended with structured field errors. Returned for `400` responses
+         *     with codes `invalid_field`, `unsupported_event_type` or `unsupported_schema_version`.
+         */
+        ValidationProblem: {
+            /**
+             * Format: uri
+             * @description URI identifying the problem type.
+             */
+            type: string;
+            /** @description Short, human-readable summary of the problem type. */
+            title: string;
+            /** @description HTTP status code, repeated for convenience. */
+            status: number;
+            /** @description Human-readable explanation specific to this occurrence. */
+            detail: string;
+            /**
+             * @description Stable machine-readable error code: `invalid_field`, `unsupported_event_type` or
+             *     `unsupported_schema_version`.
+             */
+            code: string;
+            /**
+             * Format: uri-reference
+             * @description URI reference identifying this specific occurrence.
+             */
+            instance?: string;
+            /** @description All detected field-level violations, never empty. */
+            errors: components["schemas"]["ValidationError"][];
+        };
+        /**
+         * Format: int64
+         * @description Server side project position at the moment the snapshot was read. It is the position of
+         *     the last event committed for the project, so a client can compare an HTTP snapshot with
+         *     its SSE cursor and know exactly which events it still has to apply. `0` means nothing
+         *     has been reported yet.
+         * @example 17
+         */
+        ProjectPosition: number;
+        /**
+         * Format: int64
+         * @description Project position of the event that last wrote this row. It lets the UI reconcile a
+         *     single node when a live event arrives instead of refetching the whole snapshot.
+         * @example 11
+         */
+        AppliedPosition: number;
+        /**
+         * @description Opaque continuation token. It encodes the sort key of the last returned entry; clients
+         *     echo it back unchanged and must not parse it.
+         * @example djF8MTY
+         */
+        Cursor: string;
+        /** @description One project as shown in the project list. */
+        ProjectSummary: {
+            projectId: components["schemas"]["ProjectId"];
+            /** @description When the first accepted event of this project was reported. */
+            firstSeenAt: components["schemas"]["Timestamp"];
+            /** @description When the most recent accepted event of this project was reported. */
+            lastEventAt: components["schemas"]["Timestamp"];
+            lastPosition: components["schemas"]["ProjectPosition"];
+            /**
+             * @description The run a root orchestrator opened last, or `null` while no root orchestrator has
+             *     opened one.
+             */
+            currentRunId: components["schemas"]["RunId"] | null;
+        };
+        /** @description Sizes of the read models of one project. */
+        ProjectCounts: {
+            /** @description Runs of this project, current and historical. */
+            runs: number;
+            /** @description Runs without an explicit `run.finished`. */
+            openRuns: number;
+            /** @description Components of the applied architecture model. */
+            components: number;
+            /** @description Relationships of the applied architecture model. */
+            relationships: number;
+            /** @description Pending change proposals, that is changes in state `planned`. */
+            activeChanges: number;
+        };
+        /** @description One project together with the sizes of its read models. */
+        ProjectDetail: {
+            projectId: components["schemas"]["ProjectId"];
+            /** @description When the first accepted event of this project was reported. */
+            firstSeenAt: components["schemas"]["Timestamp"];
+            /** @description When the most recent accepted event of this project was reported. */
+            lastEventAt: components["schemas"]["Timestamp"];
+            lastPosition: components["schemas"]["ProjectPosition"];
+            /** @description The run a root orchestrator opened last, or `null`. */
+            currentRunId: components["schemas"]["RunId"] | null;
+            counts: components["schemas"]["ProjectCounts"];
+        };
+        /**
+         * @description Body of `GET /api/v1/projects`. Not scoped to one project, so `projectPosition` is the
+         *     highest position across the listed projects.
+         */
+        ProjectListResponse: {
+            projectPosition: components["schemas"]["ProjectPosition"];
+            /** @description Every known project, ordered by `projectId`. */
+            projects: components["schemas"]["ProjectSummary"][];
+        };
+        /** @description Body of `GET /api/v1/projects/{projectId}`. */
+        ProjectResponse: {
+            projectPosition: components["schemas"]["ProjectPosition"];
+            project: components["schemas"]["ProjectDetail"];
+        };
+        /**
+         * @description One node of the applied architecture model. `parentComponentId` is the only expression
+         *     of the hierarchy; the list itself is flat.
+         */
+        AppliedComponent: {
+            componentId: components["schemas"]["ComponentId"];
+            /** @description Human-readable display name shown on the architecture canvas. */
+            name: string;
+            /**
+             * @description Structural role of the component, as reported.
+             * @enum {string}
+             */
+            kind: "system" | "service" | "module" | "datastore" | "queue" | "topic" | "ui" | "external" | "library";
+            /** @description Parent node in the component hierarchy, or `null` for a root component. */
+            parentComponentId: components["schemas"]["ComponentId"] | null;
+            /** @description Short explanation of the component's responsibility, empty when none was reported. */
+            description: string;
+            /**
+             * @description Reported technology metadata, handed through unchanged. An empty object means the
+             *     agent reported none.
+             */
+            technology: components["schemas"]["Technology"];
+            /** @description Reported free-form labels, empty when none were reported. */
+            tags: string[];
+            /** @description When the event that last wrote this component was reported. */
+            appliedAt: components["schemas"]["Timestamp"];
+            appliedByAgentId: components["schemas"]["AgentId"];
+            appliedRunId: components["schemas"]["RunId"];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /**
+         * @description One typed, directed edge of the applied model. Every NATS topic keeps its own row with
+         *     the topic name in `channel`; edges are never aggregated server side.
+         */
+        AppliedRelationship: {
+            relationshipId: components["schemas"]["Identifier"];
+            sourceComponentId: components["schemas"]["ComponentId"];
+            targetComponentId: components["schemas"]["ComponentId"];
+            /**
+             * @description Interaction type of the edge, as reported.
+             * @enum {string}
+             */
+            kind: "http" | "grpc" | "data" | "async" | "nats_topic" | "dependency";
+            /** @description Reported edge label, empty when none was reported. */
+            label: string;
+            /** @description Reported protocol, empty when none was reported. */
+            protocol: string;
+            /** @description Reported operation, empty when none was reported. */
+            operation: string;
+            /**
+             * @description Reported channel. For `kind: nats_topic` this is the topic name and identifies the
+             *     relationship semantically. Empty when none was reported.
+             */
+            channel: string;
+            /** @description When the event that last wrote this relationship was reported. */
+            appliedAt: components["schemas"]["Timestamp"];
+            appliedByAgentId: components["schemas"]["AgentId"];
+            appliedRunId: components["schemas"]["RunId"];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /**
+         * @description A pending change proposal, that is a reported change that is still in state `planned`.
+         *     `snapshot` carries the reported component or relationship descriptor verbatim, so the
+         *     canvas can draw the proposal next to the applied model without a second lookup.
+         */
+        ActiveChange: {
+            changeId: components["schemas"]["Identifier"];
+            /**
+             * @description What the change is about.
+             * @enum {string}
+             */
+            targetKind: "component" | "relationship";
+            /** @description Identifier of the component or relationship the change targets. */
+            targetId: string;
+            operation: components["schemas"]["ChangeOperation"];
+            /**
+             * @description Lifecycle state of the change. The read endpoints only return `planned`; `applied`
+             *     has become the model and `retracted` was withdrawn.
+             * @enum {string}
+             */
+            state: "planned" | "applied" | "retracted";
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /** @description When the change was announced, or `null` when it was never planned. */
+            plannedAt: components["schemas"]["Timestamp"] | null;
+            /** @description When the change was applied, `null` while it is pending. */
+            appliedAt: components["schemas"]["Timestamp"] | null;
+            /** @description When the change was withdrawn, `null` while it stands. */
+            retractedAt: components["schemas"]["Timestamp"] | null;
+            /**
+             * @description The reported descriptor of the proposal — a `Component` or a `Relationship`
+             *     document, selected by `targetKind` — stored and returned as reported.
+             */
+            snapshot: Record<string, unknown>;
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /**
+         * @description Body of `GET /api/v1/projects/{projectId}/architecture`: the applied model plus the
+         *     proposals that are still pending. A planned change never appears in `components` or
+         *     `relationships`.
+         */
+        ArchitectureResponse: {
+            projectPosition: components["schemas"]["ProjectPosition"];
+            /** @description Every component of the applied model, ordered by `componentId`. */
+            components: components["schemas"]["AppliedComponent"][];
+            /** @description Every relationship of the applied model, ordered by `relationshipId`. */
+            relationships: components["schemas"]["AppliedRelationship"][];
+            /** @description Pending proposals, newest first. */
+            activeChanges: components["schemas"]["ActiveChange"][];
+        };
+        /**
+         * @description One run. It stays open until an explicit `run.finished` closes it; silence never
+         *     produces a terminal state.
+         */
+        RunSummary: {
+            runId: components["schemas"]["RunId"];
+            /**
+             * @description The orchestrator that opened the run, or `null` while no root orchestrator reported
+             *     `agent.started` for it.
+             */
+            rootAgentId: components["schemas"]["AgentId"] | null;
+            /** @description When the run was first seen. */
+            startedAt: components["schemas"]["Timestamp"];
+            /** @description When `run.finished` was reported, `null` while the run is open. */
+            finishedAt: components["schemas"]["Timestamp"] | null;
+            /** @description Reported terminal outcome, `null` while the run is open. */
+            outcome: components["schemas"]["Outcome"] | null;
+            /** @description `false` only after an explicit `run.finished`. */
+            isOpen: boolean;
+            /** @description Whether this is the run `current` resolves to. */
+            isCurrent: boolean;
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /** @description Sizes of the read models of one run. */
+        RunCounts: {
+            /** @description Agents that reported `agent.started` in this run. */
+            agents: number;
+            /** @description Plans published in this run. */
+            plans: number;
+            /** @description Work steps reported in this run. */
+            workSteps: number;
+        };
+        /** @description One run together with the sizes of the collections hanging off it. */
+        RunDetail: {
+            runId: components["schemas"]["RunId"];
+            /** @description The orchestrator that opened the run, or `null`. */
+            rootAgentId: components["schemas"]["AgentId"] | null;
+            /** @description When the run was first seen. */
+            startedAt: components["schemas"]["Timestamp"];
+            /** @description When `run.finished` was reported, `null` while the run is open. */
+            finishedAt: components["schemas"]["Timestamp"] | null;
+            /** @description Reported terminal outcome, `null` while the run is open. */
+            outcome: components["schemas"]["Outcome"] | null;
+            /** @description `false` only after an explicit `run.finished`. */
+            isOpen: boolean;
+            /** @description Whether this is the run `current` resolves to. */
+            isCurrent: boolean;
+            position: components["schemas"]["AppliedPosition"];
+            counts: components["schemas"]["RunCounts"];
+        };
+        /**
+         * @description Body of `GET /api/v1/projects/{projectId}/runs`. Current and historical runs in one
+         *     list, descending by start.
+         */
+        RunListResponse: {
+            projectPosition: components["schemas"]["ProjectPosition"];
+            /** @description One page of runs. */
+            runs: components["schemas"]["RunSummary"][];
+            /** @description Cursor of the next page, `null` on the last one. */
+            nextCursor: components["schemas"]["Cursor"] | null;
+        };
+        /** @description Body of `GET /api/v1/projects/{projectId}/runs/{runId}`. */
+        RunResponse: {
+            projectPosition: components["schemas"]["ProjectPosition"];
+            run: components["schemas"]["RunDetail"];
+        };
+        /**
+         * @description Progress **as reported by the agent itself**. `scope` separates a subagent's own task
+         *     from an orchestrator's estimate for the whole run; `basis` separates a free estimate
+         *     from counted steps. The cockpit displays it as reported and checks nothing.
+         */
+        AgentProgress: {
+            /** @description Reported completion in percent. */
+            percent: number;
+            /** @description What the percentage refers to, `null` when it was not reported. */
+            scope: ("own_task" | "overall_estimate") | null;
+            /** @description How the number was derived, `null` when it was not reported. */
+            basis: ("reported_estimate" | "completed_steps") | null;
+        };
+        /**
+         * @description One node of the agent tree of a run. The tree is expressed through `parentAgentId`;
+         *     the list is flat.
+         *
+         *     Nothing here is derived: `status` stays empty until `agent.status_reported` arrives,
+         *     `progress` stays `null` until the agent reported a number, and `finishedOutcome` stays
+         *     `null` until `agent.finished`. Silence changes nothing.
+         */
+        RunAgent: {
+            agentId: components["schemas"]["AgentId"];
+            runId: components["schemas"]["RunId"];
+            /** @description The delegating agent, `null` for the root orchestrator. */
+            parentAgentId: components["schemas"]["AgentId"] | null;
+            /**
+             * @description Position of the agent in the run hierarchy, as reported.
+             * @enum {string}
+             */
+            role: "" | "orchestrator" | "subagent";
+            /** @description Name shown for this agent, empty when the agent never reported `agent.started`. */
+            displayName: string;
+            /** @description The task the agent was given, in its own words. Empty when never reported. */
+            assignedTask: string;
+            /**
+             * @description Last explicitly reported status. Empty means none was ever reported.
+             * @enum {string}
+             */
+            status: "" | "working" | "waiting" | "blocked" | "idle" | "done";
+            /** @description Optional one-line explanation that came with the status. */
+            statusNote: string;
+            /** @description Self-assessed progress, `null` until the agent reported one. */
+            progress: components["schemas"]["AgentProgress"] | null;
+            /** @description Reported outcome of `agent.finished`, `null` while the agent has not finished. */
+            finishedOutcome: components["schemas"]["Outcome"] | null;
+            /** @description When the agent was first seen in this run. */
+            startedAt: components["schemas"]["Timestamp"];
+            /** @description When this agent last reported anything. */
+            lastEventAt: components["schemas"]["Timestamp"];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /**
+         * @description Body of `GET /api/v1/projects/{projectId}/runs/{runId}/agents`. Flat, ordered so a
+         *     parent precedes the subagents it spawned.
+         */
+        AgentListResponse: {
+            projectPosition: components["schemas"]["ProjectPosition"];
+            /** @description Every agent of the run. */
+            agents: components["schemas"]["RunAgent"][];
+        };
+        /** @description One step of one plan revision, in the reported order. */
+        RunPlanStep: {
+            stepId: components["schemas"]["Identifier"];
+            /** @description Zero-based position of the step within its revision. */
+            order: number;
+            /** @description Short description of what the step achieves. */
+            title: string;
+            state: components["schemas"]["PlanStepState"];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /**
+         * @description One published revision of a plan. Revisions are append-only: a `plan.step_updated` only
+         *     reaches the revision that was current when it was reported, so an earlier revision keeps
+         *     exactly the states it was last seen with.
+         */
+        RunPlanRevision: {
+            /** @description Revision number, starting at 1 and strictly increasing per plan. */
+            revision: number;
+            /** @description When this revision was published. */
+            createdAt: components["schemas"]["Timestamp"];
+            createdByAgentId: components["schemas"]["AgentId"];
+            /** @description Whether `plan.step_updated` currently writes to this revision. */
+            isCurrent: boolean;
+            /** @description All steps of this revision, ordered by `order`. */
+            steps: components["schemas"]["RunPlanStep"][];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /** @description One plan of a run with every revision it ever had, ascending. */
+        RunPlan: {
+            planId: components["schemas"]["Identifier"];
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /** @description The revision the cockpit shows by default. */
+            currentRevision: number;
+            /** @description Every published revision, ascending. */
+            revisions: components["schemas"]["RunPlanRevision"][];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /** @description Body of `GET /api/v1/projects/{projectId}/runs/{runId}/plans`. */
+        PlanListResponse: {
+            projectPosition: components["schemas"]["ProjectPosition"];
+            /** @description Every plan of the run, ordered by `planId`. */
+            plans: components["schemas"]["RunPlan"][];
+        };
+        /**
+         * @description A concrete unit of work an agent reported. The inspector shows the open work step of
+         *     the selected run, or the most recently started one when all of them completed.
+         */
+        InspectorWorkStep: {
+            workStepId: components["schemas"]["Identifier"];
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /** @description The planned step this work followed, `null` for unplanned work. */
+            planStepId: components["schemas"]["Identifier"] | null;
+            /** @description Short description of the work. */
+            title: string;
+            /** @description When the work step was reported as started. */
+            startedAt: components["schemas"]["Timestamp"];
+            /** @description When it was reported as completed, `null` while it is open. */
+            completedAt: components["schemas"]["Timestamp"] | null;
+            /** @description Reported result summary, `null` while the step is open. */
+            summary: string | null;
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /**
+         * @description One published, component scoped feedback item. `body` is untrusted markdown and is
+         *     handed through verbatim — sanitising it before rendering is the client's job.
+         */
+        FeedbackEntry: {
+            feedbackId: components["schemas"]["Identifier"];
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /**
+             * @description Body format. v0 reports markdown only.
+             * @enum {string}
+             */
+            format: "markdown";
+            /** @description Reported headline, empty when none was reported. */
+            title: string;
+            /** @description The feedback text as reported. */
+            body: string;
+            /** @description When the feedback was reported. */
+            createdAt: components["schemas"]["Timestamp"];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /**
+         * @description One reported unified diff of exactly one repository file. The backend never splits or
+         *     merges diffs; `changeId` is what groups the files of one logical change.
+         */
+        ReportedDiff: {
+            diffId: components["schemas"]["Identifier"];
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /** @description The change this file belongs to, `null` for an unattributed diff. */
+            changeId: components["schemas"]["Identifier"] | null;
+            filePath: components["schemas"]["RepositoryFilePath"];
+            /** @description The unified diff of this one file, exactly as reported. */
+            unifiedDiff: string;
+            /** @description When the diff was reported. */
+            createdAt: components["schemas"]["Timestamp"];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /**
+         * @description A risk **as stated by the reporting agent**. The system never derives, scores or
+         *     aggregates risks; the human reviewer judges.
+         */
+        ReportedRisk: {
+            riskId: components["schemas"]["Identifier"];
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /** @description Short headline of the risk. */
+            title: string;
+            /** @description Longer explanation, empty when none was reported. */
+            detail: string;
+            /**
+             * @description Severity as assessed by the reporting agent.
+             * @enum {string}
+             */
+            severity: "low" | "medium" | "high";
+            /** @description When the risk was reported. */
+            createdAt: components["schemas"]["Timestamp"];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /** @description A problem as stated by the reporting agent, never a system-side evaluation. */
+        ReportedProblem: {
+            problemId: components["schemas"]["Identifier"];
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /** @description Short headline of the problem. */
+            title: string;
+            /** @description Longer explanation, empty when none was reported. */
+            detail: string;
+            /** @description When the problem was reported. */
+            createdAt: components["schemas"]["Timestamp"];
+            position: components["schemas"]["AppliedPosition"];
+        };
+        /**
+         * @description Body of `GET /api/v1/projects/{projectId}/components/{componentId}`. Everything here
+         *     belongs to **one** run — the one named in `runId`. Evidence of other runs is reachable
+         *     through `…/history` only.
+         */
+        ComponentInspectorResponse: {
+            projectPosition: components["schemas"]["ProjectPosition"];
+            /** @description The run this evidence belongs to, `null` when the project has no run at all yet. */
+            runId: components["schemas"]["RunId"] | null;
+            /**
+             * @description The applied descriptor, `null` when the component left the applied model but is
+             *     still known from the history.
+             */
+            component: components["schemas"]["AppliedComponent"] | null;
+            /**
+             * @description The agent of `currentWorkStep`, or the agent that applied the component in this run.
+             *     `null` when neither was reported — responsibility is read from evidence, not guessed.
+             */
+            responsibleAgent: components["schemas"]["RunAgent"] | null;
+            /**
+             * @description The open work step of this run touching the component, or the most recently started
+             *     one when all of them completed. `null` when no work step named the component.
+             */
+            currentWorkStep: components["schemas"]["InspectorWorkStep"] | null;
+            /** @description Component scoped feedback of this run, newest first. Complete, not paged. */
+            feedback: components["schemas"]["FeedbackEntry"][];
+            /**
+             * @description Unified diffs of this run touching the component, newest first. Paged — see
+             *     `nextDiffCursor`.
+             */
+            diffs: components["schemas"]["ReportedDiff"][];
+            /** @description Cursor for the next page of diffs, `null` when the last page was returned. */
+            nextDiffCursor: components["schemas"]["Cursor"] | null;
+            /** @description Risks reported for this component in this run, newest first. */
+            risks: components["schemas"]["ReportedRisk"][];
+            /** @description Problems reported for this component in this run, newest first. */
+            problems: components["schemas"]["ReportedProblem"][];
+            /**
+             * @description Pending proposals of this run that target this component. Proposals that target a
+             *     relationship are shown on the architecture endpoint instead.
+             */
+            activeChanges: components["schemas"]["ActiveChange"][];
+        };
+        /**
+         * @description One reported event that touched the component, as it was stored. Corrections and
+         *     retractions appear as their own entries; nothing is ever overwritten.
+         */
+        ComponentHistoryEntry: {
+            position: components["schemas"]["AppliedPosition"];
+            /** @description Server-assigned identity of the stored event. */
+            serverEventId: components["schemas"]["Uuid"];
+            /** @description The idempotency key the agent assigned. */
+            clientEventId: components["schemas"]["Uuid"];
+            runId: components["schemas"]["RunId"];
+            agentId: components["schemas"]["AgentId"];
+            /** @description The delegating agent, `null` for the root orchestrator. */
+            parentAgentId: components["schemas"]["AgentId"] | null;
+            type: components["schemas"]["EventType"];
+            schemaVersion: components["schemas"]["SchemaVersion"];
+            /** @description When the reported step happened, as observed by the agent. */
+            occurredAt: components["schemas"]["Timestamp"];
+            /** @description When the backend accepted and committed the event. */
+            receivedAt: components["schemas"]["Timestamp"];
+            /**
+             * @description The reported payload, canonicalised but otherwise unchanged. Its effective schema is
+             *     fixed by `type`, exactly as during ingestion.
+             */
+            payload: Record<string, unknown>;
+        };
+        /**
+         * @description Body of `GET /api/v1/projects/{projectId}/components/{componentId}/history`: the run
+         *     spanning evidence of one component, descending by project position.
+         */
+        ComponentHistoryResponse: {
+            projectPosition: components["schemas"]["ProjectPosition"];
+            /** @description One page of history, newest first. */
+            entries: components["schemas"]["ComponentHistoryEntry"][];
+            /** @description Cursor of the next page, `null` on the last one. */
+            nextCursor: components["schemas"]["Cursor"] | null;
+        };
+        /** @description Liveness probe response of the internal backend. */
+        LivenessStatus: {
+            /**
+             * @description Always `ok` while the process is answering.
+             * @enum {string}
+             */
+            status: "ok";
+        };
+        /** @description Readiness probe response of the internal backend. */
+        ReadinessStatus: {
+            /**
+             * @description Always `ready`; a backend that is not ready answers `503` instead.
+             * @enum {string}
+             */
+            status: "ready";
+        };
+    };
+    responses: {
+        /**
+         * @description The request body is syntactically valid JSON but violates the contract. Common codes:
+         *     `invalid_field`, `unsupported_event_type`, `unsupported_schema_version`.
+         */
+        BadRequest: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["ValidationProblem"];
+            };
+        };
+        /**
+         * @description The `clientEventId` was already used within this project for an event with different
+         *     content. Code: `client_event_id_conflict`.
+         */
+        Conflict: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["Problem"];
+            };
+        };
+        /**
+         * @description The request body exceeds the configured maximum event size. The default limit is
+         *     2 MiB (2097152 bytes) and is configurable server-side via `MAX_EVENT_BYTES`.
+         *     Code: `event_too_large`.
+         */
+        ContentTooLarge: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["Problem"];
+            };
+        };
+        /** @description The request `Content-Type` is not `application/json`. Code: `unsupported_media_type`. */
+        UnsupportedMediaType: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["Problem"];
+            };
+        };
+        /**
+         * @description The event is well-formed and schema-valid but contradicts the current state of the
+         *     project. Codes: `unknown_agent`, `run_already_finished`, `run_not_started`,
+         *     `run_already_started`, `parent_agent_unknown`, `terminal_event_not_allowed`,
+         *     `correction_target_unknown`.
+         */
+        UnprocessableContent: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["Problem"];
+            };
+        };
+        /** @description The project is unknown. Code: `project_not_found`. */
+        ProjectNotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["Problem"];
+            };
+        };
+        /**
+         * @description The project, or the requested run inside it, is unknown. Codes: `project_not_found`,
+         *     `run_not_found`, `current_run_not_found`. The last one is distinct on purpose: a project
+         *     whose runs were never opened by a root orchestrator has no current run, which a client
+         *     must be able to tell apart from a wrong run id.
+         */
+        RunNotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["Problem"];
+            };
+        };
+        /**
+         * @description The project, the requested run or the component is unknown. Codes:
+         *     `project_not_found`, `run_not_found`, `current_run_not_found`, `component_not_found`.
+         *
+         *     A component that left the applied model but still has history is **not** an error: it
+         *     is answered with `200` and `component: null`.
+         */
+        ComponentNotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["Problem"];
+            };
+        };
+        /**
+         * @description A query parameter of a read request is not acceptable. Code:
+         *     `invalid_query_parameter`. `errors[].field` names the rejected query parameter.
+         */
+        InvalidQueryParameter: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["ValidationProblem"];
+            };
+        };
+    };
+    parameters: {
+        /** @description Project the request is scoped to. */
+        ProjectIdPath: components["schemas"]["ProjectId"];
+        /**
+         * @description Run inside the project, or the literal `current` for the run a root orchestrator opened
+         *     last. The alias wins over a run that happens to carry that identifier: the default view
+         *     of the cockpit must not depend on how an agent named its run.
+         * @example current
+         */
+        RunIdPath: components["schemas"]["RunId"];
+        /** @description Component of the project's architecture model. */
+        ComponentIdPath: components["schemas"]["ComponentId"];
+        /**
+         * @description Run the component evidence is read from. Omitted means the current run; `current` means
+         *     the same thing explicitly. Any other value must name a run of this project, otherwise
+         *     the request is rejected with `404` and code `run_not_found` rather than silently falling
+         *     back to the current run.
+         * @example run-2026-08-04-0001
+         */
+        RunIdQuery: components["schemas"]["RunId"];
+        /**
+         * @description Number of entries per page. Defaults to 50, maximum 200. A value outside that range is
+         *     rejected with `400` rather than clamped, so a client cannot believe it received
+         *     everything.
+         * @example 50
+         */
+        LimitQuery: number;
+        /**
+         * @description Continuation token of the previous page, taken from its `nextCursor`. Opaque: it is
+         *     echoed back unchanged and its encoding is free to change.
+         */
+        CursorQuery: components["schemas"]["Cursor"];
+        /**
+         * @description Number of unified diffs in the component inspector. Defaults to 50, maximum 200; a value
+         *     outside that range is rejected with `400`.
+         * @example 50
+         */
+        DiffLimitQuery: number;
+        /**
+         * @description Continuation token for the diffs of the component inspector, taken from the previous
+         *     response's `nextDiffCursor`.
+         */
+        DiffCursorQuery: components["schemas"]["Cursor"];
+        /**
+         * @description Last server-side project position the client has already processed. Replay starts at
+         *     `lastEventPosition + 1`. Use `0` to replay the whole project from the beginning.
+         *     Takes precedence over the `Last-Event-ID` header.
+         *
+         *     A value that cannot be used as a cursor is rejected with `400`
+         *     (`invalid_query_parameter`) rather than silently ignored, because a client that spells
+         *     its own cursor wrongly must not believe it received a gap-free replay. An unusable
+         *     `Last-Event-ID` header is ignored instead: browsers set it automatically and a stream
+         *     that refuses to open would be worse than one that starts live. A position beyond the
+         *     end of the log is clamped to the current end.
+         * @example 41
+         */
+        LastEventPositionQuery: number;
+        /**
+         * @description Standard SSE reconnect header. Browsers set it automatically to the `id:` of the last
+         *     received frame, which is the server-side project position. Ignored when
+         *     `lastEventPosition` is present.
+         * @example 41
+         */
+        LastEventIdHeader: string;
+    };
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    ingestEvent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description One event envelope from the closed v0 catalogue. */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IngestEventRequest"];
+            };
+        };
+        responses: {
+            /**
+             * @description Idempotent retry. The event was already stored under this `clientEventId` with
+             *     identical content; the original `position` is returned and nothing is appended.
+             */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventAccepted"];
+                };
+            };
+            /** @description Event accepted and appended to the project event log. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventAccepted"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            409: components["responses"]["Conflict"];
+            413: components["responses"]["ContentTooLarge"];
+            415: components["responses"]["UnsupportedMediaType"];
+            422: components["responses"]["UnprocessableContent"];
+        };
+    };
+    streamProjectEvents: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Last server-side project position the client has already processed. Replay starts at
+                 *     `lastEventPosition + 1`. Use `0` to replay the whole project from the beginning.
+                 *     Takes precedence over the `Last-Event-ID` header.
+                 *
+                 *     A value that cannot be used as a cursor is rejected with `400`
+                 *     (`invalid_query_parameter`) rather than silently ignored, because a client that spells
+                 *     its own cursor wrongly must not believe it received a gap-free replay. An unusable
+                 *     `Last-Event-ID` header is ignored instead: browsers set it automatically and a stream
+                 *     that refuses to open would be worse than one that starts live. A position beyond the
+                 *     end of the log is clamped to the current end.
+                 * @example 41
+                 */
+                lastEventPosition?: components["parameters"]["LastEventPositionQuery"];
+            };
+            header?: {
+                /**
+                 * @description Standard SSE reconnect header. Browsers set it automatically to the `id:` of the last
+                 *     received frame, which is the server-side project position. Ignored when
+                 *     `lastEventPosition` is present.
+                 * @example 41
+                 */
+                "Last-Event-ID"?: components["parameters"]["LastEventIdHeader"];
+            };
+            path: {
+                /** @description Project the request is scoped to. */
+                projectId: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /**
+             * @description The event stream. The body is an endless `text/event-stream` document; the schema
+             *     below describes the JSON payload of a single `data:` line.
+             */
+            200: {
+                headers: {
+                    /** @description Always `no-cache`; the stream must never be cached. */
+                    "Cache-Control"?: string;
+                    /** @description Always `keep-alive`. */
+                    Connection?: string;
+                    /**
+                     * @description Always `no`. Disables response buffering in the Nginx frontend so that events
+                     *     reach the browser immediately.
+                     */
+                    "X-Accel-Buffering"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": components["schemas"]["StreamedEvent"];
+                };
+            };
+            400: components["responses"]["InvalidQueryParameter"];
+            404: components["responses"]["ProjectNotFound"];
+        };
+    };
+    listProjects: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The known projects. Empty, with `projectPosition: 0`, before the first event. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectListResponse"];
+                };
+            };
+        };
+    };
+    getProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project the request is scoped to. */
+                projectId: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The project. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            404: components["responses"]["ProjectNotFound"];
+        };
+    };
+    getProjectArchitecture: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project the request is scoped to. */
+                projectId: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The applied model and the pending proposals. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArchitectureResponse"];
+                };
+            };
+            404: components["responses"]["ProjectNotFound"];
+        };
+    };
+    listProjectRuns: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Number of entries per page. Defaults to 50, maximum 200. A value outside that range is
+                 *     rejected with `400` rather than clamped, so a client cannot believe it received
+                 *     everything.
+                 * @example 50
+                 */
+                limit?: components["parameters"]["LimitQuery"];
+                /**
+                 * @description Continuation token of the previous page, taken from its `nextCursor`. Opaque: it is
+                 *     echoed back unchanged and its encoding is free to change.
+                 */
+                cursor?: components["parameters"]["CursorQuery"];
+            };
+            header?: never;
+            path: {
+                /** @description Project the request is scoped to. */
+                projectId: components["parameters"]["ProjectIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description One page of runs. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunListResponse"];
+                };
+            };
+            400: components["responses"]["InvalidQueryParameter"];
+            404: components["responses"]["ProjectNotFound"];
+        };
+    };
+    getProjectRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project the request is scoped to. */
+                projectId: components["parameters"]["ProjectIdPath"];
+                /**
+                 * @description Run inside the project, or the literal `current` for the run a root orchestrator opened
+                 *     last. The alias wins over a run that happens to carry that identifier: the default view
+                 *     of the cockpit must not depend on how an agent named its run.
+                 * @example current
+                 */
+                runId: components["parameters"]["RunIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The run. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunResponse"];
+                };
+            };
+            404: components["responses"]["RunNotFound"];
+        };
+    };
+    listRunAgents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project the request is scoped to. */
+                projectId: components["parameters"]["ProjectIdPath"];
+                /**
+                 * @description Run inside the project, or the literal `current` for the run a root orchestrator opened
+                 *     last. The alias wins over a run that happens to carry that identifier: the default view
+                 *     of the cockpit must not depend on how an agent named its run.
+                 * @example current
+                 */
+                runId: components["parameters"]["RunIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Every agent of the run. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentListResponse"];
+                };
+            };
+            404: components["responses"]["RunNotFound"];
+        };
+    };
+    listRunPlans: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project the request is scoped to. */
+                projectId: components["parameters"]["ProjectIdPath"];
+                /**
+                 * @description Run inside the project, or the literal `current` for the run a root orchestrator opened
+                 *     last. The alias wins over a run that happens to carry that identifier: the default view
+                 *     of the cockpit must not depend on how an agent named its run.
+                 * @example current
+                 */
+                runId: components["parameters"]["RunIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Every plan of the run. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlanListResponse"];
+                };
+            };
+            404: components["responses"]["RunNotFound"];
+        };
+    };
+    getComponentInspector: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Run the component evidence is read from. Omitted means the current run; `current` means
+                 *     the same thing explicitly. Any other value must name a run of this project, otherwise
+                 *     the request is rejected with `404` and code `run_not_found` rather than silently falling
+                 *     back to the current run.
+                 * @example run-2026-08-04-0001
+                 */
+                runId?: components["parameters"]["RunIdQuery"];
+                /**
+                 * @description Number of unified diffs in the component inspector. Defaults to 50, maximum 200; a value
+                 *     outside that range is rejected with `400`.
+                 * @example 50
+                 */
+                diffLimit?: components["parameters"]["DiffLimitQuery"];
+                /**
+                 * @description Continuation token for the diffs of the component inspector, taken from the previous
+                 *     response's `nextDiffCursor`.
+                 */
+                diffCursor?: components["parameters"]["DiffCursorQuery"];
+            };
+            header?: never;
+            path: {
+                /** @description Project the request is scoped to. */
+                projectId: components["parameters"]["ProjectIdPath"];
+                /** @description Component of the project's architecture model. */
+                componentId: components["parameters"]["ComponentIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The component evidence of one run. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComponentInspectorResponse"];
+                };
+            };
+            400: components["responses"]["InvalidQueryParameter"];
+            404: components["responses"]["ComponentNotFound"];
+        };
+    };
+    getComponentHistory: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Number of entries per page. Defaults to 50, maximum 200. A value outside that range is
+                 *     rejected with `400` rather than clamped, so a client cannot believe it received
+                 *     everything.
+                 * @example 50
+                 */
+                limit?: components["parameters"]["LimitQuery"];
+                /**
+                 * @description Continuation token of the previous page, taken from its `nextCursor`. Opaque: it is
+                 *     echoed back unchanged and its encoding is free to change.
+                 */
+                cursor?: components["parameters"]["CursorQuery"];
+            };
+            header?: never;
+            path: {
+                /** @description Project the request is scoped to. */
+                projectId: components["parameters"]["ProjectIdPath"];
+                /** @description Component of the project's architecture model. */
+                componentId: components["parameters"]["ComponentIdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description One page of component history. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComponentHistoryResponse"];
+                };
+            };
+            400: components["responses"]["InvalidQueryParameter"];
+            404: components["responses"]["ComponentNotFound"];
+        };
+    };
+    getLiveness: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The process is alive. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LivenessStatus"];
+                };
+            };
+        };
+    };
+    getReadiness: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The backend is ready to serve ingestion and streaming. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReadinessStatus"];
+                };
+            };
+            /** @description The backend is not ready, for example because PostgreSQL is unreachable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+}

--- a/frontend/src/api/problem.ts
+++ b/frontend/src/api/problem.ts
@@ -1,4 +1,4 @@
-import type { Problem, ValidationErrorDetail, ValidationProblem } from './types'
+import type { Problem, ValidationError, ValidationProblem } from './types'
 
 /**
  * A response the backend rejected, expressed as RFC 9457 problem details.
@@ -12,7 +12,7 @@ export class ProblemError extends Error {
   readonly name = 'ProblemError'
   readonly problem: Problem
   /** Field-level violations of a `400 ValidationProblem`, otherwise empty. */
-  readonly errors: readonly ValidationErrorDetail[]
+  readonly errors: readonly ValidationError[]
   /** Request URL that produced the problem, for logging. */
   readonly url: string
 

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -8,18 +8,18 @@ import {
 import { fetchJson } from './fetchJson'
 import { queryKeys } from './queryKeys'
 import type {
-  AgentsResponse,
+  AgentListResponse,
   ArchitectureResponse,
   ComponentHistoryResponse,
   ComponentId,
   ComponentInspectorResponse,
-  PlansResponse,
+  PlanListResponse,
   ProjectId,
+  ProjectListResponse,
   ProjectResponse,
-  ProjectsResponse,
   RunId,
+  RunListResponse,
   RunResponse,
-  RunsResponse,
 } from './types'
 
 /** Page size used for the two cursor-paged endpoints. */
@@ -32,7 +32,7 @@ export const PAGE_SIZE = 50
 export function projectsQuery() {
   return queryOptions({
     queryKey: queryKeys.projects(),
-    queryFn: ({ signal }) => fetchJson<ProjectsResponse>('/projects', { signal }),
+    queryFn: ({ signal }) => fetchJson<ProjectListResponse>('/projects', { signal }),
   })
 }
 
@@ -61,12 +61,12 @@ export function runsQuery(projectId: ProjectId, limit = PAGE_SIZE) {
   return infiniteQueryOptions({
     queryKey: queryKeys.runs(projectId),
     queryFn: ({ signal, pageParam }) =>
-      fetchJson<RunsResponse>(`/projects/${encodeURIComponent(projectId)}/runs`, {
+      fetchJson<RunListResponse>(`/projects/${encodeURIComponent(projectId)}/runs`, {
         signal,
         query: { limit, cursor: pageParam },
       }),
     initialPageParam: null as string | null,
-    getNextPageParam: (lastPage: RunsResponse) => lastPage.nextCursor,
+    getNextPageParam: (lastPage: RunListResponse) => lastPage.nextCursor,
   })
 }
 
@@ -85,7 +85,7 @@ export function agentsQuery(projectId: ProjectId, runId: RunId) {
   return queryOptions({
     queryKey: queryKeys.agents(projectId, runId),
     queryFn: ({ signal }) =>
-      fetchJson<AgentsResponse>(
+      fetchJson<AgentListResponse>(
         `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(runId)}/agents`,
         { signal },
       ),
@@ -96,7 +96,7 @@ export function plansQuery(projectId: ProjectId, runId: RunId) {
   return queryOptions({
     queryKey: queryKeys.plans(projectId, runId),
     queryFn: ({ signal }) =>
-      fetchJson<PlansResponse>(
+      fetchJson<PlanListResponse>(
         `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(runId)}/plans`,
         { signal },
       ),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,46 +1,99 @@
 /**
  * Domain and read-model types of the cockpit.
  *
- * Everything here is derived by hand from `api/openapi.yaml` — there is
- * deliberately **no code generation step**, so the Docker build stays a plain
- * `npm ci && npm run build` with no generator in between.
+ * **Nothing in this file describes a shape.** Every type below is an alias for a
+ * schema of `api/openapi.yaml`, resolved through the generated module
+ * `./generated/contract.ts`. The contract is the authority; when a name here
+ * differs from a name there, this file is wrong.
  *
- * Two groups live in this file:
+ * This indirection exists so the rest of the app writes `ActiveChange` instead
+ * of `components['schemas']['ActiveChange']`, and so a renamed schema shows up
+ * as a compile error in exactly one place.
  *
- * 1. Types that appear verbatim in the event contract (`Component`,
- *    `Relationship`, `PlanStep`, `Technology`, every event payload and the
- *    streamed envelope). They must stay byte-compatible with the contract.
- * 2. Read models (`ProjectSummary`, `Agent`, `Plan`, `ActiveChange`, …). The
- *    read API projects the event log into these shapes; it is specified in the
- *    issue and implemented server-side in #8. They are folds over the events of
- *    group 1 and never introduce information the contract cannot carry.
+ * Why the aliases are not hand-written any more: they were, and they drifted.
+ * `ActiveChange` alone had a `target`/`componentId`/`relationshipId` triple the
+ * contract never had (`targetKind`/`targetId`), lacked `snapshot`, and was
+ * missing the `retracted` state. See
+ * `docs/decisions/0009-generated-frontend-contract-types.md`.
  *
- * Nothing in the cockpit is inferred: a field is `null` when no agent reported
- * it, never a guess.
+ * Two vocabularies live in the contract and must not be confused:
+ *
+ * * **Event descriptors** — `Component`, `Relationship`, `PlanStep`, every
+ *   `*Payload`: what an agent reports.
+ * * **Read models** — `AppliedComponent`, `AppliedRelationship`, `RunAgent`,
+ *   `RunPlan`, `ActiveChange`, …: what the read API projects out of the log.
+ *   They carry provenance (`appliedAt`, `appliedByAgentId`, `position`) that an
+ *   event descriptor does not have, and they report "nothing was reported" as an
+ *   empty string or `null` rather than by omitting the field.
  */
+
+import type { components } from './generated/contract'
+
+type Schemas = components['schemas']
 
 // ---------------------------------------------------------------------------
 // Primitive identifiers (contract)
 // ---------------------------------------------------------------------------
 
 /** Stable project slug, e.g. `visualise-ai`. */
-export type ProjectId = string
+export type ProjectId = Schemas['ProjectId']
 /** Identifier of one agent run inside a project. */
-export type RunId = string
+export type RunId = Schemas['RunId']
 /** Identifier of a reporting agent, unique within a run. */
-export type AgentId = string
+export type AgentId = Schemas['AgentId']
 /** Identifier of an architecture component, stable across snapshots. */
-export type ComponentId = string
+export type ComponentId = Schemas['ComponentId']
 /** Opaque agent-assigned identifier (plan, work step, feedback, diff, risk, …). */
-export type Identifier = string
+export type Identifier = Schemas['Identifier']
 /** RFC 4122 UUID. */
-export type Uuid = string
+export type Uuid = Schemas['Uuid']
 /** RFC 3339 timestamp, UTC. */
-export type Timestamp = string
+export type Timestamp = Schemas['Timestamp']
 /** Repository-relative POSIX file path. */
-export type RepositoryFilePath = string
+export type RepositoryFilePath = Schemas['RepositoryFilePath']
+/** Contract version an event was reported under. */
+export type SchemaVersion = Schemas['SchemaVersion']
+/** Opaque continuation token of a paged read endpoint. */
+export type Cursor = Schemas['Cursor']
+/** Project position a read response was taken at. */
+export type ProjectPosition = Schemas['ProjectPosition']
+/** Project position of the event that last wrote a read-model row. */
+export type AppliedPosition = Schemas['AppliedPosition']
 
-/** The closed v0 event catalogue. */
+// ---------------------------------------------------------------------------
+// Closed vocabularies (contract)
+// ---------------------------------------------------------------------------
+
+export type EventType = Schemas['EventType']
+export type ChangeOperation = Schemas['ChangeOperation']
+export type Outcome = Schemas['Outcome']
+export type PlanStepState = Schemas['PlanStepState']
+
+/**
+ * The enums below are declared inline in the contract rather than as named
+ * schemas, so they are read off the schema that owns them instead of being
+ * re-typed here.
+ */
+export type ComponentKind = Schemas['Component']['kind']
+export type RelationshipKind = Schemas['Relationship']['kind']
+export type AgentRole = Schemas['AgentStartedPayload']['role']
+export type AgentStatus = Schemas['AgentStatusReportedPayload']['status']
+export type ProgressScope = Schemas['AgentProgressReportedPayload']['scope']
+export type ProgressBasis = Schemas['AgentProgressReportedPayload']['basis']
+export type RiskSeverity = Schemas['RiskReportedPayload']['severity']
+
+/**
+ * The closed v0 event catalogue as a runtime value.
+ *
+ * The SSE client needs the list at runtime — the server sets `event:` to the
+ * event type, so a `message` listener never fires and every type has to be
+ * subscribed individually. Types are erased at runtime, so this one list cannot
+ * be generated away.
+ *
+ * `EventTypeCatalogueIsComplete` below is the compile-time proof that it still
+ * covers the contract enum: adding a type to `api/openapi.yaml` without adding
+ * it here fails `tsc`.
+ */
 export const EVENT_TYPES = [
   'agent.started',
   'agent.status_reported',
@@ -62,530 +115,160 @@ export const EVENT_TYPES = [
   'correction.issued',
   'retraction.issued',
   'run.finished',
-] as const
-
-export type EventType = (typeof EVENT_TYPES)[number]
-
-export type ChangeOperation = 'add' | 'modify' | 'remove'
-export type Outcome = 'completed' | 'failed' | 'cancelled'
-export type PlanStepState = 'pending' | 'in_progress' | 'done' | 'skipped'
-export type AgentRole = 'orchestrator' | 'subagent'
-export type AgentStatus = 'working' | 'waiting' | 'blocked' | 'idle' | 'done'
-export type ProgressScope = 'own_task' | 'overall_estimate'
-export type ProgressBasis = 'reported_estimate' | 'completed_steps'
-export type RiskSeverity = 'low' | 'medium' | 'high'
-export type ComponentKind =
-  | 'system'
-  | 'service'
-  | 'module'
-  | 'datastore'
-  | 'queue'
-  | 'topic'
-  | 'ui'
-  | 'external'
-  | 'library'
-export type RelationshipKind =
-  | 'http'
-  | 'grpc'
-  | 'data'
-  | 'async'
-  | 'nats_topic'
-  | 'dependency'
-
-// ---------------------------------------------------------------------------
-// Architecture model (contract)
-// ---------------------------------------------------------------------------
-
-export interface Technology {
-  language?: string
-  framework?: string
-  runtime?: string
-  version?: string
-}
+] as const satisfies readonly EventType[]
 
 /**
- * One node of the application architecture. The hierarchy is expressed
- * exclusively through `parentComponentId`; dotted ids are a convention only.
+ * Errors with "does not satisfy the constraint `never`" and names the event
+ * types the contract has and `EVENT_TYPES` does not.
  */
-export interface Component {
-  componentId: ComponentId
-  name: string
-  kind: ComponentKind
-  parentComponentId: ComponentId | null
-  description?: string
-  technology?: Technology
-  tags?: string[]
-}
+type NoneLeftOver<T extends never> = T
+export type EventTypeCatalogueIsComplete = NoneLeftOver<
+  Exclude<EventType, (typeof EVENT_TYPES)[number]>
+>
 
+// ---------------------------------------------------------------------------
+// Architecture model as an agent reports it (contract)
+// ---------------------------------------------------------------------------
+
+export type Technology = Schemas['Technology']
 /**
- * A typed, directed edge. Every NATS topic is its own relationship — topics are
- * never merged server-side into one aggregated messaging edge.
+ * One node of the architecture **as reported**. The read API answers with
+ * `AppliedComponent`; this shape appears in event payloads and in
+ * `ActiveChange.snapshot`.
  */
-export interface Relationship {
-  relationshipId: Identifier
-  sourceComponentId: ComponentId
-  targetComponentId: ComponentId
-  kind: RelationshipKind
-  label?: string
-  protocol?: string
-  operation?: string
-  channel?: string
-}
-
-export interface PlanStep {
-  stepId: Identifier
-  order: number
-  title: string
-  state: PlanStepState
-  componentIds?: ComponentId[]
-}
+export type Component = Schemas['Component']
+/** A typed, directed edge as reported. The read API answers `AppliedRelationship`. */
+export type Relationship = Schemas['Relationship']
+export type PlanStep = Schemas['PlanStep']
 
 // ---------------------------------------------------------------------------
 // Event payloads (contract)
 // ---------------------------------------------------------------------------
 
-export interface AgentStartedPayload {
-  role: AgentRole
-  displayName: string
-  assignedTask: string
-  capabilities?: string[]
-}
-
-export interface AgentStatusReportedPayload {
-  status: AgentStatus
-  note?: string
-}
-
-export interface AgentProgressReportedPayload {
-  percent: number
-  scope: ProgressScope
-  basis: ProgressBasis
-  note?: string
-}
-
-export interface AgentFinishedPayload {
-  outcome: Outcome
-  summary?: string
-}
-
-export interface PlanPublishedPayload {
-  planId: Identifier
-  revision: number
-  steps: PlanStep[]
-}
-
-export interface PlanStepUpdatedPayload {
-  planId: Identifier
-  stepId: Identifier
-  state: PlanStepState
-  note?: string
-}
-
-export interface WorkStepStartedPayload {
-  workStepId: Identifier
-  title: string
-  componentIds: ComponentId[]
-  planStepId?: Identifier
-}
-
-export interface WorkStepCompletedPayload {
-  workStepId: Identifier
-  summary?: string
-}
-
-export interface FeedbackPublishedPayload {
-  feedbackId: Identifier
-  componentIds: ComponentId[]
-  format: 'markdown'
-  body: string
-  title?: string
-}
-
-export interface ArchitectureSnapshotPublishedPayload {
-  snapshotId: Identifier
-  components: Component[]
-  relationships: Relationship[]
-}
-
-export interface ComponentChangePlannedPayload {
-  changeId: Identifier
-  operation: ChangeOperation
-  component: Component
-  rationale?: string
-}
-
-export interface ComponentChangeAppliedPayload {
-  changeId?: Identifier
-  operation: ChangeOperation
-  component: Component
-}
-
-export interface RelationshipChangePlannedPayload {
-  changeId: Identifier
-  operation: ChangeOperation
-  relationship: Relationship
-  rationale?: string
-}
-
-export interface RelationshipChangeAppliedPayload {
-  changeId?: Identifier
-  operation: ChangeOperation
-  relationship: Relationship
-}
-
-export interface DiffReportedPayload {
-  diffId: Identifier
-  changeId?: Identifier
-  componentIds: ComponentId[]
-  filePath: RepositoryFilePath
-  unifiedDiff: string
-}
-
-export interface RiskReportedPayload {
-  riskId: Identifier
-  componentIds: ComponentId[]
-  title: string
-  detail?: string
-  severity: RiskSeverity
-}
-
-export interface ProblemReportedPayload {
-  problemId: Identifier
-  componentIds: ComponentId[]
-  title: string
-  detail?: string
-}
-
-export interface CorrectionIssuedPayload {
-  correctsClientEventId: Uuid
-  reason: string
-  correctedType: EventType
-  correctedPayload: Record<string, unknown>
-}
-
-export interface RetractionIssuedPayload {
-  retractsClientEventId: Uuid
-  reason: string
-}
-
-export interface RunFinishedPayload {
-  outcome: Outcome
-  summary?: string
-}
-
-/** Maps every event type to its payload schema. */
-export interface EventPayloadMap {
-  'agent.started': AgentStartedPayload
-  'agent.status_reported': AgentStatusReportedPayload
-  'agent.progress_reported': AgentProgressReportedPayload
-  'agent.finished': AgentFinishedPayload
-  'plan.published': PlanPublishedPayload
-  'plan.step_updated': PlanStepUpdatedPayload
-  'work.step_started': WorkStepStartedPayload
-  'work.step_completed': WorkStepCompletedPayload
-  'feedback.published': FeedbackPublishedPayload
-  'architecture.snapshot_published': ArchitectureSnapshotPublishedPayload
-  'component.change_planned': ComponentChangePlannedPayload
-  'component.change_applied': ComponentChangeAppliedPayload
-  'relationship.change_planned': RelationshipChangePlannedPayload
-  'relationship.change_applied': RelationshipChangeAppliedPayload
-  'diff.reported': DiffReportedPayload
-  'risk.reported': RiskReportedPayload
-  'problem.reported': ProblemReportedPayload
-  'correction.issued': CorrectionIssuedPayload
-  'retraction.issued': RetractionIssuedPayload
-  'run.finished': RunFinishedPayload
-}
+export type AgentStartedPayload = Schemas['AgentStartedPayload']
+export type AgentStatusReportedPayload = Schemas['AgentStatusReportedPayload']
+export type AgentProgressReportedPayload = Schemas['AgentProgressReportedPayload']
+export type AgentFinishedPayload = Schemas['AgentFinishedPayload']
+export type PlanPublishedPayload = Schemas['PlanPublishedPayload']
+export type PlanStepUpdatedPayload = Schemas['PlanStepUpdatedPayload']
+export type WorkStepStartedPayload = Schemas['WorkStepStartedPayload']
+export type WorkStepCompletedPayload = Schemas['WorkStepCompletedPayload']
+export type FeedbackPublishedPayload = Schemas['FeedbackPublishedPayload']
+export type ArchitectureSnapshotPublishedPayload =
+  Schemas['ArchitectureSnapshotPublishedPayload']
+export type ComponentChangePlannedPayload = Schemas['ComponentChangePlannedPayload']
+export type ComponentChangeAppliedPayload = Schemas['ComponentChangeAppliedPayload']
+export type RelationshipChangePlannedPayload = Schemas['RelationshipChangePlannedPayload']
+export type RelationshipChangeAppliedPayload = Schemas['RelationshipChangeAppliedPayload']
+export type DiffReportedPayload = Schemas['DiffReportedPayload']
+export type RiskReportedPayload = Schemas['RiskReportedPayload']
+export type ProblemReportedPayload = Schemas['ProblemReportedPayload']
+export type CorrectionIssuedPayload = Schemas['CorrectionIssuedPayload']
+export type RetractionIssuedPayload = Schemas['RetractionIssuedPayload']
+export type RunFinishedPayload = Schemas['RunFinishedPayload']
 
 // ---------------------------------------------------------------------------
 // Streamed events (contract, SSE)
 // ---------------------------------------------------------------------------
 
 /** Server-assigned metadata every streamed event carries. */
-export interface StreamedEventMeta {
-  schemaVersion: '1.0'
-  clientEventId: Uuid
-  projectId: ProjectId
-  runId: RunId
-  agentId: AgentId
-  parentAgentId?: AgentId | null
-  occurredAt: Timestamp
-  /** Strictly increasing per project. Cursor for SSE replay. */
-  position: number
-  serverEventId: Uuid
-  receivedAt: Timestamp
-}
-
-/** One event of the closed catalogue as carried by a single SSE `data:` line. */
-export type StreamedEventOf<T extends EventType> = StreamedEventMeta & {
-  type: T
-  payload: EventPayloadMap[T]
-}
+export type StreamedEventEnvelope = Schemas['StreamedEventEnvelope']
 
 /** Discriminated union over the whole catalogue, keyed by `type`. */
-export type StreamedEvent = {
-  [T in EventType]: StreamedEventOf<T>
-}[EventType]
+export type StreamedEvent = Schemas['StreamedEvent']
+
+/** One event of the closed catalogue, narrowed to a single `type`. */
+export type StreamedEventOf<T extends EventType> = Extract<StreamedEvent, { type: T }>
+
+/** Maps every event type to its payload schema. */
+export type EventPayloadMap = {
+  [T in EventType]: StreamedEventOf<T>['payload']
+}
 
 // ---------------------------------------------------------------------------
 // Read models (projections of the event log, served by the read API)
 // ---------------------------------------------------------------------------
 
-/**
- * Server-side project position every read response carries. It is the same
- * counter the SSE stream uses as `id:`, so an HTTP snapshot and the live stream
- * can be reconciled deterministically.
- */
-export interface PositionedResponse {
-  projectPosition: number
-}
+export type ProjectSummary = Schemas['ProjectSummary']
+export type ProjectCounts = Schemas['ProjectCounts']
+export type ProjectDetail = Schemas['ProjectDetail']
 
-export interface ProjectSummary {
-  projectId: ProjectId
-  name: string
-  /** Most recent run, or `null` while a project has not reported one yet. */
-  currentRunId: RunId | null
-  runCount: number
-  lastEventAt: Timestamp | null
-}
-
-export interface ProjectDetail extends ProjectSummary {
-  description: string | null
-  firstEventAt: Timestamp | null
-  componentCount: number
-  relationshipCount: number
-}
-
-export interface RunSummary {
-  runId: RunId
-  projectId: ProjectId
-  startedAt: Timestamp
-  lastEventAt: Timestamp
-  /** `null` while no `run.finished` was reported — never inferred from silence. */
-  outcome: Outcome | null
-  finishedAt: Timestamp | null
-  orchestratorAgentId: AgentId | null
-  agentCount: number
-}
-
-export interface RunDetail extends RunSummary {
-  summary: string | null
-}
-
-export interface AgentProgress {
-  percent: number
-  scope: ProgressScope
-  basis: ProgressBasis
-  note: string | null
-  reportedAt: Timestamp
-}
+/** One node of the **applied** architecture model, with its provenance. */
+export type AppliedComponent = Schemas['AppliedComponent']
+/** One edge of the **applied** architecture model, with its provenance. */
+export type AppliedRelationship = Schemas['AppliedRelationship']
 
 /**
- * One agent of a run. The tree is flat with `parentAgentId`; the left pane
- * builds the hierarchy from it (#11).
+ * A pending change proposal.
+ *
+ * `snapshot` carries the reported `Component` or `Relationship` descriptor
+ * verbatim — selected by `targetKind` — so the canvas can draw a proposal
+ * without a second lookup. The contract types it as a free-form object; narrow
+ * it with `changeSnapshot()` below rather than casting at the use site.
  */
-export interface Agent {
-  agentId: AgentId
-  runId: RunId
-  parentAgentId: AgentId | null
-  role: AgentRole
-  displayName: string
-  assignedTask: string
-  capabilities: string[]
-  /** Last explicitly reported status; `null` until the agent reported one. */
-  status: AgentStatus | null
-  statusNote: string | null
-  statusReportedAt: Timestamp | null
-  progress: AgentProgress | null
-  outcome: Outcome | null
-  summary: string | null
-  startedAt: Timestamp
-  lastEventAt: Timestamp
-}
+export type ActiveChange = Schemas['ActiveChange']
 
-export interface PlanRevision {
-  revision: number
-  publishedAt: Timestamp
-  publishedByAgentId: AgentId
-  steps: PlanStep[]
-}
+export type RunSummary = Schemas['RunSummary']
+export type RunCounts = Schemas['RunCounts']
+export type RunDetail = Schemas['RunDetail']
 
-/** Plans are append-only: a changed plan is a new revision of the same plan. */
-export interface Plan {
-  planId: Identifier
-  runId: RunId
-  agentId: AgentId
-  currentRevision: number
-  revisions: PlanRevision[]
-}
+export type AgentProgress = Schemas['AgentProgress']
+/** One node of the agent tree of a run. */
+export type RunAgent = Schemas['RunAgent']
 
-export interface WorkStep {
-  workStepId: Identifier
-  runId: RunId
-  agentId: AgentId
-  title: string
-  componentIds: ComponentId[]
-  planStepId: Identifier | null
-  startedAt: Timestamp
-  completedAt: Timestamp | null
-  summary: string | null
-}
+export type RunPlanStep = Schemas['RunPlanStep']
+export type RunPlanRevision = Schemas['RunPlanRevision']
+export type RunPlan = Schemas['RunPlan']
 
-/**
- * A component or relationship change that is currently visible on the canvas —
- * either only planned, or applied recently enough to still be highlighted.
- * Drives the work-state overlay (#10); `src/state/workStates.ts` owns the
- * mapping to a visual state.
- */
-export interface ActiveChange {
-  changeId: Identifier | null
-  target: 'component' | 'relationship'
-  state: 'planned' | 'applied'
-  operation: ChangeOperation
-  componentId: ComponentId | null
-  relationshipId: Identifier | null
-  runId: RunId
-  agentId: AgentId
-  rationale: string | null
-  reportedAt: Timestamp
-}
-
-export interface Feedback {
-  feedbackId: Identifier
-  runId: RunId
-  agentId: AgentId
-  componentIds: ComponentId[]
-  format: 'markdown'
-  /** Untrusted markdown — rendered sanitised by the inspector (#12). */
-  body: string
-  title: string | null
-  publishedAt: Timestamp
-  retracted: boolean
-  correctedAt: Timestamp | null
-}
-
-export interface Diff {
-  diffId: Identifier
-  changeId: Identifier | null
-  runId: RunId
-  agentId: AgentId
-  componentIds: ComponentId[]
-  filePath: RepositoryFilePath
-  unifiedDiff: string
-  reportedAt: Timestamp
-  retracted: boolean
-}
-
-export interface Risk {
-  riskId: Identifier
-  runId: RunId
-  agentId: AgentId
-  componentIds: ComponentId[]
-  title: string
-  detail: string | null
-  severity: RiskSeverity
-  reportedAt: Timestamp
-  retracted: boolean
-}
-
-export interface ReportedProblem {
-  problemId: Identifier
-  runId: RunId
-  agentId: AgentId
-  componentIds: ComponentId[]
-  title: string
-  detail: string | null
-  reportedAt: Timestamp
-  retracted: boolean
-}
-
-/**
- * One entry of the component history. Corrections and retractions stay visible
- * as their own entries; nothing is overwritten.
- */
-export interface HistoryEntry {
-  position: number
-  eventType: EventType
-  runId: RunId
-  agentId: AgentId
-  occurredAt: Timestamp
-  receivedAt: Timestamp
-  title: string
-  retracted: boolean
-  correctsPosition: number | null
-}
+export type InspectorWorkStep = Schemas['InspectorWorkStep']
+export type FeedbackEntry = Schemas['FeedbackEntry']
+export type ReportedDiff = Schemas['ReportedDiff']
+export type ReportedRisk = Schemas['ReportedRisk']
+export type ReportedProblem = Schemas['ReportedProblem']
+export type ComponentHistoryEntry = Schemas['ComponentHistoryEntry']
 
 // ---------------------------------------------------------------------------
 // Read API responses
 // ---------------------------------------------------------------------------
 
-export interface ProjectsResponse extends PositionedResponse {
-  projects: ProjectSummary[]
-}
-
-export interface ProjectResponse extends PositionedResponse {
-  project: ProjectDetail
-}
-
-export interface ArchitectureResponse extends PositionedResponse {
-  components: Component[]
-  relationships: Relationship[]
-  activeChanges: ActiveChange[]
-}
-
-export interface RunsResponse extends PositionedResponse {
-  runs: RunSummary[]
-  nextCursor: string | null
-}
-
-export interface RunResponse extends PositionedResponse {
-  run: RunDetail
-}
-
-export interface AgentsResponse extends PositionedResponse {
-  agents: Agent[]
-}
-
-export interface PlansResponse extends PositionedResponse {
-  plans: Plan[]
-}
-
-export interface ComponentInspectorResponse extends PositionedResponse {
-  component: Component
-  responsibleAgent: Agent | null
-  currentWorkStep: WorkStep | null
-  feedback: Feedback[]
-  diffs: Diff[]
-  risks: Risk[]
-  problems: ReportedProblem[]
-  activeChanges: ActiveChange[]
-}
-
-export interface ComponentHistoryResponse extends PositionedResponse {
-  entries: HistoryEntry[]
-  nextCursor: string | null
-}
+export type ProjectListResponse = Schemas['ProjectListResponse']
+export type ProjectResponse = Schemas['ProjectResponse']
+export type ArchitectureResponse = Schemas['ArchitectureResponse']
+export type RunListResponse = Schemas['RunListResponse']
+export type RunResponse = Schemas['RunResponse']
+export type AgentListResponse = Schemas['AgentListResponse']
+export type PlanListResponse = Schemas['PlanListResponse']
+export type ComponentInspectorResponse = Schemas['ComponentInspectorResponse']
+export type ComponentHistoryResponse = Schemas['ComponentHistoryResponse']
 
 // ---------------------------------------------------------------------------
 // RFC 9457 problem details
 // ---------------------------------------------------------------------------
 
-export interface Problem {
-  type: string
-  title: string
-  status: number
-  detail: string
-  code: string
-  instance?: string
-}
+export type Problem = Schemas['Problem']
+export type ValidationError = Schemas['ValidationError']
+export type ValidationProblem = Schemas['ValidationProblem']
 
-export interface ValidationErrorDetail {
-  /** RFC 6901 JSON Pointer into the rejected body. */
-  field: string
-  code: string
-  message: string
-}
+// ---------------------------------------------------------------------------
+// Local narrowing helpers — no shape of their own
+// ---------------------------------------------------------------------------
 
-export interface ValidationProblem extends Problem {
-  errors: ValidationErrorDetail[]
+/**
+ * Narrows `ActiveChange.snapshot` to the descriptor `targetKind` announces.
+ *
+ * The contract deliberately types `snapshot` as a free-form object: it stores
+ * what the agent reported, unchanged. `targetKind` is the discriminator, so this
+ * is a projection of the contract's own rule, not an added assumption. Returns
+ * `null` when the snapshot is not an object at all, so a malformed row degrades
+ * to "nothing was reported" instead of throwing.
+ */
+export function changeSnapshot(change: ActiveChange & { targetKind: 'component' }): Component | null
+export function changeSnapshot(
+  change: ActiveChange & { targetKind: 'relationship' },
+): Relationship | null
+export function changeSnapshot(change: ActiveChange): Component | Relationship | null
+export function changeSnapshot(change: ActiveChange): Component | Relationship | null {
+  const snapshot = change.snapshot
+  if (typeof snapshot !== 'object' || snapshot === null) return null
+  return snapshot as Component | Relationship
 }

--- a/frontend/src/canvas/graphProjection.test.ts
+++ b/frontend/src/canvas/graphProjection.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import type { Component, Relationship } from '@/api/types'
+import type { AppliedComponent, AppliedRelationship } from '@/api/types'
 import {
   ALL_RELATIONSHIP_KINDS,
   BUNDLED_TOPIC_CHANNELS,
   NESTED_COMPONENTS,
   NESTED_RELATIONSHIPS,
+  appliedComponent,
+  appliedRelationship,
   reorder,
 } from '@/test/architectureFixtures'
 
@@ -172,23 +174,23 @@ describe('projectArchitecture — bundling and NATS topics', () => {
   })
 
   it('does not bundle across directions', () => {
-    const components: Component[] = [
-      { componentId: 'a', name: 'A', kind: 'service', parentComponentId: null },
-      { componentId: 'b', name: 'B', kind: 'service', parentComponentId: null },
+    const components: AppliedComponent[] = [
+      appliedComponent({ componentId: 'a', name: 'A', kind: 'service', parentComponentId: null }),
+      appliedComponent({ componentId: 'b', name: 'B', kind: 'service', parentComponentId: null }),
     ]
-    const relationships: Relationship[] = [
-      {
+    const relationships: AppliedRelationship[] = [
+      appliedRelationship({
         relationshipId: 'x',
         sourceComponentId: 'a',
         targetComponentId: 'b',
         kind: 'http',
-      },
-      {
+      }),
+      appliedRelationship({
         relationshipId: 'y',
         sourceComponentId: 'b',
         targetComponentId: 'a',
         kind: 'http',
-      },
+      }),
     ]
 
     const { edges } = projectArchitecture({ components, relationships })
@@ -199,14 +201,19 @@ describe('projectArchitecture — bundling and NATS topics', () => {
 
 describe('projectArchitecture — robustness', () => {
   it('renders a component with a missing parent as a root instead of dropping it', () => {
-    const components: Component[] = [
-      { componentId: 'root', name: 'Root', kind: 'system', parentComponentId: null },
-      {
+    const components: AppliedComponent[] = [
+      appliedComponent({
+        componentId: 'root',
+        name: 'Root',
+        kind: 'system',
+        parentComponentId: null,
+      }),
+      appliedComponent({
         componentId: 'orphan',
         name: 'Orphan',
         kind: 'service',
         parentComponentId: 'gone-in-this-snapshot',
-      },
+      }),
     ]
 
     const { nodes, diagnostics } = projectArchitecture({ components, relationships: [] })
@@ -221,11 +228,16 @@ describe('projectArchitecture — robustness', () => {
   })
 
   it('breaks a hierarchy cycle deterministically instead of looping forever', () => {
-    const components: Component[] = [
-      { componentId: 'c-b', name: 'B', kind: 'module', parentComponentId: 'c-a' },
-      { componentId: 'c-a', name: 'A', kind: 'module', parentComponentId: 'c-c' },
-      { componentId: 'c-c', name: 'C', kind: 'module', parentComponentId: 'c-b' },
-      { componentId: 'c-leaf', name: 'Leaf', kind: 'module', parentComponentId: 'c-c' },
+    const components: AppliedComponent[] = [
+      appliedComponent({ componentId: 'c-b', name: 'B', kind: 'module', parentComponentId: 'c-a' }),
+      appliedComponent({ componentId: 'c-a', name: 'A', kind: 'module', parentComponentId: 'c-c' }),
+      appliedComponent({ componentId: 'c-c', name: 'C', kind: 'module', parentComponentId: 'c-b' }),
+      appliedComponent({
+        componentId: 'c-leaf',
+        name: 'Leaf',
+        kind: 'module',
+        parentComponentId: 'c-c',
+      }),
     ]
 
     const { nodes, diagnostics } = projectArchitecture({ components, relationships: [] })
@@ -256,8 +268,13 @@ describe('projectArchitecture — robustness', () => {
   })
 
   it('handles a component that is its own parent', () => {
-    const components: Component[] = [
-      { componentId: 'self', name: 'Self', kind: 'module', parentComponentId: 'self' },
+    const components: AppliedComponent[] = [
+      appliedComponent({
+        componentId: 'self',
+        name: 'Self',
+        kind: 'module',
+        parentComponentId: 'self',
+      }),
     ]
 
     const { nodes, diagnostics } = projectArchitecture({ components, relationships: [] })
@@ -268,12 +285,22 @@ describe('projectArchitecture — robustness', () => {
   })
 
   it('drops relationships with an endpoint outside the snapshot and reports them', () => {
-    const components: Component[] = [
-      { componentId: 'a', name: 'A', kind: 'service', parentComponentId: null },
+    const components: AppliedComponent[] = [
+      appliedComponent({ componentId: 'a', name: 'A', kind: 'service', parentComponentId: null }),
     ]
-    const relationships: Relationship[] = [
-      { relationshipId: 'r1', sourceComponentId: 'a', targetComponentId: 'b', kind: 'http' },
-      { relationshipId: 'r2', sourceComponentId: 'z', targetComponentId: 'a', kind: 'grpc' },
+    const relationships: AppliedRelationship[] = [
+      appliedRelationship({
+        relationshipId: 'r1',
+        sourceComponentId: 'a',
+        targetComponentId: 'b',
+        kind: 'http',
+      }),
+      appliedRelationship({
+        relationshipId: 'r2',
+        sourceComponentId: 'z',
+        targetComponentId: 'a',
+        kind: 'grpc',
+      }),
     ]
 
     const { edges, diagnostics } = projectArchitecture({ components, relationships })
@@ -286,9 +313,19 @@ describe('projectArchitecture — robustness', () => {
   })
 
   it('keeps the first of two components sharing an id', () => {
-    const components: Component[] = [
-      { componentId: 'dup', name: 'First', kind: 'service', parentComponentId: null },
-      { componentId: 'dup', name: 'Second', kind: 'module', parentComponentId: null },
+    const components: AppliedComponent[] = [
+      appliedComponent({
+        componentId: 'dup',
+        name: 'First',
+        kind: 'service',
+        parentComponentId: null,
+      }),
+      appliedComponent({
+        componentId: 'dup',
+        name: 'Second',
+        kind: 'module',
+        parentComponentId: null,
+      }),
     ]
 
     const { nodes, diagnostics } = projectArchitecture({ components, relationships: [] })

--- a/frontend/src/canvas/graphProjection.ts
+++ b/frontend/src/canvas/graphProjection.ts
@@ -1,6 +1,11 @@
 import type { Edge, Node, NodeHandle, Position } from '@xyflow/react'
 
-import type { Component, ComponentId, Identifier, Relationship } from '@/api/types'
+import type {
+  AppliedComponent,
+  AppliedRelationship,
+  ComponentId,
+  Identifier,
+} from '@/api/types'
 
 import { relationshipDiscriminator, relationshipDisplayName } from './relationshipKinds'
 
@@ -81,7 +86,7 @@ export function nodeHandles(width: number, height: number): NodeHandle[] {
 }
 
 export interface ComponentNodeData extends Record<string, unknown> {
-  component: Component
+  component: AppliedComponent
   /** 0 for a root component, 1 for its children, and so on. */
   depth: number
   /** Number of direct children rendered inside this node. */
@@ -100,7 +105,7 @@ export interface RelationshipEdgeData extends Record<string, unknown> {
    * `relationshipId`. Always at least one entry — this is the list the UI
    * resolves a bundle back into.
    */
-  relationships: Relationship[]
+  relationships: AppliedRelationship[]
   /** `true` when more than one relationship shares this pair of components. */
   bundled: boolean
   /**
@@ -199,8 +204,8 @@ export function diagnosticsCount(diagnostics: ProjectionDiagnostics): number {
 // ---------------------------------------------------------------------------
 
 export interface ArchitectureModel {
-  components: readonly Component[]
-  relationships: readonly Relationship[]
+  components: readonly AppliedComponent[]
+  relationships: readonly AppliedRelationship[]
 }
 
 export interface ArchitectureProjection {
@@ -210,7 +215,7 @@ export interface ArchitectureProjection {
   edges: ArchitectureEdge[]
   diagnostics: ProjectionDiagnostics
   /** Components by id, for lookups that would otherwise re-scan the list. */
-  componentsById: Map<ComponentId, Component>
+  componentsById: Map<ComponentId, AppliedComponent>
 }
 
 export const EMPTY_DIAGNOSTICS: ProjectionDiagnostics = {
@@ -246,7 +251,7 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
   }
 
   // ---- 1. canonical component index ---------------------------------------
-  const componentsById = new Map<ComponentId, Component>()
+  const componentsById = new Map<ComponentId, AppliedComponent>()
   const sortedComponents = [...model.components].sort((a, b) =>
     compareIds(a.componentId, b.componentId),
   )
@@ -263,8 +268,11 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
   // ---- 2. resolve parents, cutting links that point nowhere ---------------
   const parentOf = new Map<ComponentId, ComponentId | null>()
   for (const [componentId, component] of componentsById) {
+    // The contract types `parentComponentId` as `ComponentId | null` and always
+    // sends the field; `ComponentId` has `minLength: 1`, so "no parent" is
+    // `null` and never an empty string. There is nothing else to guard against.
     const parentId = component.parentComponentId
-    if (parentId === null || parentId === undefined || parentId === '') {
+    if (parentId === null) {
       parentOf.set(componentId, null)
       continue
     }
@@ -365,7 +373,7 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
   }
 
   // ---- 6. relationships -> bundled edges ----------------------------------
-  const relationshipsById = new Map<Identifier, Relationship>()
+  const relationshipsById = new Map<Identifier, AppliedRelationship>()
   const sortedRelationships = [...model.relationships].sort((a, b) =>
     compareIds(a.relationshipId, b.relationshipId),
   )
@@ -379,7 +387,7 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
     relationshipsById.set(relationship.relationshipId, relationship)
   }
 
-  const bundles = new Map<string, Relationship[]>()
+  const bundles = new Map<string, AppliedRelationship[]>()
   for (const relationship of relationshipsById.values()) {
     const { sourceComponentId, targetComponentId, relationshipId } = relationship
 
@@ -413,8 +421,8 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
     .sort(compareIds)
     .map((edgeId) => {
       // Non-null: the key came from this very map.
-      const relationships = bundles.get(edgeId) as Relationship[]
-      const first = relationships[0] as Relationship
+      const relationships = bundles.get(edgeId) as AppliedRelationship[]
+      const first = relationships[0] as AppliedRelationship
       return {
         id: edgeId,
         type: RELATIONSHIP_EDGE_TYPE,
@@ -439,7 +447,7 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
 // ---------------------------------------------------------------------------
 
 export interface ResolvedRelationship {
-  relationship: Relationship
+  relationship: AppliedRelationship
   /** Index within the bundle, used for the fan-out offset. */
   index: number
   /** Number of relationships in the bundle this one belongs to. */
@@ -468,7 +476,7 @@ export function resolveEdgeBundle(edge: ArchitectureEdge): ResolvedRelationship[
 
 /** Same as `resolveEdgeBundle`, for callers that already hold the list. */
 export function resolveRelationships(
-  relationships: readonly Relationship[],
+  relationships: readonly AppliedRelationship[],
 ): ResolvedRelationship[] {
   return relationships.map((relationship, index) => ({
     relationship,

--- a/frontend/src/components/workspace/RunAgentPane.tsx
+++ b/frontend/src/components/workspace/RunAgentPane.tsx
@@ -166,8 +166,13 @@ function RunLink({
         ) : (
           <>ohne Terminalereignis</>
         )}
+        {/*
+          `RunSummary` carries no agent count — only `RunDetail.counts` does, and
+          the list endpoint does not return it. The root agent is what the
+          summary actually reports.
+        */}
         <span aria-hidden="true">·</span>
-        {run.agentCount} Agents
+        {run.rootAgentId ?? 'kein Root-Agent gemeldet'}
       </span>
     </Link>
   )

--- a/frontend/src/components/workspace/WorkspaceHeader.tsx
+++ b/frontend/src/components/workspace/WorkspaceHeader.tsx
@@ -11,14 +11,16 @@ import { useUiStore } from '@/state/uiStore'
 export interface WorkspaceHeaderProps {
   projectId: ProjectId
   runId: RunId
-  projectName?: string | undefined
 }
 
 /**
  * Top bar of the workspace: where you are, whether the stream is live and the
  * two independent pane toggles.
+ *
+ * The project is shown as its slug. The contract carries no display name for a
+ * project, and the cockpit does not invent one.
  */
-export function WorkspaceHeader({ projectId, runId, projectName }: WorkspaceHeaderProps) {
+export function WorkspaceHeader({ projectId, runId }: WorkspaceHeaderProps) {
   const leftCollapsed = useUiStore((state) => state.leftCollapsed)
   const rightCollapsed = useUiStore((state) => state.rightCollapsed)
   const toggleLeft = useUiStore((state) => state.toggleLeftCollapsed)
@@ -46,7 +48,7 @@ export function WorkspaceHeader({ projectId, runId, projectName }: WorkspaceHead
         <span aria-hidden="true" className="text-muted-foreground text-xs">
           /
         </span>
-        <span className="truncate text-sm font-medium">{projectName ?? projectId}</span>
+        <span className="truncate font-mono text-sm font-medium">{projectId}</span>
         <span aria-hidden="true" className="text-muted-foreground text-xs">
           /
         </span>

--- a/frontend/src/routes/pages/ProjectIndexPage.tsx
+++ b/frontend/src/routes/pages/ProjectIndexPage.tsx
@@ -27,9 +27,8 @@ export function ProjectIndexPage() {
         emptyTitle="Projekt nicht verfügbar"
         onRetry={() => void project.refetch()}
       >
-        <h1 className="text-xl font-semibold">
-          {project.data?.project.name ?? projectId}
-        </h1>
+        {/* A project has no display name in the contract — it is its slug. */}
+        <h1 className="font-mono text-xl font-semibold">{projectId}</h1>
         <EmptyState
           className="mt-4"
           title="Noch kein Run gemeldet"

--- a/frontend/src/routes/pages/ProjectsPage.tsx
+++ b/frontend/src/routes/pages/ProjectsPage.tsx
@@ -40,14 +40,17 @@ export function ProjectsPage() {
                       className="border-border bg-card hover:bg-accent focus-visible:ring-ring flex items-center gap-3 rounded-lg border px-4 py-3 focus-visible:ring-2 focus-visible:outline-none"
                     >
                       <span className="min-w-0 flex-1">
-                        <span className="block truncate font-medium">{project.name}</span>
-                        <span className="text-muted-foreground block truncate font-mono text-xs">
+                        {/*
+                          The contract knows no display name for a project: a
+                          project is its slug. Nothing is invented here.
+                        */}
+                        <span className="block truncate font-mono font-medium">
                           {project.projectId}
                         </span>
+                        <span className="text-muted-foreground block truncate text-xs">
+                          zuletzt gemeldet {project.lastEventAt}
+                        </span>
                       </span>
-                      <Badge variant="outline" className="text-2xs font-normal">
-                        {project.runCount} Runs
-                      </Badge>
                       <Badge variant="outline" className="text-2xs font-normal">
                         {project.currentRunId ?? 'kein aktueller Run'}
                       </Badge>

--- a/frontend/src/routes/pages/WorkspacePage.tsx
+++ b/frontend/src/routes/pages/WorkspacePage.tsx
@@ -27,7 +27,9 @@ export function WorkspacePage() {
   const search = route.useSearch()
   const navigate = route.useNavigate()
 
-  const project = useProject(projectId)
+  // Keeps the project detail subscribed so live events invalidate and refetch
+  // it. The header renders the slug — the contract has no project display name.
+  useProject(projectId)
   useLiveStream(projectId)
 
   const setSelectedComponentId = useUiStore((state) => state.setSelectedComponentId)
@@ -91,11 +93,7 @@ export function WorkspacePage() {
 
   return (
     <>
-      <WorkspaceHeader
-        projectId={projectId}
-        runId={runId}
-        projectName={project.data?.project.name}
-      />
+      <WorkspaceHeader projectId={projectId} runId={runId} />
       <WorkspaceLayout
         left={<RunAgentPane projectId={projectId} runId={runId} />}
         center={

--- a/frontend/src/routes/router.test.tsx
+++ b/frontend/src/routes/router.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
+import type { ProjectResponse } from '@/api/types'
 import { PROJECT_ID, RUN_ID, createFakeFetch } from '@/test/fixtures'
 import { renderApp } from '@/test/renderApp'
 
@@ -41,16 +42,19 @@ describe('routing', () => {
           projectPosition: 3,
           project: {
             projectId: PROJECT_ID,
-            name: 'Visualise AI',
+            firstSeenAt: '2026-08-04T09:00:00Z',
+            lastEventAt: '2026-08-04T09:00:00Z',
+            lastPosition: 3,
             currentRunId: null,
-            runCount: 0,
-            lastEventAt: null,
-            description: null,
-            firstEventAt: null,
-            componentCount: 0,
-            relationshipCount: 0,
+            counts: {
+              runs: 0,
+              openRuns: 0,
+              components: 0,
+              relationships: 0,
+              activeChanges: 0,
+            },
           },
-        },
+        } satisfies ProjectResponse,
       }),
     })
 

--- a/frontend/src/state/workStates.test.ts
+++ b/frontend/src/state/workStates.test.ts
@@ -25,6 +25,22 @@ describe('resolveWorkState', () => {
     )
   })
 
+  it('shows nothing for a retracted change — the agent withdrew it', () => {
+    expect(resolveWorkState({ change: { state: 'retracted', operation: 'add' } })).toBeNull()
+    expect(
+      resolveWorkState({ change: { state: 'retracted', operation: 'remove' } }),
+    ).toBeNull()
+  })
+
+  it('still reports a running work step when the change was retracted', () => {
+    expect(
+      resolveWorkState({
+        hasActiveWorkStep: true,
+        change: { state: 'retracted', operation: 'modify' },
+      }),
+    ).toBe('active')
+  })
+
   it('prefers a running work step over a merely planned change', () => {
     expect(
       resolveWorkState({

--- a/frontend/src/state/workStates.ts
+++ b/frontend/src/state/workStates.ts
@@ -117,9 +117,17 @@ export interface WorkStateInput {
  * Resolves the work state of a component or relationship from what was actually
  * reported. Returns `null` when nothing was reported — the element is then drawn
  * in the neutral graphite of the applied model, with no state colour at all.
+ *
+ * The contract knows three change states, not two: besides `planned` and
+ * `applied` there is `retracted`, a proposal its agent withdrew. A withdrawn
+ * proposal contributes **nothing** to the overlay — it is neither planned nor
+ * applied, and inventing a fifth colour for it would show the reviewer work
+ * that is no longer claimed. A running work step is reported independently of
+ * the change and still counts.
  */
 export function resolveWorkState(input: WorkStateInput): WorkStateId | null {
-  const { change, hasActiveWorkStep } = input
+  const { hasActiveWorkStep } = input
+  const change = input.change?.state === 'retracted' ? null : input.change
 
   if (change?.state === 'applied' && change.operation === 'remove') return 'removed'
   if (hasActiveWorkStep) return 'active'

--- a/frontend/src/test/architectureFixtures.ts
+++ b/frontend/src/test/architectureFixtures.ts
@@ -1,4 +1,6 @@
 import type {
+  AppliedComponent,
+  AppliedRelationship,
   ArchitectureResponse,
   Component,
   Relationship,
@@ -19,10 +21,68 @@ import type {
  *   is the case that must be bundled visually and stay individually resolvable,
  * * fields that the read API reports as empty strings rather than omitting them.
  *
+ * The rows below are written as the *reported* descriptors (`Component`,
+ * `Relationship`) and lifted into the read-model shapes the architecture
+ * endpoint actually answers with (`AppliedComponent`, `AppliedRelationship`) by
+ * `appliedComponent` / `appliedRelationship`. Those two builders are the single
+ * place that fills in the provenance and the empty-string defaults the contract
+ * requires, so a fixture can never accidentally describe a shape the read API
+ * does not serve.
+ *
  * It is test data only and never reaches application code.
  */
 
-export const NESTED_COMPONENTS: Component[] = [
+const APPLIED_AT = '2026-08-04T09:05:00Z'
+const APPLIED_BY_AGENT_ID = 'orchestrator-root'
+const APPLIED_RUN_ID = 'run-2026-08-04-0001'
+
+type Provenance = Partial<
+  Pick<AppliedComponent, 'appliedAt' | 'appliedByAgentId' | 'appliedRunId' | 'position'>
+>
+
+/**
+ * Lifts a reported component into the applied read model.
+ *
+ * The read API never omits an optional field — it reports "not reported" as an
+ * empty string, an empty object or an empty array.
+ */
+export function appliedComponent(
+  reported: Component,
+  provenance: Provenance = {},
+): AppliedComponent {
+  return {
+    appliedAt: APPLIED_AT,
+    appliedByAgentId: APPLIED_BY_AGENT_ID,
+    appliedRunId: APPLIED_RUN_ID,
+    position: 1,
+    ...provenance,
+    ...reported,
+    description: reported.description ?? '',
+    technology: reported.technology ?? {},
+    tags: reported.tags ?? [],
+  }
+}
+
+/** Lifts a reported relationship into the applied read model. */
+export function appliedRelationship(
+  reported: Relationship,
+  provenance: Provenance = {},
+): AppliedRelationship {
+  return {
+    appliedAt: APPLIED_AT,
+    appliedByAgentId: APPLIED_BY_AGENT_ID,
+    appliedRunId: APPLIED_RUN_ID,
+    position: 1,
+    ...provenance,
+    ...reported,
+    label: reported.label ?? '',
+    protocol: reported.protocol ?? '',
+    operation: reported.operation ?? '',
+    channel: reported.channel ?? '',
+  }
+}
+
+const REPORTED_COMPONENTS: Component[] = [
   {
     componentId: 'platform',
     name: 'Shop Platform',
@@ -110,7 +170,11 @@ export const NESTED_COMPONENTS: Component[] = [
   },
 ]
 
-export const NESTED_RELATIONSHIPS: Relationship[] = [
+export const NESTED_COMPONENTS: AppliedComponent[] = REPORTED_COMPONENTS.map(
+  (component, index) => appliedComponent(component, { position: index + 1 }),
+)
+
+const REPORTED_RELATIONSHIPS: Relationship[] = [
   {
     relationshipId: 'r-01',
     sourceComponentId: 'platform.api.http.router',
@@ -184,6 +248,11 @@ export const NESTED_RELATIONSHIPS: Relationship[] = [
   },
 ]
 
+export const NESTED_RELATIONSHIPS: AppliedRelationship[] = REPORTED_RELATIONSHIPS.map(
+  (relationship, index) =>
+    appliedRelationship(relationship, { position: REPORTED_COMPONENTS.length + index + 1 }),
+)
+
 /** The three topics that share the `orders → bus` node pair. */
 export const BUNDLED_TOPIC_CHANNELS = [
   'orders.cancelled',
@@ -215,25 +284,31 @@ export const grownArchitectureResponse: ArchitectureResponse = {
   projectPosition: 43,
   components: [
     ...NESTED_COMPONENTS,
-    {
-      componentId: 'platform.core.shipping',
-      name: 'Shipping',
-      kind: 'module',
-      parentComponentId: 'platform.core',
-      technology: { language: 'Go' },
-      tags: ['domain'],
-    },
+    appliedComponent(
+      {
+        componentId: 'platform.core.shipping',
+        name: 'Shipping',
+        kind: 'module',
+        parentComponentId: 'platform.core',
+        technology: { language: 'Go' },
+        tags: ['domain'],
+      },
+      { position: 43 },
+    ),
   ],
   relationships: [
     ...NESTED_RELATIONSHIPS,
-    {
-      relationshipId: 'r-09',
-      sourceComponentId: 'platform.core.shipping',
-      targetComponentId: 'platform.bus',
-      kind: 'nats_topic',
-      protocol: 'NATS',
-      channel: 'shipping.dispatched',
-    },
+    appliedRelationship(
+      {
+        relationshipId: 'r-09',
+        sourceComponentId: 'platform.core.shipping',
+        targetComponentId: 'platform.bus',
+        kind: 'nats_topic',
+        protocol: 'NATS',
+        channel: 'shipping.dispatched',
+      },
+      { position: 43 },
+    ),
   ],
   activeChanges: [],
 }

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -1,16 +1,16 @@
 import type {
-  Agent,
-  AgentsResponse,
+  AgentListResponse,
+  AppliedComponent,
   ArchitectureResponse,
-  Component,
   ComponentHistoryResponse,
   ComponentInspectorResponse,
   EventType,
-  PlansResponse,
+  PlanListResponse,
+  ProjectListResponse,
   ProjectResponse,
-  ProjectsResponse,
+  RunAgent,
+  RunListResponse,
   RunResponse,
-  RunsResponse,
   StreamedEvent,
   StreamedEventOf,
 } from '@/api/types'
@@ -25,17 +25,29 @@ import type {
 export const PROJECT_ID = 'visualise-ai'
 export const RUN_ID = 'run-2026-08-04-0001'
 
-export function component(overrides: Partial<Component> = {}): Component {
+export function component(overrides: Partial<AppliedComponent> = {}): AppliedComponent {
   return {
     componentId: 'shop-platform.orders.domain',
     name: 'Orders Domain',
     kind: 'module',
     parentComponentId: null,
+    description: '',
+    technology: {},
+    tags: [],
+    appliedAt: '2026-08-04T09:05:00Z',
+    appliedByAgentId: 'orchestrator-root',
+    appliedRunId: RUN_ID,
+    position: 7,
     ...overrides,
   }
 }
 
-export function agent(overrides: Partial<Agent> = {}): Agent {
+/**
+ * `RunAgent` reports "nothing was reported" as an empty string, not as `null`,
+ * and carries no `capabilities`, no `summary` and no `statusReportedAt` — those
+ * live on the events, not on the projection.
+ */
+export function agent(overrides: Partial<RunAgent> = {}): RunAgent {
   return {
     agentId: 'orchestrator-root',
     runId: RUN_ID,
@@ -43,15 +55,13 @@ export function agent(overrides: Partial<Agent> = {}): Agent {
     role: 'orchestrator',
     displayName: 'Orchestrator',
     assignedTask: 'Koordiniert den Run.',
-    capabilities: [],
     status: 'working',
-    statusNote: null,
-    statusReportedAt: '2026-08-04T09:12:00Z',
+    statusNote: '',
     progress: null,
-    outcome: null,
-    summary: null,
+    finishedOutcome: null,
     startedAt: '2026-08-04T09:00:00Z',
     lastEventAt: '2026-08-04T09:12:00Z',
+    position: 12,
     ...overrides,
   }
 }
@@ -78,15 +88,15 @@ export function streamedEvent<T extends EventType>(
   } as StreamedEvent
 }
 
-export const projectsResponse: ProjectsResponse = {
+export const projectsResponse: ProjectListResponse = {
   projectPosition: 42,
   projects: [
     {
       projectId: PROJECT_ID,
-      name: 'Visualise AI',
-      currentRunId: RUN_ID,
-      runCount: 1,
+      firstSeenAt: '2026-08-04T09:00:00Z',
       lastEventAt: '2026-08-04T09:12:00Z',
+      lastPosition: 42,
+      currentRunId: RUN_ID,
     },
   ],
 }
@@ -95,14 +105,17 @@ export const projectResponse: ProjectResponse = {
   projectPosition: 42,
   project: {
     projectId: PROJECT_ID,
-    name: 'Visualise AI',
-    currentRunId: RUN_ID,
-    runCount: 1,
+    firstSeenAt: '2026-08-04T09:00:00Z',
     lastEventAt: '2026-08-04T09:12:00Z',
-    description: null,
-    firstEventAt: '2026-08-04T09:00:00Z',
-    componentCount: 1,
-    relationshipCount: 0,
+    lastPosition: 42,
+    currentRunId: RUN_ID,
+    counts: {
+      runs: 1,
+      openRuns: 1,
+      components: 1,
+      relationships: 0,
+      activeChanges: 0,
+    },
   },
 }
 
@@ -113,18 +126,18 @@ export const architectureResponse: ArchitectureResponse = {
   activeChanges: [],
 }
 
-export const runsResponse: RunsResponse = {
+export const runsResponse: RunListResponse = {
   projectPosition: 42,
   runs: [
     {
       runId: RUN_ID,
-      projectId: PROJECT_ID,
+      rootAgentId: 'orchestrator-root',
       startedAt: '2026-08-04T09:00:00Z',
-      lastEventAt: '2026-08-04T09:12:00Z',
-      outcome: null,
       finishedAt: null,
-      orchestratorAgentId: 'orchestrator-root',
-      agentCount: 1,
+      outcome: null,
+      isOpen: true,
+      isCurrent: true,
+      position: 42,
     },
   ],
   nextCursor: null,
@@ -132,23 +145,28 @@ export const runsResponse: RunsResponse = {
 
 export const runResponse: RunResponse = {
   projectPosition: 42,
-  run: { ...runsResponse.runs[0]!, summary: null },
+  run: {
+    ...runsResponse.runs[0]!,
+    counts: { agents: 1, plans: 0, workSteps: 0 },
+  },
 }
 
-export const agentsResponse: AgentsResponse = {
+export const agentsResponse: AgentListResponse = {
   projectPosition: 42,
   agents: [agent()],
 }
 
-export const plansResponse: PlansResponse = { projectPosition: 42, plans: [] }
+export const plansResponse: PlanListResponse = { projectPosition: 42, plans: [] }
 
 export const inspectorResponse: ComponentInspectorResponse = {
   projectPosition: 42,
+  runId: RUN_ID,
   component: component(),
   responsibleAgent: agent(),
   currentWorkStep: null,
   feedback: [],
   diffs: [],
+  nextDiffCursor: null,
   risks: [],
   problems: [],
   activeChanges: [],


### PR DESCRIPTION
Vertragskorrektur, kein Issue. Bereitet #10 (Live-Overlays), #11 (Agentbaum) und #12 (Inspector) vor, die alle auf diesen Typen aufbauen. Der Befund stammt aus der Arbeit an #24.

## Warum

`frontend/src/api/types.ts` schrieb im eigenen Header, die Typen seien „von Hand aus `api/openapi.yaml` abgeleitet" und es gebe „bewusst keinen Codegenerierungsschritt". Das beschrieb ehrlich, wie die Datei entstand — und war innerhalb eines Arbeitspakets falsch. Frontend-Shell (#7) und Read API (#8) wurden parallel gegen denselben Issue-Text gebaut statt gegen das fertige Dokument. TypeScript konnte den Versatz nicht bemerken: nichts im Frontend hat je eine echte Antwort zur Compilezeit gesehen.

## Gefundene Abweichungen

| handgeschrieben | `api/openapi.yaml` |
| --- | --- |
| `ActiveChange.target`, `componentId`, `relationshipId` | `targetKind`, `targetId` |
| `ActiveChange.reportedAt` | `plannedAt`, `appliedAt`, `retractedAt` |
| `ActiveChange.state: planned \| applied` | zusätzlich `retracted` |
| — fehlte — | `ActiveChange.snapshot` (Deskriptor verbatim) |
| `Component`, `Relationship` als Read Models | `AppliedComponent`, `AppliedRelationship` mit Provenienz |
| `Agent` (`capabilities`, `summary`, `statusReportedAt`) | `RunAgent` (keins davon; `finishedOutcome`) |
| `ProjectSummary.name`, `runCount` | existieren nicht; `firstSeenAt`, `lastPosition`, `counts` schon |
| `RunSummary.agentCount`, `projectId`, `lastEventAt` | `rootAgentId`, `isOpen`, `isCurrent`, `position` |
| `Plan`, `WorkStep`, `Feedback`, `Diff`, `Risk`, `HistoryEntry` | `RunPlan`, `InspectorWorkStep`, `FeedbackEntry`, `ReportedDiff`, `ReportedRisk`, `ComponentHistoryEntry` |
| `ProjectsResponse`, `RunsResponse`, `AgentsResponse`, `PlansResponse` | `ProjectListResponse`, `RunListResponse`, `AgentListResponse`, `PlanListResponse` |
| `ValidationErrorDetail` | `ValidationError` |

**Drei davon waren keine Umbenennungen, sondern echte Fehler.** `ProjectsPage`, `WorkspaceHeader` und `RunAgentPane` rendern `project.name`, `project.runCount` und `run.agentCount` — Felder, die die API nie gesendet hat. Gegen ein echtes Backend zeigten sie `undefined`. Behoben: Projektliste und Workspace-Header zeigen den Slug (der Vertrag kennt keinen Anzeigenamen für ein Projekt, und das Cockpit erfindet keinen), die Runliste zeigt `rootAgentId` (`RunSummary` hat keine Agent-Anzahl — nur `RunDetail.counts`, auf einem anderen Endpunkt).

Kein Feld erfunden, keine Zeile am Vertrag geändert (`git diff api/` ist leer).

## Was sich ändert

- `openapi-typescript` als devDependency, `npm run generate:contract` erzeugt `src/api/generated/contract.ts`.
- `types.ts` definiert **keine Form mehr**: jeder Export ist ein Alias in die generierte Datei. Die Alias-Schicht bleibt, damit App-Code `ActiveChange` schreibt statt `components['schemas']['ActiveChange']`.
- Die generierte Datei ist eingecheckt, weil das Frontend-Image mit `frontend/` als Docker-Kontext baut und `../api` dort nicht existiert — dieselbe Begründung wie beim eingebetteten Vertrag des Backends (ADR 0004).
- `--empty-objects-unknown`: `ActiveChange.snapshot` und jedes `payload` sind im Vertrag absichtlich formfreie Objekte. Die Voreinstellung `Record<string, never>` würde das Gegenteil behaupten und jede Verengung zu `never` machen. `changeSnapshot()` verengt stattdessen über den vertragseigenen Diskriminator `targetKind`.
- `EVENT_TYPES` bleibt handgeschrieben (die SSE-Anmeldung braucht die Liste zur Laufzeit), aber mit `satisfies readonly EventType[]` plus Vollständigkeitsprüfung auf Typebene.
- `graphProjection`: die Leerstring-Notmaßnahme für `parentComponentId` ist weg — der Vertrag typisiert das Feld als `ComponentId | null` mit `minLength: 1`.
- `resolveWorkState`: expliziter `retracted`-Zweig. Ein zurückgezogener Vorschlag trägt nichts zum Overlay bei, statt durch einen unbedachten Pfad zu fallen.

## Drift-Guard — nachweislich rot

`src/api/contractDrift.test.ts` führt `scripts/generate-contract.mjs --check` aus (neu erzeugen, byteweise vergleichen) und prüft zusätzlich den sha256 im Header gegen den der Autorität auf der Platte.

Beide Fehlerfälle wurden reproduziert, bevor das akzeptiert wurde:

- Ein Feld zu `ActiveChange` in `api/openapi.yaml` hinzugefügt → beide Assertions rot, Spec zurückgesetzt.
- Eine Zeile der generierten Datei von Hand geändert → Bytevergleich rot, neu generiert.

## Realer Gegencheck

Stack gestartet (`FRONTEND_HTTP_PORT=8096 docker compose -p vai-types up --build -d`), Simulator mit 62 Ereignissen durchgespielt, dann **jede** Read-Antwort mit Ajv gegen ihr Schema aus `api/openapi.yaml` validiert — `/projects`, `/projects/{id}`, `/architecture`, `/runs`, `/runs/current`, `/runs/{id}`, `/agents`, `/plans` sowie Inspector und History **aller 17** Komponenten des angewandten Modells.

**42 Antworten, alle gültig.** Keine echte Antwort ist gegen ihr Schema durchgefallen: Spec und Implementierung stimmen überein, nur das Frontend war aus dem Tritt. Die laufende UI wurde zusätzlich im Browser gegen das echte Backend geprüft (17 Komponenten, 11 Beziehungen, 2 aktive Änderungen, keine Konsolenfehler).

## Qualität

`npm run lint`, `npm run typecheck`, `npm test` (105 Tests, vorher 101 + 2 Drift-Guard + 2 `retracted`), `npm run build` grün. `docker build -t vai-types-check ./frontend` läuft durch, Image entfernt.

Angepasste Tests: die Canvas-Fixtures bauen ihre Read Models jetzt über `appliedComponent` / `appliedRelationship`, damit eine Fixture keine Form beschreiben kann, die die API nicht liefert. `router.test.tsx` und `src/test/fixtures.ts` folgen den Vertragsformen.

## Entscheidungsdokument

`docs/decisions/0009-generated-frontend-contract-types.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
