### PR TITLE
[v0] Run- und Agenthierarchie mit Fortschritt umsetzen

### DIFF
--- a/docs/decisions/0011-run-and-agent-hierarchy.md
+++ b/docs/decisions/0011-run-and-agent-hierarchy.md
@@ -1,0 +1,188 @@
+# 11. Run and agent hierarchy: estimates that cannot be mistaken for measurements
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #11 (part of the v0 epic #1)
+- **Builds on:** [0003 — Frontend state split and live updates](./0003-frontend-state-split-and-live-updates.md),
+  [0005 — Read API shape and run scoping](./0005-read-api-shape-and-run-scoping.md),
+  [0009 — Generated frontend contract types](./0009-generated-frontend-contract-types.md)
+
+## Context
+
+The left pane answers one question: *what are the agents doing right now, and
+what did they say about it?* Everything it shows is a report — an agent's own
+account of its work — and the pane has no independent way to check any of it.
+That is the product boundary of v0: the cockpit observes and the human judges
+(#1).
+
+Four things make that boundary easy to violate by accident:
+
+- The contract carries two unrelated percentages under the same field name.
+  A subagent reporting `70 %` about its own extraction task and an orchestrator
+  reporting `20 %` about the whole run are different kinds of sentence, and the
+  obvious rendering — two progress bars under each other — silently claims they
+  are comparable.
+- `agent.progress_reported` distinguishes `basis: reported_estimate` from
+  `basis: completed_steps`. A guess and a count look identical once both are a
+  filled bar.
+- The agent list arrives flat, with the hierarchy in `parentAgentId`. Whoever
+  builds the tree owns what happens when that field does not describe a tree.
+- Silence is the normal state of an agent between two events. Any code that
+  reacts to it invents a fact.
+
+## Decision
+
+### Estimates and counted facts get different shapes, not different colours
+
+The pane has exactly two renderings for a number, and they share no geometry:
+
+| | Counted fact | Reported claim |
+| --- | --- | --- |
+| Shape | a row of discrete segments, filled from the left | no track, no fill at all |
+| Semantics | `role="progressbar"` with `aria-valuenow`/`aria-valuemax` | plain text, no ARIA value |
+| Marker | — | a leading `≈` that is part of the value |
+| Attribution | — | "Gemeldete Selbsteinschätzung von *Agent*" |
+| Used for | `scope: own_task` **and** `basis: completed_steps`; completed plan steps of one revision | everything else |
+
+The segments are the point. A counted quantity is drawn as something the reader
+can literally count — ten segments for a percentage, one segment per step for a
+plan revision — because the underlying thing *is* countable. A claim gets no
+track, because there is nothing to measure it against; drawing an empty
+remainder next to it would invent a scale that nobody reported.
+
+Colour is not the carrier. The two forms differ in geometry, in ARIA role and in
+wording, so the distinction survives greyscale, a colour vision deficiency and a
+screenshot — the same rule `src/state/workStates.ts` already follows (ADR 0003).
+The tests assert the separation structurally: segment counts, the absence of a
+`progressbar` role on a claim, and the fact that neither element contains the
+other.
+
+**An orchestrator's overall estimate is always a claim, whatever basis it
+names.** Even `scope: overall_estimate` with `basis: completed_steps` renders as
+a claim, because nothing in v0 can count the steps of a whole run: the plans of a
+run are themselves reports, subagents can be spawned at any moment, and no agent
+knows what the others will still do. The `basis` field says how *that agent*
+arrived at its number, not that the number is checkable. `scope: null` and
+`basis: null` land in the claim form for the same reason — an unqualified
+percentage is not a measurement.
+
+The alternative — one bar, with the estimate drawn in a lighter shade — was
+rejected. It reads as "the same quantity, less certain", which is precisely the
+sentence the contract's two scopes exist to prevent. Aggregating the subagent
+percentages into a run-level number was rejected for the same reason and one
+more: it would be the cockpit's own progress claim, and the cockpit does not make
+claims about agent work.
+
+### There is no stall detection, and no clock is consulted
+
+`lastEventAt` is rendered as a timestamp and compared against nothing. There is
+no timeout, no "no events for n minutes", no inferred `blocked`, and no visual
+decay of an old row. A run without `run.finished` is described as *"offen — kein
+Terminalereignis gemeldet"*, which is a statement about the log, not about the
+agent.
+
+This is not caution, it is correctness. A long silence is indistinguishable from
+deep work, from a slow tool call, from a paused sandbox and from a crash, and the
+cockpit sees none of the four. A heuristic would therefore produce a verdict the
+data does not support — and it would produce it exactly when the user is trying
+to decide whether to intervene, which is the moment a wrong signal costs the
+most. Judging whether work has run off the rails is the user's job by product
+definition (#1).
+
+Concretely, `src/components/workspace/runAgents/reporting.ts` contains no time
+arithmetic at all, every "nothing was reported" case has its own explicit label
+("kein Status gemeldet", "kein Abschluss gemeldet", "kein Ende gemeldet"), and a
+test asserts that the rendered pane contains none of the derived-verdict
+vocabulary.
+
+### The tree is built on the client, and malformed edges are shown, not hidden
+
+`GET /runs/{runId}/agents` answers flat and expresses the hierarchy only through
+`parentAgentId`, so that the server never has to commit to a maximum spawn depth
+(ADR 0005). `buildAgentTree` turns that into a tree in a single pass and is a
+pure module with no React in it, so its rules are testable without rendering.
+
+Because every agent has at most one parent, the relation is a functional graph:
+each connected component contains at most one cycle. Walking upwards with an
+explicit "currently on this path" mark therefore finds every cycle once, in
+linear time, and the node the walk re-enters is the one whose upward edge is cut.
+Three malformed shapes have a defined result:
+
+| Input | Result |
+| --- | --- |
+| `parentAgentId` names an agent outside the run | the agent becomes a root, flagged `orphaned`, with a note naming the missing parent |
+| the parent chain closes a cycle, self-parenting included | exactly one member is promoted to a root, flagged `cycle_broken`, with a note that the edge was cut |
+| the same `agentId` appears twice | the first occurrence wins; the rest are reported in `duplicateAgentIds` |
+
+No agent is ever dropped. Only the *edge* the data could not support disappears,
+and the row says so — hiding a malformed node would hide the fact that the report
+was malformed, which is information about the agent the user is watching. The
+depth pass is iterative and guarded by a seen-set rather than recursive, so even
+a wrong cycle analysis could not produce a stack overflow or an endless walk.
+
+Rows are rendered as one flat list with an indent per level instead of nested
+lists. A run with many spawns then scrolls as a single column rather than
+drifting off the right edge of a 346 px pane, and collapsing a branch changes
+which rows are produced rather than the DOM around them. Collapse state is keyed
+by agent id in the persisted UI store, so a new subagent arriving live cannot
+fold something the user had opened.
+
+### Plan revisions are shown in full, never replaced
+
+Every revision of every plan is rendered, ascending, with all of its steps.
+Revisions are append-only by contract — a `plan.step_updated` only reaches the
+revision that was current when it was reported — so an earlier revision keeps
+exactly the states it was last seen with. Showing only `currentRevision` would
+make a re-plan invisible, and a re-plan is one of the few moments where an agent
+visibly changes its mind. Older revisions are receded but never collapsed away:
+what changed between revision 1 and revision 2 has to be readable without an
+interaction.
+
+### A historical run is a different URL, announced before anything else
+
+The current run is resolved through `/runs/current` rather than by scanning the
+paged run list for `isCurrent`: the list is cursor-paged, so that scan would
+silently stop working once the current run is not on the first page. The
+contract's `404 current_run_not_found` is a state, not a failure, and resolves to
+`null` and an empty state.
+
+Selecting a historical run navigates to its own route. The pane then shows a
+banner naming the current run and carrying the link back, and the "Aktueller
+Run" marker disappears. Nothing merges: the agent tree, the plans and the run
+state all come from the run in the URL, and a test asserts that no agent of the
+current run appears while a historical one is open.
+
+### Live events reach one node, and selection is not in the cache
+
+The three queries of the pane are keyed per run through the central factory, so
+`agent.progress_reported` invalidates `agents(project, run)` and nothing else —
+the architecture and the plans are provably not refetched (asserted by counting
+requests per path). Selection lives in component state and collapse state in the
+UI store; neither is in the query cache, so a refetch cannot move either.
+
+The one addition to the key factory is `currentRun(projectId)`, nested **below**
+`runs(projectId)`. `run.finished` already invalidates that prefix, so closing a
+run refreshes the current-run pointer without a new entry in the event →
+query-key map — the map stays exactly as ADR 0003 defined it.
+
+## Consequences
+
+- A future "overall run progress" feature cannot be added by aggregating agent
+  percentages without re-opening this decision. That is intended.
+- `ProgressForm` is decided by `scope` **and** `basis` together, so an agent
+  cannot obtain a meter by claiming `completed_steps` for the whole run. An agent
+  that wants a meter has to scope its report to its own task, which is the honest
+  claim.
+- The pane will never tell a user that an agent is stuck. Users watching a run
+  that genuinely died will see a timestamp that stops advancing and have to draw
+  the conclusion themselves. This is the accepted cost of not producing false
+  verdicts, and it is why the last reported timestamp is shown on every row
+  rather than only on hover.
+- `buildAgentTree` accepts input the API should never produce. That code is
+  reachable only through a backend bug, and it exists because the alternative to
+  a defined result is a hung tab in the one tool the user opened to find out what
+  went wrong.
+- Test data for the pane lives in `src/test/runFixtures.ts` and mirrors the
+  simulator's `full` scenario — five agents three levels deep, both progress
+  scopes, two plan revisions, no terminal event. Divergence between the two would
+  make the test suite and the visual acceptance disagree.

--- a/frontend/src/api/currentRun.ts
+++ b/frontend/src/api/currentRun.ts
@@ -1,0 +1,51 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+
+import { fetchJson } from './fetchJson'
+import { isProblemError } from './problem'
+import { queryKeys } from './queryKeys'
+import type { ProjectId, RunDetail, RunResponse } from './types'
+
+/**
+ * The project's current run, resolved through the contract's `current` alias.
+ *
+ * ADR 0005 makes "the current run" its own endpoint rather than a flag on the
+ * list, and this hook is why that matters here: the run list is cursor-paged, so
+ * scanning it for `isCurrent` would silently stop working as soon as the current
+ * run is not on the first page. `/runs/current` answers the question directly.
+ *
+ * **A project without a current run is not an error.** The contract reports it
+ * as `404 current_run_not_found`, explicitly distinct from "this run id is
+ * wrong", so that case resolves to `null` and the pane renders an empty state.
+ * Every other failure still surfaces as an error.
+ *
+ * The query key is nested **below** `queryKeys.runs(projectId)` on purpose:
+ * `run.finished` already invalidates that prefix, so closing a run refreshes the
+ * current-run pointer without adding an entry to the event → query-key map.
+ */
+export const CURRENT_RUN_ALIAS = 'current'
+
+/** The contract's code for "this project never saw a root orchestrator". */
+export const CURRENT_RUN_NOT_FOUND = 'current_run_not_found'
+
+export function currentRunQuery(projectId: ProjectId) {
+  return queryOptions({
+    queryKey: queryKeys.currentRun(projectId),
+    queryFn: async ({ signal }): Promise<RunDetail | null> => {
+      try {
+        const response = await fetchJson<RunResponse>(
+          `/projects/${encodeURIComponent(projectId)}/runs/${CURRENT_RUN_ALIAS}`,
+          { signal },
+        )
+        return response.run
+      } catch (error) {
+        if (isProblemError(error) && error.status === 404) return null
+        throw error
+      }
+    },
+  })
+}
+
+/** `GET /projects/{projectId}/runs/current` — `null` when there is none. */
+export function useCurrentRun(projectId: ProjectId) {
+  return useQuery(currentRunQuery(projectId))
+}

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -19,6 +19,7 @@ import type { ComponentId, ProjectId, RunId } from './types'
  *         └ 'detail'                            projectDetail()
  *         └ 'architecture'                      architecture()
  *         └ 'runs'                              runs()              paged list
+ *             └ 'current'                       currentRun()        `current` alias
  *         └ 'run', runId                        run()               run scope
  *             └ 'detail'                        runDetail()
  *             └ 'agents'                        agents()
@@ -48,6 +49,16 @@ export const queryKeys = {
   /** Paged run list of a project. */
   runs: (projectId: ProjectId) =>
     [...queryKeys.project(projectId), 'runs'] as const,
+
+  /**
+   * The `current` alias of `GET /runs/{runId}`.
+   *
+   * Nested below `runs` on purpose: `run.finished` already invalidates that
+   * prefix, so closing a run refreshes the current-run pointer without adding
+   * an entry to the event → query-key map.
+   */
+  currentRun: (projectId: ProjectId) =>
+    [...queryKeys.runs(projectId), 'current'] as const,
 
   /** Scope of one run: prefix of run detail, agents and plans. */
   run: (projectId: ProjectId, runId: RunId) =>

--- a/frontend/src/components/workspace/RunAgentPane.test.tsx
+++ b/frontend/src/components/workspace/RunAgentPane.test.tsx
@@ -1,0 +1,460 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { act, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { applyLiveEvent } from '@/api/useLiveStream'
+import type { AgentListResponse } from '@/api/types'
+import { PROJECT_ID, RUN_ID, createFakeFetch, streamedEvent } from '@/test/fixtures'
+import { renderApp } from '@/test/renderApp'
+import {
+  HISTORICAL_RUN_ID,
+  historicalAgentsResponse,
+  historicalPlansResponse,
+  historicalRunResponse,
+  openRunResponse,
+  runPaths,
+  runsWithHistoryResponse,
+  treeAgentsResponse,
+  twoRevisionPlansResponse,
+} from '@/test/runFixtures'
+
+const WORKSPACE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}`
+const HISTORICAL_URL = `/projects/${PROJECT_ID}/runs/${HISTORICAL_RUN_ID}`
+
+/**
+ * Words the pane must never produce: every one of them would be a verdict
+ * derived from silence rather than something an agent reported.
+ */
+const DERIVED_VERDICTS =
+  /\bstall\w*|steht still|hängt\b|hängen\b|\btimeout\b|abgelaufen|vermutlich|wahrscheinlich|inaktiv|\btot\b|abgestürzt|reagiert nicht|keine Rückmeldung seit/i
+
+interface Harness {
+  fetchImpl: typeof fetch
+  /** Number of requests per exact path, so a narrow invalidation is provable. */
+  calls: Map<string, number>
+  /** Replaces the body served for `/agents`, simulating a projection update. */
+  setAgents: (response: AgentListResponse) => void
+}
+
+function harness(extraOverrides: Record<string, unknown> = {}): Harness {
+  const calls = new Map<string, number>()
+  let agents: AgentListResponse = treeAgentsResponse
+
+  const inner = createFakeFetch({
+    [runPaths.runs]: runsWithHistoryResponse,
+    [runPaths.currentRun]: openRunResponse,
+    [runPaths.runDetail]: openRunResponse,
+    [runPaths.agents]: () => json(agents),
+    [runPaths.plans]: twoRevisionPlansResponse,
+    [runPaths.historicalRunDetail]: historicalRunResponse,
+    [runPaths.historicalAgents]: historicalAgentsResponse,
+    [runPaths.historicalPlans]: historicalPlansResponse,
+    ...extraOverrides,
+  })
+
+  const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const path = url.split('?')[0] ?? url
+    calls.set(path, (calls.get(path) ?? 0) + 1)
+    return inner(input, init)
+  }) as typeof fetch
+
+  return {
+    fetchImpl,
+    calls,
+    setAgents: (response) => {
+      agents = response
+    },
+  }
+}
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function problem(status: number, code: string): Response {
+  return new Response(
+    JSON.stringify({
+      type: `https://visualise.ai/problems/${code}`,
+      title: code,
+      status,
+      detail: code,
+      code,
+    }),
+    { status, headers: { 'Content-Type': 'application/problem+json' } },
+  )
+}
+
+async function renderPane(url = WORKSPACE_URL, extraOverrides: Record<string, unknown> = {}) {
+  const test = harness(extraOverrides)
+  const app = renderApp(url, { fetchImpl: test.fetchImpl })
+  await screen.findByTestId('agent-tree')
+  return { ...app, ...test }
+}
+
+// ---------------------------------------------------------------------------
+// Hierarchy
+// ---------------------------------------------------------------------------
+
+describe('agent hierarchy in the pane', () => {
+  it('renders the root agent and its nested subagents at their reported depth', async () => {
+    await renderPane()
+
+    expect(screen.getByTestId('agent-row-orchestrator-root')).toHaveAttribute('data-depth', '0')
+    expect(screen.getByTestId('agent-row-subagent-architect')).toHaveAttribute('data-depth', '1')
+    expect(screen.getByTestId('agent-row-subagent-implementer')).toHaveAttribute(
+      'data-depth',
+      '1',
+    )
+    expect(screen.getByTestId('agent-row-subagent-reviewer')).toHaveAttribute('data-depth', '2')
+    expect(screen.getByTestId('agent-row-subagent-tester')).toHaveAttribute('data-depth', '3')
+    expect(screen.getByRole('list', { name: 'Agenthierarchie' })).toHaveAttribute(
+      'data-max-depth',
+      '3',
+    )
+  })
+
+  it('shows role, assigned task, last reported time and the explicit status', async () => {
+    await renderPane()
+
+    const row = screen.getByTestId('agent-row-subagent-implementer')
+    expect(within(row).getByText('Subagent')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-task-subagent-implementer')).toHaveTextContent(
+      'VAT-Behandlung in ein eigenes Modul verschieben.',
+    )
+    expect(screen.getByTestId('agent-status-subagent-implementer')).toHaveAttribute(
+      'data-status',
+      'working',
+    )
+    expect(screen.getByTestId('agent-last-event-subagent-implementer')).toHaveTextContent(
+      '04.08.2026, 09:06:31 UTC',
+    )
+  })
+
+  it('says so when an agent never reported a status or a number', async () => {
+    await renderPane()
+
+    expect(screen.getByTestId('agent-status-subagent-tester')).toHaveTextContent(
+      'kein Status gemeldet',
+    )
+    expect(screen.getByTestId('agent-progress-subagent-tester')).toHaveAttribute(
+      'data-progress-form',
+      'none',
+    )
+  })
+
+  it('collapses a branch without losing the agent that owns it', async () => {
+    const user = userEvent.setup()
+    await renderPane()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Subagents von Implementer einklappen' }),
+    )
+
+    expect(screen.getByTestId('agent-row-subagent-implementer')).toBeInTheDocument()
+    expect(screen.queryByTestId('agent-row-subagent-reviewer')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('agent-row-subagent-tester')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Live updates
+// ---------------------------------------------------------------------------
+
+describe('live updates', () => {
+  it('updates only the affected node and keeps the selection', async () => {
+    const user = userEvent.setup()
+    const { queryClient, calls, setAgents } = await renderPane()
+
+    // The user selects a node and reads it.
+    const selectImplementer = within(
+      screen.getByTestId('agent-row-subagent-implementer'),
+    ).getByRole('button', { pressed: false })
+    await user.click(selectImplementer)
+    expect(selectImplementer).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('agent-row-subagent-implementer')).toHaveAttribute(
+      'data-selected',
+      'true',
+    )
+
+    const architectureCallsBefore = calls.get(runPaths.architecture) ?? 0
+    const planCallsBefore = calls.get(runPaths.plans) ?? 0
+    const reviewerBefore = screen.getByTestId('agent-progress-subagent-reviewer').textContent
+
+    // The implementer reports 90 %; nothing else about the run changed.
+    setAgents({
+      ...treeAgentsResponse,
+      agents: treeAgentsResponse.agents.map((agent) =>
+        agent.agentId === 'subagent-implementer'
+          ? {
+              ...agent,
+              progress: { percent: 90, scope: 'own_task', basis: 'completed_steps' },
+              lastEventAt: '2026-08-04T09:08:00Z',
+            }
+          : agent,
+      ),
+    })
+
+    await act(async () => {
+      applyLiveEvent(
+        queryClient as QueryClient,
+        streamedEvent(
+          'agent.progress_reported',
+          { percent: 90, scope: 'own_task', basis: 'completed_steps', note: '' },
+          { agentId: 'subagent-implementer', position: 63 },
+        ),
+      )
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-progress-subagent-implementer')).toHaveTextContent(
+        '90 %',
+      ),
+    )
+
+    // The selection survived the refetch …
+    expect(
+      within(screen.getByTestId('agent-row-subagent-implementer')).getByRole('button', {
+        pressed: true,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('agent-row-subagent-implementer')).toHaveAttribute(
+      'data-selected',
+      'true',
+    )
+
+    // … the sibling node is untouched …
+    expect(screen.getByTestId('agent-progress-subagent-reviewer').textContent).toBe(
+      reviewerBefore,
+    )
+
+    // … and nothing outside the agent list was refetched.
+    expect(calls.get(runPaths.architecture) ?? 0).toBe(architectureCallsBefore)
+    expect(calls.get(runPaths.plans) ?? 0).toBe(planCallsBefore)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Open runs and silence
+// ---------------------------------------------------------------------------
+
+describe('a run without a terminal event', () => {
+  it('stays open and shows the last reported state, deriving nothing from silence', async () => {
+    const { container } = await renderPane()
+
+    const openness = screen.getByTestId('run-openness')
+    expect(openness).toHaveAttribute('data-open', 'true')
+    expect(openness).toHaveTextContent('offen — kein Terminalereignis gemeldet')
+
+    // The run reported no end, and the pane says exactly that.
+    expect(screen.getByTestId('run-state')).toHaveTextContent('kein Ende gemeldet')
+
+    // Agents keep the status they last reported, however old the timestamp is.
+    expect(screen.getByTestId('agent-status-orchestrator-root')).toHaveTextContent('arbeitet')
+    expect(screen.getByTestId('agent-outcome-orchestrator-root')).toHaveTextContent(
+      'kein Abschluss gemeldet',
+    )
+    expect(screen.getByTestId('agent-status-subagent-reviewer')).toHaveTextContent('wartet')
+
+    // No timeout, no heuristic, no "seems stuck" anywhere in the pane.
+    const pane = container.querySelector('[data-testid="pane-run-agents"]')
+    expect(pane?.textContent ?? '').not.toMatch(DERIVED_VERDICTS)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Current versus historical run
+// ---------------------------------------------------------------------------
+
+describe('run selection', () => {
+  it('marks the current run and shows no historical banner on it', async () => {
+    await renderPane()
+
+    expect(screen.getByTestId('current-run-banner')).toBeInTheDocument()
+    expect(screen.queryByTestId('historical-run-banner')).not.toBeInTheDocument()
+    expect(screen.getByTestId(`run-option-${RUN_ID}`)).toHaveAttribute('data-current', 'true')
+  })
+
+  it('never lets a historical run overlay the current run view', async () => {
+    await renderPane(HISTORICAL_URL)
+
+    // The switch is announced before anything else, and offers the way back.
+    const banner = screen.getByTestId('historical-run-banner')
+    expect(banner).toHaveTextContent('Historischer Run')
+    expect(banner).toHaveTextContent(RUN_ID)
+    expect(screen.getByTestId('back-to-current-run')).toHaveAttribute(
+      'href',
+      `/projects/${PROJECT_ID}/runs/${RUN_ID}`,
+    )
+    expect(screen.queryByTestId('current-run-banner')).not.toBeInTheDocument()
+
+    // Only the historical run's agents are shown — the two runs never mix.
+    expect(screen.getByTestId('pane-run-agents')).toHaveAttribute(
+      'data-run-id',
+      HISTORICAL_RUN_ID,
+    )
+    expect(screen.getByTestId('agent-row-orchestrator-yesterday')).toHaveAttribute(
+      'data-run-id',
+      HISTORICAL_RUN_ID,
+    )
+    for (const agentId of ['orchestrator-root', 'subagent-implementer', 'subagent-reviewer']) {
+      expect(screen.queryByTestId(`agent-row-${agentId}`)).not.toBeInTheDocument()
+    }
+  })
+
+  it('reaches a historical run only through an explicit navigation', async () => {
+    const user = userEvent.setup()
+    const { router } = await renderPane()
+
+    expect(router.state.location.pathname).toBe(WORKSPACE_URL)
+    await user.click(screen.getByTestId(`run-option-${HISTORICAL_RUN_ID}`))
+
+    await waitFor(() => expect(router.state.location.pathname).toBe(HISTORICAL_URL))
+    expect(await screen.findByTestId('historical-run-banner')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Progress: two kinds of statement
+// ---------------------------------------------------------------------------
+
+describe('reported progress', () => {
+  it('renders the orchestrator estimate as a claim, never as overall progress', async () => {
+    await renderPane()
+
+    const orchestrator = screen.getByTestId('agent-progress-orchestrator-root')
+    expect(orchestrator).toHaveAttribute('data-progress-form', 'claim')
+    expect(orchestrator).toHaveAttribute('data-progress-scope', 'overall_estimate')
+    // No measure: no progressbar role, no segments, and the value is quoted.
+    expect(within(orchestrator).queryByRole('progressbar')).not.toBeInTheDocument()
+    expect(orchestrator.querySelectorAll('[data-progress-segment]')).toHaveLength(0)
+    expect(orchestrator.querySelector('[data-claim-marker]')).not.toBeNull()
+    expect(orchestrator).toHaveTextContent('Gemeldete Selbsteinschätzung von Root Orchestrator')
+    expect(orchestrator).toHaveTextContent('Kein gemessener Fortschritt.')
+
+    // A subagent number is a different statement: its own task, and countable.
+    const subagent = screen.getByTestId('agent-progress-subagent-implementer')
+    expect(subagent).toHaveAttribute('data-progress-form', 'counted')
+    expect(subagent).toHaveAttribute('data-progress-scope', 'own_task')
+    expect(within(subagent).getByRole('progressbar')).toBeInTheDocument()
+    expect(subagent).toHaveTextContent('für den eigenen Task')
+
+    // Nothing in the pane presents a measured bar for the whole run.
+    const overallMeters = document.querySelectorAll(
+      '[data-progress-form="counted"][data-progress-scope="overall_estimate"]',
+    )
+    expect(overallMeters).toHaveLength(0)
+  })
+
+  it('keeps an estimate and counted steps structurally apart', async () => {
+    await renderPane()
+
+    const estimate = screen.getByTestId('agent-progress-orchestrator-root')
+    const counted = screen.getByTestId('agent-progress-subagent-architect')
+
+    // Different form, not a different colour.
+    expect(estimate.getAttribute('data-progress-form')).toBe('claim')
+    expect(counted.getAttribute('data-progress-form')).toBe('counted')
+
+    // The counted statement is a countable row of segments; the estimate has none.
+    expect(counted.querySelectorAll('[data-progress-segment]')).toHaveLength(10)
+    expect(estimate.querySelectorAll('[data-progress-segment]')).toHaveLength(0)
+
+    // Neither is nested inside the other, and they never share a group.
+    expect(counted.contains(estimate)).toBe(false)
+    expect(estimate.contains(counted)).toBe(false)
+    expect(estimate.getAttribute('data-progress-group')).toBe('claim')
+    expect(counted.getAttribute('data-progress-group')).toBe('counted')
+
+    // Completed plan steps use the counted form as well — same shape, same kind
+    // of statement — and are reported per revision, never merged into an estimate.
+    const planCounted = screen.getByTestId('plan-completion-plan-2026-08-04-0001-2')
+    expect(planCounted).toHaveAttribute('data-progress-form', 'counted')
+    expect(planCounted.querySelectorAll('[data-progress-segment]')).toHaveLength(5)
+    expect(planCounted.querySelectorAll('[data-progress-segment][data-filled="true"]')).toHaveLength(
+      2,
+    )
+    expect(planCounted.querySelectorAll('[data-claim-marker]')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Plan revisions
+// ---------------------------------------------------------------------------
+
+describe('plan revisions', () => {
+  it('shows every revision in order and keeps revision 1 after revision 2 exists', async () => {
+    await renderPane()
+
+    const plan = screen.getByTestId('plan-plan-2026-08-04-0001')
+    expect(plan).toHaveAttribute('data-revision-count', '2')
+
+    const revisionOrder = Array.from(plan.querySelectorAll('[data-revision]')).map((element) =>
+      element.getAttribute('data-revision'),
+    )
+    expect(revisionOrder).toEqual(['1', '2'])
+
+    // Revision 1 is still there, complete, with the states it was last seen with.
+    const first = screen.getByTestId('plan-revision-plan-2026-08-04-0001-1')
+    expect(first).toHaveAttribute('data-current-revision', 'false')
+    expect(first).toHaveTextContent('frühere Fassung')
+    expect(first.querySelectorAll('[data-step-state]')).toHaveLength(4)
+    expect(
+      screen.getByTestId('plan-step-plan-2026-08-04-0001-1-step-extract'),
+    ).toHaveAttribute('data-step-state', 'in_progress')
+
+    // Revision 2 is the current one and carries the fifth step.
+    const second = screen.getByTestId('plan-revision-plan-2026-08-04-0001-2')
+    expect(second).toHaveAttribute('data-current-revision', 'true')
+    expect(second.querySelectorAll('[data-step-state]')).toHaveLength(5)
+    expect(
+      screen.getByTestId('plan-step-plan-2026-08-04-0001-2-step-extract'),
+    ).toHaveAttribute('data-step-state', 'done')
+    expect(
+      screen.getByTestId('plan-step-plan-2026-08-04-0001-2-step-rates'),
+    ).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+describe('a project without a run', () => {
+  it('renders the pane cleanly instead of crashing', async () => {
+    const emptyRunId = 'run-does-not-exist'
+    const test = harness({
+      [runPaths.runs]: { projectPosition: 0, runs: [], nextCursor: null },
+      [runPaths.currentRun]: () => problem(404, 'current_run_not_found'),
+      [`/api/v1/projects/${PROJECT_ID}/runs/${emptyRunId}/agents`]: {
+        projectPosition: 0,
+        agents: [],
+      },
+      [`/api/v1/projects/${PROJECT_ID}/runs/${emptyRunId}/plans`]: {
+        projectPosition: 0,
+        plans: [],
+      },
+      [`/api/v1/projects/${PROJECT_ID}/runs/${emptyRunId}`]: () =>
+        problem(404, 'run_not_found'),
+    })
+
+    renderApp(`/projects/${PROJECT_ID}/runs/${emptyRunId}`, { fetchImpl: test.fetchImpl })
+
+    expect(await screen.findByTestId('pane-run-agents')).toBeInTheDocument()
+    expect(await screen.findByTestId('no-current-run')).toBeInTheDocument()
+    expect(await screen.findByText('Keine Runs gemeldet')).toBeInTheDocument()
+    expect(await screen.findByText('Keine Agents gemeldet')).toBeInTheDocument()
+    expect(await screen.findByText('Kein Plan veröffentlicht')).toBeInTheDocument()
+
+    // Without a current run there is nothing to be historical about.
+    expect(screen.queryByTestId('historical-run-banner')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('current-run-banner')).not.toBeInTheDocument()
+
+    // The rest of the workspace is unaffected.
+    expect(screen.getByTestId('pane-architecture')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/workspace/RunAgentPane.tsx
+++ b/frontend/src/components/workspace/RunAgentPane.tsx
@@ -1,10 +1,15 @@
-import { Link } from '@tanstack/react-router'
-import { ChevronRight, ListTree } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
 
-import { useAgents, useRuns } from '@/api/queries'
-import type { ProjectId, RunId, RunSummary } from '@/api/types'
-import { AsyncState, EmptyState } from '@/components/AsyncState'
+import { useCurrentRun } from '@/api/currentRun'
+import { useAgents, usePlans, useRun, useRuns } from '@/api/queries'
+import type { AgentId, ProjectId, RunId, RunSummary } from '@/api/types'
+import { AsyncState } from '@/components/AsyncState'
 import { PaneHeader } from '@/components/workspace/PaneHeader'
+import { AgentTree } from '@/components/workspace/runAgents/AgentTree'
+import { PlanRevisions } from '@/components/workspace/runAgents/PlanRevisions'
+import { RunSelector } from '@/components/workspace/runAgents/RunSelector'
+import { OUTCOME_LABEL, formatTimestamp } from '@/components/workspace/runAgents/reporting'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -14,7 +19,6 @@ import {
 } from '@/components/ui/collapsible'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
-import { cn } from '@/lib/utils'
 
 export interface RunAgentPaneProps {
   projectId: ProjectId
@@ -22,81 +26,124 @@ export interface RunAgentPaneProps {
 }
 
 /**
- * Left pane: run selection and the agent hierarchy of the selected run.
+ * Left pane: run selection, the agent/subagent hierarchy and the plans of the
+ * selected run.
  *
- * The shell owns the **navigation** between runs, because direct navigation to a
- * run is an acceptance criterion of this issue. The agent/subagent tree itself,
- * its progress rendering and the plan revisions are built in #11 — this pane
- * only provides the named region and the correct loading, error and empty
- * states for it. No agent data is invented here.
+ * Four rules hold across everything below, and each of them is a rule about what
+ * the pane must *not* do:
+ *
+ * 1. **Nothing is derived from silence.** A run without `run.finished` is open
+ *    and shows its last reported values. There is no timeout, no heuristic and
+ *    no "seems stuck" anywhere in this subtree — `lastEventAt` is rendered as a
+ *    timestamp and never compared against a clock.
+ * 2. **A historical run never overlays the current one.** Looking at an older
+ *    run is a different URL, announced by a banner that carries the way back.
+ * 3. **Estimates and counted facts keep different shapes.** See
+ *    `runAgents/ProgressDisplay.tsx`.
+ * 4. **Live events invalidate narrowly.** The queries below are keyed per run
+ *    (ADR 0003), so an `agent.progress_reported` refetches this run's agent list
+ *    and nothing else. Selection and collapse state live outside the cache, so a
+ *    refetch cannot move them.
  */
 export function RunAgentPane({ projectId, runId }: RunAgentPaneProps) {
   const runs = useRuns(projectId)
+  const currentRun = useCurrentRun(projectId)
+  const run = useRun(projectId, runId)
   const agents = useAgents(projectId, runId)
+  const plans = usePlans(projectId, runId)
+
+  // Selection is transient by design (ADR 0003): it describes this tab looking
+  // at the run, not the run. Keeping it in component state is also what makes a
+  // live refetch harmless — the query cache changes, this value does not.
+  const [selectedAgentId, setSelectedAgentId] = useState<AgentId | null>(null)
 
   const runList: RunSummary[] = runs.data?.pages.flatMap((page) => page.runs) ?? []
-  const agentCount = agents.data?.agents.length ?? 0
+  const agentList = agents.data?.agents ?? []
+  const planList = plans.data?.plans ?? []
 
   return (
     <section
       className="pane-surface"
       aria-label="Run- und Agent-Bereich"
       data-testid="pane-run-agents"
+      data-run-id={runId}
     >
       <PaneHeader title="Runs und Agents" subtitle={projectId} />
 
       <ScrollArea className="min-h-0 flex-1">
         <div className="space-y-4 p-3">
-          <Collapsible defaultOpen>
-            <div className="flex items-center justify-between gap-2">
-              <CollapsibleTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1 px-1.5 [&[data-state=open]>svg]:rotate-90"
-                >
-                  <ChevronRight className="size-3.5 transition-transform" aria-hidden="true" />
-                  <span className="pane-heading">Runs</span>
-                </Button>
-              </CollapsibleTrigger>
-              {runList.length > 0 && (
-                <span className="text-muted-foreground text-2xs">
-                  {runList.length} geladen
-                </span>
-              )}
-            </div>
+          <Section
+            title="Runs"
+            count={runList.length > 0 ? `${runList.length} geladen` : null}
+          >
+            <RunSelector
+              projectId={projectId}
+              runId={runId}
+              currentRun={currentRun.data}
+              runs={runList}
+              isPending={runs.isPending}
+              isError={runs.isError}
+              error={runs.error}
+              hasNextPage={runs.hasNextPage}
+              isFetchingNextPage={runs.isFetchingNextPage}
+              onFetchNextPage={() => void runs.fetchNextPage()}
+              onRetry={() => void runs.refetch()}
+            />
+          </Section>
 
-            <CollapsibleContent className="pt-1">
+          <Separator />
+
+          <section aria-label="Gemeldeter Runzustand" data-testid="run-state">
+            <span className="pane-heading">Runzustand</span>
+            <div className="pt-1">
               <AsyncState
-                isPending={runs.isPending}
-                isError={runs.isError}
-                error={runs.error}
-                isEmpty={runList.length === 0}
-                emptyTitle="Keine Runs gemeldet"
-                emptyDescription="Sobald ein Orchestrator Ereignisse sendet, erscheint sein Run hier."
-                onRetry={() => void runs.refetch()}
+                isPending={run.isPending}
+                isError={run.isError}
+                error={run.error}
+                emptyTitle="Run nicht verfügbar"
+                onRetry={() => void run.refetch()}
+                skeletonRows={2}
               >
-                <ul className="space-y-1">
-                  {runList.map((run) => (
-                    <li key={run.runId}>
-                      <RunLink projectId={projectId} run={run} active={run.runId === runId} />
-                    </li>
-                  ))}
-                </ul>
-                {runs.hasNextPage && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="mt-2 w-full"
-                    disabled={runs.isFetchingNextPage}
-                    onClick={() => void runs.fetchNextPage()}
-                  >
-                    {runs.isFetchingNextPage ? 'Lädt…' : 'Ältere Runs laden'}
-                  </Button>
+                {run.data && (
+                  <dl className="space-y-0.5 text-2xs">
+                    <Row label="Run">
+                      <span className="font-mono">{run.data.run.runId}</span>
+                    </Row>
+                    <Row label="Zustand">
+                      <span
+                        data-testid="run-openness"
+                        data-open={run.data.run.isOpen ? 'true' : 'false'}
+                      >
+                        {run.data.run.isOpen
+                          ? 'offen — kein Terminalereignis gemeldet'
+                          : `beendet: ${
+                              run.data.run.outcome
+                                ? OUTCOME_LABEL[run.data.run.outcome]
+                                : 'ohne gemeldetes Ergebnis'
+                            }`}
+                      </span>
+                    </Row>
+                    <Row label="Beginn">
+                      <span className="font-mono">
+                        {formatTimestamp(run.data.run.startedAt)}
+                      </span>
+                    </Row>
+                    <Row label="Ende">
+                      <span className="font-mono">
+                        {run.data.run.finishedAt
+                          ? formatTimestamp(run.data.run.finishedAt)
+                          : 'kein Ende gemeldet'}
+                      </span>
+                    </Row>
+                    <Row label="Umfang">
+                      {run.data.run.counts.agents} Agents · {run.data.run.counts.plans}{' '}
+                      Pläne · {run.data.run.counts.workSteps} Arbeitsschritte
+                    </Row>
+                  </dl>
                 )}
               </AsyncState>
-            </CollapsibleContent>
-          </Collapsible>
+            </div>
+          </section>
 
           <Separator />
 
@@ -105,7 +152,7 @@ export function RunAgentPane({ projectId, runId }: RunAgentPaneProps) {
               <span className="pane-heading">Agenthierarchie</span>
               {agents.isSuccess && (
                 <Badge variant="outline" className="text-2xs font-normal">
-                  {agentCount} gemeldet
+                  {agentList.length} gemeldet
                 </Badge>
               )}
             </div>
@@ -115,65 +162,78 @@ export function RunAgentPane({ projectId, runId }: RunAgentPaneProps) {
                 isPending={agents.isPending}
                 isError={agents.isError}
                 error={agents.error}
-                isEmpty={agentCount === 0}
+                isEmpty={agentList.length === 0}
                 emptyTitle="Keine Agents gemeldet"
                 emptyDescription={`Für Run ${runId} liegt noch kein agent.started-Ereignis vor.`}
                 onRetry={() => void agents.refetch()}
                 skeletonRows={4}
               >
-                <EmptyState
-                  title="Agentbaum folgt"
-                  description="Die Darstellung von Agents, Subagents, Fortschritt und Planrevisionen wird in einem eigenen Arbeitspaket ergänzt. Die Daten werden bereits geladen und live invalidiert."
-                >
-                  <p className="text-muted-foreground mt-2 flex items-center gap-1.5 text-xs">
-                    <ListTree className="size-3.5" aria-hidden="true" />
-                    {agentCount} Agents im Run {runId}
-                  </p>
-                </EmptyState>
+                <AgentTree
+                  agents={agentList}
+                  selectedAgentId={selectedAgentId}
+                  onSelectAgent={setSelectedAgentId}
+                />
               </AsyncState>
             </div>
           </section>
+
+          <Separator />
+
+          <Section title="Pläne" count={planList.length > 0 ? `${planList.length}` : null}>
+            <AsyncState
+              isPending={plans.isPending}
+              isError={plans.isError}
+              error={plans.error}
+              isEmpty={planList.length === 0}
+              emptyTitle="Kein Plan veröffentlicht"
+              emptyDescription={`Für Run ${runId} liegt noch kein plan.published-Ereignis vor.`}
+              onRetry={() => void plans.refetch()}
+              skeletonRows={3}
+            >
+              <PlanRevisions plans={planList} />
+            </AsyncState>
+          </Section>
         </div>
       </ScrollArea>
     </section>
   )
 }
 
-function RunLink({
-  projectId,
-  run,
-  active,
+/** A collapsible block of the pane, with the same header row everywhere. */
+function Section({
+  title,
+  count,
+  children,
 }: {
-  projectId: ProjectId
-  run: RunSummary
-  active: boolean
+  title: string
+  count: string | null
+  children: ReactNode
 }) {
   return (
-    <Link
-      to="/projects/$projectId/runs/$runId"
-      params={{ projectId, runId: run.runId }}
-      search={{}}
-      aria-current={active ? 'page' : undefined}
-      className={cn(
-        'hover:bg-accent focus-visible:ring-ring block rounded-md px-2 py-1.5 text-sm focus-visible:ring-2 focus-visible:outline-none',
-        active && 'bg-accent text-accent-foreground',
-      )}
-    >
-      <span className="block truncate font-mono text-xs">{run.runId}</span>
-      <span className="text-muted-foreground flex items-center gap-1.5 text-2xs">
-        {run.outcome ? (
-          <>abgeschlossen: {run.outcome}</>
-        ) : (
-          <>ohne Terminalereignis</>
-        )}
-        {/*
-          `RunSummary` carries no agent count — only `RunDetail.counts` does, and
-          the list endpoint does not return it. The root agent is what the
-          summary actually reports.
-        */}
-        <span aria-hidden="true">·</span>
-        {run.rootAgentId ?? 'kein Root-Agent gemeldet'}
-      </span>
-    </Link>
+    <Collapsible defaultOpen>
+      <div className="flex items-center justify-between gap-2">
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 px-1.5 [&[data-state=open]>svg]:rotate-90"
+          >
+            <ChevronRight className="size-3.5 transition-transform" aria-hidden="true" />
+            <span className="pane-heading">{title}</span>
+          </Button>
+        </CollapsibleTrigger>
+        {count && <span className="text-muted-foreground text-2xs">{count}</span>}
+      </div>
+      <CollapsibleContent className="pt-1">{children}</CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex gap-1.5">
+      <dt className="text-muted-foreground w-16 shrink-0">{label}</dt>
+      <dd className="min-w-0">{children}</dd>
+    </div>
   )
 }

--- a/frontend/src/components/workspace/runAgents/AgentTree.tsx
+++ b/frontend/src/components/workspace/runAgents/AgentTree.tsx
@@ -1,0 +1,115 @@
+import { ChevronsDownUp, ChevronsUpDown, Search } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import type { AgentId, RunAgent } from '@/api/types'
+import { EmptyState } from '@/components/AsyncState'
+import { Button } from '@/components/ui/button'
+import { useUiStore } from '@/state/uiStore'
+
+import { AgentTreeItem } from './AgentTreeItem'
+import {
+  branchAgentIds,
+  buildAgentTree,
+  filterAgentTree,
+  visibleAgentRows,
+} from './agentHierarchy'
+
+export interface AgentTreeProps {
+  agents: readonly RunAgent[]
+  selectedAgentId: AgentId | null
+  onSelectAgent: (agentId: AgentId) => void
+}
+
+/**
+ * The agent/subagent hierarchy of one run.
+ *
+ * The rows are rendered as one flat list with an indent per level rather than
+ * as nested lists: a run with many spawns then scrolls as a single column
+ * instead of drifting to the right, and collapsing a branch is a change to which
+ * rows are produced, not to the DOM structure around them.
+ *
+ * Collapse state lives in the UI store (`collapsedAgentIds`) and is keyed by
+ * agent id, so a live event that adds a subagent cannot fold anything the user
+ * had opened. Selection is local and transient — it is a property of looking at
+ * the run, not of the run (ADR 0003).
+ */
+export function AgentTree({ agents, selectedAgentId, onSelectAgent }: AgentTreeProps) {
+  const collapsedAgentIds = useUiStore((state) => state.collapsedAgentIds)
+  const setAgentCollapsed = useUiStore((state) => state.setAgentCollapsed)
+  const toggleAgentCollapsed = useUiStore((state) => state.toggleAgentCollapsed)
+  const [filter, setFilter] = useState('')
+
+  const tree = useMemo(() => buildAgentTree(agents), [agents])
+  const visibleRoots = useMemo(() => filterAgentTree(tree.roots, filter), [tree.roots, filter])
+  const collapsedSet = useMemo(() => new Set(collapsedAgentIds), [collapsedAgentIds])
+  const rows = useMemo(
+    // A filtered view shows every match; collapsing only applies to the full tree.
+    () => visibleAgentRows(visibleRoots, filter.trim() === '' ? collapsedSet : new Set()),
+    [visibleRoots, collapsedSet, filter],
+  )
+
+  const branches = useMemo(() => branchAgentIds(tree.roots), [tree.roots])
+  const allCollapsed = branches.length > 0 && branches.every((id) => collapsedSet.has(id))
+
+  return (
+    <div data-testid="agent-tree" className="space-y-2">
+      <div className="flex items-center gap-1">
+        <div className="relative min-w-0 flex-1">
+          <Search
+            className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-3 -translate-y-1/2"
+            aria-hidden="true"
+          />
+          <input
+            type="search"
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            aria-label="Agents filtern"
+            placeholder="Agents filtern"
+            className="border-input bg-background focus-visible:ring-ring h-7 w-full rounded-md border pr-2 pl-6 text-xs focus-visible:ring-2 focus-visible:outline-none"
+          />
+        </div>
+        {branches.length > 0 && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7 shrink-0"
+            aria-label={allCollapsed ? 'Alle Subagents ausklappen' : 'Alle Subagents einklappen'}
+            onClick={() => {
+              for (const id of branches) setAgentCollapsed(id, !allCollapsed)
+            }}
+          >
+            {allCollapsed ? (
+              <ChevronsUpDown className="size-3.5" aria-hidden="true" />
+            ) : (
+              <ChevronsDownUp className="size-3.5" aria-hidden="true" />
+            )}
+          </Button>
+        )}
+      </div>
+
+      {rows.length === 0 ? (
+        <EmptyState
+          title="Kein Agent passt zum Filter"
+          description={`Kein Agent dieses Runs enthält „${filter.trim()}“.`}
+        />
+      ) : (
+        <ul
+          aria-label="Agenthierarchie"
+          data-max-depth={tree.maxDepth}
+          className="divide-border/60 divide-y"
+        >
+          {rows.map(({ node, collapsed }) => (
+            <AgentTreeItem
+              key={node.agent.agentId}
+              node={node}
+              collapsed={collapsed}
+              selected={node.agent.agentId === selectedAgentId}
+              onToggleCollapsed={toggleAgentCollapsed}
+              onSelect={onSelectAgent}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/runAgents/AgentTreeItem.tsx
+++ b/frontend/src/components/workspace/runAgents/AgentTreeItem.tsx
@@ -1,0 +1,202 @@
+import { ChevronRight, CornerDownRight, RotateCcw, Unlink } from 'lucide-react'
+
+import type { AgentId } from '@/api/types'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+import type { AgentTreeNode } from './agentHierarchy'
+import { ReportedProgress } from './ProgressDisplay'
+import {
+  AGENT_ROLE_LABEL,
+  AGENT_STATUS_LABEL,
+  OUTCOME_LABEL,
+  formatTimestamp,
+} from './reporting'
+
+/** Indent per level, in pixels. Kept small so depth 5 still fits the pane. */
+const INDENT_PX = 12
+
+export interface AgentTreeItemProps {
+  node: AgentTreeNode
+  collapsed: boolean
+  selected: boolean
+  onToggleCollapsed: (agentId: AgentId) => void
+  onSelect: (agentId: AgentId) => void
+}
+
+/**
+ * One agent of the tree.
+ *
+ * The row always answers the four questions the issue asks for — role, assigned
+ * task, last reported point in time, explicitly reported status — and answers
+ * them with what was reported, including "nothing was". `lastEventAt` is a
+ * timestamp and never a judgement: the pane does not compare it against a clock
+ * and has no notion of an agent being late.
+ */
+export function AgentTreeItem({
+  node,
+  collapsed,
+  selected,
+  onToggleCollapsed,
+  onSelect,
+}: AgentTreeItemProps) {
+  const { agent, depth, attachment, children, descendantCount } = node
+  const hasChildren = children.length > 0
+  const name = agent.displayName || agent.agentId
+
+  return (
+    <li
+      data-testid={`agent-row-${agent.agentId}`}
+      data-agent-id={agent.agentId}
+      data-run-id={agent.runId}
+      data-depth={depth}
+      data-attachment={attachment}
+      data-selected={selected ? 'true' : 'false'}
+      className={cn(
+        'border-l-2 py-1 pr-1',
+        selected ? 'border-l-primary bg-accent/60' : 'border-l-transparent',
+      )}
+      style={{ paddingLeft: `${depth * INDENT_PX + 2}px` }}
+    >
+      <div className="flex items-start gap-1">
+        {hasChildren ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="mt-0.5 size-5 shrink-0"
+            aria-expanded={!collapsed}
+            aria-label={`Subagents von ${name} ${collapsed ? 'ausklappen' : 'einklappen'}`}
+            onClick={() => onToggleCollapsed(agent.agentId)}
+          >
+            <ChevronRight
+              className={cn('size-3.5 transition-transform', !collapsed && 'rotate-90')}
+              aria-hidden="true"
+            />
+          </Button>
+        ) : (
+          <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center">
+            {depth > 0 && (
+              <CornerDownRight
+                className="text-muted-foreground/60 size-3"
+                aria-hidden="true"
+              />
+            )}
+          </span>
+        )}
+
+        <button
+          type="button"
+          aria-pressed={selected}
+          onClick={() => onSelect(agent.agentId)}
+          className="focus-visible:ring-ring min-w-0 flex-1 rounded-sm text-left focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate text-sm font-medium">{name}</span>
+            <Badge variant="outline" className="shrink-0 text-2xs font-normal">
+              {AGENT_ROLE_LABEL[agent.role]}
+            </Badge>
+            {collapsed && descendantCount > 0 && (
+              <Badge variant="secondary" className="shrink-0 text-2xs font-normal">
+                +{descendantCount}
+              </Badge>
+            )}
+          </span>
+
+          <span className="text-muted-foreground block truncate font-mono text-2xs">
+            {agent.agentId}
+          </span>
+        </button>
+      </div>
+
+      <div className="space-y-1.5 pt-1 pl-6">
+        {attachment === 'orphaned' && (
+          <AttachmentNote
+            icon={Unlink}
+            testId={`agent-orphaned-${agent.agentId}`}
+            text={`Gemeldeter Parent „${agent.parentAgentId ?? ''}“ gehört nicht zu diesem Run. Der Agent wird als eigene Wurzel gezeigt.`}
+          />
+        )}
+        {attachment === 'cycle_broken' && (
+          <AttachmentNote
+            icon={RotateCcw}
+            testId={`agent-cycle-${agent.agentId}`}
+            text={`Die gemeldete Parent-Kette läuft im Kreis. Die Kante zu „${agent.parentAgentId ?? ''}“ wurde hier getrennt; der Agent wird als eigene Wurzel gezeigt.`}
+          />
+        )}
+
+        <dl className="space-y-0.5 text-2xs">
+          <div className="flex gap-1.5">
+            <dt className="text-muted-foreground shrink-0">Aufgabe</dt>
+            <dd
+              data-testid={`agent-task-${agent.agentId}`}
+              className={cn('min-w-0', !agent.assignedTask && 'text-muted-foreground italic')}
+            >
+              {agent.assignedTask || 'keine Aufgabe gemeldet'}
+            </dd>
+          </div>
+          <div className="flex gap-1.5">
+            <dt className="text-muted-foreground shrink-0">Status</dt>
+            <dd
+              data-testid={`agent-status-${agent.agentId}`}
+              data-status={agent.status}
+              className={cn('min-w-0', !agent.status && 'text-muted-foreground italic')}
+            >
+              {AGENT_STATUS_LABEL[agent.status]}
+              {agent.statusNote && (
+                <span className="text-muted-foreground"> — {agent.statusNote}</span>
+              )}
+            </dd>
+          </div>
+          <div className="flex gap-1.5">
+            <dt className="text-muted-foreground shrink-0">Zuletzt</dt>
+            <dd
+              data-testid={`agent-last-event-${agent.agentId}`}
+              className="text-muted-foreground min-w-0 font-mono"
+            >
+              {formatTimestamp(agent.lastEventAt)}
+            </dd>
+          </div>
+          <div className="flex gap-1.5">
+            <dt className="text-muted-foreground shrink-0">Abschluss</dt>
+            <dd
+              data-testid={`agent-outcome-${agent.agentId}`}
+              data-outcome={agent.finishedOutcome ?? 'none'}
+              className={cn('min-w-0', !agent.finishedOutcome && 'text-muted-foreground italic')}
+            >
+              {agent.finishedOutcome
+                ? OUTCOME_LABEL[agent.finishedOutcome]
+                : 'kein Abschluss gemeldet'}
+            </dd>
+          </div>
+        </dl>
+
+        <ReportedProgress
+          progress={agent.progress}
+          reportedBy={name}
+          testId={`agent-progress-${agent.agentId}`}
+        />
+      </div>
+    </li>
+  )
+}
+
+function AttachmentNote({
+  icon: Icon,
+  text,
+  testId,
+}: {
+  icon: typeof Unlink
+  text: string
+  testId: string
+}) {
+  return (
+    <p
+      data-testid={testId}
+      className="border-state-planned/60 text-muted-foreground flex items-start gap-1 rounded-md border border-dashed px-1.5 py-1 text-2xs"
+    >
+      <Icon className="mt-px size-3 shrink-0" aria-hidden="true" />
+      <span>{text}</span>
+    </p>
+  )
+}

--- a/frontend/src/components/workspace/runAgents/PlanRevisions.tsx
+++ b/frontend/src/components/workspace/runAgents/PlanRevisions.tsx
@@ -1,0 +1,132 @@
+import type { RunPlan, RunPlanRevision } from '@/api/types'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+import { CompletedStepsMeter } from './ProgressDisplay'
+import {
+  PLAN_STEP_STATE_GLYPH,
+  PLAN_STEP_STATE_LABEL,
+  formatTimestamp,
+  stepCompletion,
+} from './reporting'
+
+export interface PlanRevisionsProps {
+  plans: readonly RunPlan[]
+}
+
+/**
+ * Every plan of the run with **every** revision it ever had.
+ *
+ * Revisions are append-only by contract: a `plan.step_updated` only reaches the
+ * revision that was current when it was reported, so an earlier revision keeps
+ * exactly the step states it was last seen with. The pane renders that literally
+ * — all revisions, ascending, each with all of its steps. Showing only the
+ * current revision would make a re-plan invisible, and a re-plan is one of the
+ * things a reviewer most needs to see.
+ *
+ * Older revisions are visually receded but never hidden and never collapsed
+ * away: what changed between revision 1 and revision 2 has to be readable
+ * without an interaction.
+ */
+export function PlanRevisions({ plans }: PlanRevisionsProps) {
+  return (
+    <div data-testid="plan-revisions" className="space-y-3">
+      {plans.map((plan) => (
+        <article
+          key={plan.planId}
+          data-testid={`plan-${plan.planId}`}
+          data-revision-count={plan.revisions.length}
+          className="border-border rounded-md border"
+        >
+          <header className="border-border flex items-baseline gap-1.5 border-b px-2 py-1.5">
+            <h4 className="truncate font-mono text-xs font-medium">{plan.planId}</h4>
+            <span className="text-muted-foreground shrink-0 text-2xs">
+              {plan.revisions.length} Revision{plan.revisions.length === 1 ? '' : 'en'}
+            </span>
+          </header>
+
+          <ol aria-label={`Revisionen von ${plan.planId}`} className="divide-border divide-y">
+            {[...plan.revisions]
+              .sort((left, right) => left.revision - right.revision)
+              .map((revision) => (
+                <PlanRevisionEntry
+                  key={revision.revision}
+                  planId={plan.planId}
+                  revision={revision}
+                />
+              ))}
+          </ol>
+        </article>
+      ))}
+    </div>
+  )
+}
+
+function PlanRevisionEntry({
+  planId,
+  revision,
+}: {
+  planId: string
+  revision: RunPlanRevision
+}) {
+  const completion = stepCompletion(revision)
+
+  return (
+    <li
+      data-testid={`plan-revision-${planId}-${revision.revision}`}
+      data-revision={revision.revision}
+      data-current-revision={revision.isCurrent ? 'true' : 'false'}
+      className={cn('space-y-1.5 px-2 py-2', !revision.isCurrent && 'bg-muted/30')}
+    >
+      <div className="flex items-baseline gap-1.5">
+        <h5 className="text-xs font-medium">Revision {revision.revision}</h5>
+        {revision.isCurrent ? (
+          <Badge variant="secondary" className="text-2xs font-normal">
+            aktuell
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="text-2xs font-normal">
+            frühere Fassung
+          </Badge>
+        )}
+      </div>
+
+      <p className="text-muted-foreground font-mono text-2xs">
+        {formatTimestamp(revision.createdAt)} · {revision.createdByAgentId}
+      </p>
+
+      <CompletedStepsMeter
+        completion={completion}
+        label={`Revision ${revision.revision}`}
+        testId={`plan-completion-${planId}-${revision.revision}`}
+      />
+
+      <ol className="space-y-0.5">
+        {[...revision.steps]
+          .sort((left, right) => left.order - right.order)
+          .map((step) => (
+            <li
+              key={step.stepId}
+              data-testid={`plan-step-${planId}-${revision.revision}-${step.stepId}`}
+              data-step-state={step.state}
+              className="flex items-baseline gap-1.5 text-2xs"
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'shrink-0 font-mono',
+                  step.state === 'done' ? 'text-state-applied' : 'text-muted-foreground',
+                )}
+              >
+                {PLAN_STEP_STATE_GLYPH[step.state]}
+              </span>
+              <span className="min-w-0 flex-1">{step.title}</span>
+              <span className="text-muted-foreground shrink-0">
+                {PLAN_STEP_STATE_LABEL[step.state]}
+              </span>
+            </li>
+          ))}
+      </ol>
+    </li>
+  )
+}

--- a/frontend/src/components/workspace/runAgents/ProgressDisplay.tsx
+++ b/frontend/src/components/workspace/runAgents/ProgressDisplay.tsx
@@ -1,0 +1,208 @@
+import { cn } from '@/lib/utils'
+
+import { progressStatement, type ProgressStatement, type StepCompletion } from './reporting'
+import type { AgentProgress } from '@/api/types'
+
+/**
+ * Two renderings for two different kinds of statement, told apart by **shape**
+ * rather than by colour.
+ *
+ * * **Counted facts** are drawn as a row of discrete segments. The reader can
+ *   literally count them, because the underlying thing is countable: steps an
+ *   agent explicitly marked done, in its own bounded task.
+ * * **Reported claims** get no track and no fill at all. They are a quoted
+ *   number, prefixed with `≈`, attributed to the agent that said it. There is
+ *   nothing to measure against, so nothing is drawn as if there were.
+ *
+ * The two never share a container, never share a shape, and the distinction
+ * survives greyscale — that is why it is geometry and not a colour. See
+ * `docs/decisions/0011-run-and-agent-hierarchy.md`.
+ */
+
+/** Segments of the counted meter. Ten keeps a segment worth exactly 10 %. */
+const METER_SEGMENTS = 10
+
+export interface ReportedProgressProps {
+  /** `null` when the agent never reported a number — say so, do not guess. */
+  progress: AgentProgress | null
+  /** Who reported it; a claim is always attributed. */
+  reportedBy: string
+  testId: string
+}
+
+/** The progress an agent reported about itself, in the form its claim allows. */
+export function ReportedProgress({ progress, reportedBy, testId }: ReportedProgressProps) {
+  if (progress === null) {
+    return (
+      <p
+        data-testid={testId}
+        data-progress-form="none"
+        className="text-muted-foreground text-2xs"
+      >
+        Kein Fortschritt gemeldet
+      </p>
+    )
+  }
+
+  const statement = progressStatement(progress)
+
+  return statement.form === 'counted' ? (
+    <CountedProgress statement={statement} testId={testId} />
+  ) : (
+    <ClaimedProgress statement={statement} reportedBy={reportedBy} testId={testId} />
+  )
+}
+
+/**
+ * A countable quantity: one segment per tenth, filled from the left.
+ *
+ * This is the only progress rendering with `role="progressbar"`. The role
+ * promises a measurable value between a known minimum and a known maximum, and
+ * only counted steps of a bounded task keep that promise.
+ */
+function CountedProgress({
+  statement,
+  testId,
+}: {
+  statement: ProgressStatement
+  testId: string
+}) {
+  const filled = Math.round((statement.percent / 100) * METER_SEGMENTS)
+
+  return (
+    <div
+      data-testid={testId}
+      data-progress-group="counted"
+      data-progress-form="counted"
+      data-progress-scope={statement.scope}
+      data-progress-basis={statement.basis}
+      className="space-y-1"
+    >
+      <div
+        role="progressbar"
+        aria-valuenow={statement.percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${statement.percent} % ${statement.subject}, ${statement.derivation}`}
+        className="flex gap-0.5"
+      >
+        {Array.from({ length: METER_SEGMENTS }, (_, index) => (
+          <span
+            key={index}
+            data-progress-segment=""
+            data-filled={index < filled ? 'true' : 'false'}
+            className={cn(
+              'h-1.5 flex-1 rounded-[1px]',
+              index < filled ? 'bg-state-applied' : 'bg-muted',
+            )}
+          />
+        ))}
+      </div>
+      <p className="text-muted-foreground text-2xs">
+        <span className="text-foreground font-medium">{statement.percent} %</span>{' '}
+        {statement.subject} · {statement.derivation}
+      </p>
+    </div>
+  )
+}
+
+/**
+ * A reported claim: no track, no fill, no `progressbar` role.
+ *
+ * The `≈` and the attribution are part of the value, not decoration — they are
+ * what keeps the number from being read as a measurement. An orchestrator's
+ * estimate for the whole run lands here even when it says it counted steps,
+ * because nothing in v0 can count the steps of a whole run.
+ */
+function ClaimedProgress({
+  statement,
+  reportedBy,
+  testId,
+}: {
+  statement: ProgressStatement
+  reportedBy: string
+  testId: string
+}) {
+  return (
+    <div
+      data-testid={testId}
+      data-progress-group="claim"
+      data-progress-form="claim"
+      data-progress-scope={statement.scope}
+      data-progress-basis={statement.basis}
+      className="border-border/70 text-muted-foreground rounded-md border border-dashed px-2 py-1 text-2xs"
+    >
+      <p>
+        <span data-claim-marker="" aria-hidden="true" className="font-mono">
+          ≈
+        </span>{' '}
+        <span data-claim-value="" className="text-foreground font-medium">
+          {statement.percent} %
+        </span>{' '}
+        {statement.subject}
+      </p>
+      <p className="mt-0.5">
+        Gemeldete Selbsteinschätzung von {reportedBy} · {statement.derivation}. Kein
+        gemessener Fortschritt.
+      </p>
+    </div>
+  )
+}
+
+export interface CompletedStepsMeterProps {
+  completion: StepCompletion
+  /** Names what the steps belong to, e.g. `Revision 2`. */
+  label: string
+  testId: string
+}
+
+/**
+ * The objective counterpart of `ReportedProgress`: one segment per plan step,
+ * filled for every step the agent explicitly marked `done`.
+ *
+ * Same shape language as `CountedProgress` on purpose — both are counts of
+ * reported facts. A revision without steps renders `0 von 0` and no segments
+ * rather than an empty full-width track.
+ */
+export function CompletedStepsMeter({
+  completion,
+  label,
+  testId,
+}: CompletedStepsMeterProps) {
+  return (
+    <div
+      data-testid={testId}
+      data-progress-group="counted"
+      data-progress-form="counted"
+      data-progress-basis="completed_steps"
+      className="space-y-1"
+    >
+      {completion.total > 0 && (
+        <div
+          role="progressbar"
+          aria-valuenow={completion.done}
+          aria-valuemin={0}
+          aria-valuemax={completion.total}
+          aria-label={`${label}: ${completion.done} von ${completion.total} Schritten abgeschlossen`}
+          className="flex gap-0.5"
+        >
+          {completion.states.map((state, index) => (
+            <span
+              key={index}
+              data-progress-segment=""
+              data-segment-state={state}
+              data-filled={state === 'done' ? 'true' : 'false'}
+              className={cn(
+                'h-1.5 flex-1 rounded-[1px]',
+                state === 'done' ? 'bg-state-applied' : 'bg-muted',
+              )}
+            />
+          ))}
+        </div>
+      )}
+      <p className="text-muted-foreground text-2xs">
+        {completion.done} von {completion.total} Schritten abgeschlossen
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/runAgents/RunSelector.tsx
+++ b/frontend/src/components/workspace/runAgents/RunSelector.tsx
@@ -1,0 +1,189 @@
+import { Link } from '@tanstack/react-router'
+import { History, Radio } from 'lucide-react'
+
+import type { ProjectId, RunDetail, RunId, RunSummary } from '@/api/types'
+import { AsyncState, EmptyState } from '@/components/AsyncState'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+import { OUTCOME_LABEL, formatTimestamp } from './reporting'
+
+export interface RunSelectorProps {
+  projectId: ProjectId
+  /** The run the workspace is currently showing. */
+  runId: RunId
+  /** `null` when the project has no current run, `undefined` while loading. */
+  currentRun: RunDetail | null | undefined
+  runs: readonly RunSummary[]
+  isPending: boolean
+  isError: boolean
+  error: unknown
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  onFetchNextPage: () => void
+  onRetry: () => void
+}
+
+/**
+ * Run selection for one project.
+ *
+ * The current run is the default, and it is resolved through `/runs/current`
+ * rather than by scanning the paged list (see `src/api/currentRun.ts`).
+ * Historical runs are one click away, but selecting one is an explicit
+ * navigation to a different URL — it never merges into the current view. When
+ * the shown run is not the current one the pane says so before anything else and
+ * offers the way back, so a historical view can never be mistaken for live.
+ */
+export function RunSelector({
+  projectId,
+  runId,
+  currentRun,
+  runs,
+  isPending,
+  isError,
+  error,
+  hasNextPage,
+  isFetchingNextPage,
+  onFetchNextPage,
+  onRetry,
+}: RunSelectorProps) {
+  const showingCurrentRun = currentRun != null && currentRun.runId === runId
+
+  return (
+    <div className="space-y-2">
+      {currentRun === null && (
+        <div data-testid="no-current-run">
+          <EmptyState
+            title="Kein aktueller Run"
+            description="Für dieses Projekt hat noch kein Root-Orchestrator einen Run eröffnet."
+          />
+        </div>
+      )}
+
+      {currentRun && !showingCurrentRun && (
+        <div
+          data-testid="historical-run-banner"
+          role="status"
+          className="border-state-planned bg-state-planned/10 space-y-1.5 rounded-md border px-2 py-1.5"
+        >
+          <p className="flex items-center gap-1.5 text-xs font-medium">
+            <History className="size-3.5 shrink-0" aria-hidden="true" />
+            Historischer Run
+          </p>
+          <p className="text-muted-foreground text-2xs">
+            Diese Ansicht zeigt einen abgelegten Run, nicht den aktuellen. Aktuell ist{' '}
+            <span className="font-mono">{currentRun.runId}</span>.
+          </p>
+          <Button asChild variant="outline" size="sm" className="h-6 w-full text-2xs">
+            <Link
+              to="/projects/$projectId/runs/$runId"
+              params={{ projectId, runId: currentRun.runId }}
+              search={{}}
+              data-testid="back-to-current-run"
+            >
+              <Radio className="size-3" aria-hidden="true" />
+              Zum aktuellen Run wechseln
+            </Link>
+          </Button>
+        </div>
+      )}
+
+      {currentRun && showingCurrentRun && (
+        <p
+          data-testid="current-run-banner"
+          className="text-muted-foreground flex items-center gap-1.5 text-2xs"
+        >
+          <Radio className="text-state-applied size-3.5 shrink-0" aria-hidden="true" />
+          Aktueller Run des Projekts
+        </p>
+      )}
+
+      <AsyncState
+        isPending={isPending}
+        isError={isError}
+        error={error}
+        isEmpty={runs.length === 0}
+        emptyTitle="Keine Runs gemeldet"
+        emptyDescription="Sobald ein Orchestrator Ereignisse sendet, erscheint sein Run hier."
+        onRetry={onRetry}
+      >
+        <ul aria-label="Runs des Projekts" className="space-y-1">
+          {runs.map((run) => (
+            <li key={run.runId}>
+              <RunLink projectId={projectId} run={run} shown={run.runId === runId} />
+            </li>
+          ))}
+        </ul>
+        {hasNextPage && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2 w-full"
+            disabled={isFetchingNextPage}
+            onClick={onFetchNextPage}
+          >
+            {isFetchingNextPage ? 'Lädt…' : 'Ältere Runs laden'}
+          </Button>
+        )}
+      </AsyncState>
+    </div>
+  )
+}
+
+/**
+ * One run of the list.
+ *
+ * An open run is described as open — never as running, hanging or stalled. The
+ * contract closes a run only on an explicit `run.finished`, and silence is not a
+ * terminal state, so the label says exactly that.
+ */
+function RunLink({
+  projectId,
+  run,
+  shown,
+}: {
+  projectId: ProjectId
+  run: RunSummary
+  shown: boolean
+}) {
+  return (
+    <Link
+      to="/projects/$projectId/runs/$runId"
+      params={{ projectId, runId: run.runId }}
+      search={{}}
+      aria-current={shown ? 'page' : undefined}
+      data-testid={`run-option-${run.runId}`}
+      data-current={run.isCurrent ? 'true' : 'false'}
+      data-open={run.isOpen ? 'true' : 'false'}
+      className={cn(
+        'hover:bg-accent focus-visible:ring-ring block rounded-md px-2 py-1.5 focus-visible:ring-2 focus-visible:outline-none',
+        shown && 'bg-accent text-accent-foreground',
+      )}
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        <span className="truncate font-mono text-xs">{run.runId}</span>
+        {run.isCurrent && (
+          <Badge variant="secondary" className="shrink-0 text-2xs font-normal">
+            aktuell
+          </Badge>
+        )}
+      </span>
+      <span className="text-muted-foreground block text-2xs">
+        {run.isOpen
+          ? 'offen — kein Terminalereignis gemeldet'
+          : `beendet: ${run.outcome ? OUTCOME_LABEL[run.outcome] : 'ohne gemeldetes Ergebnis'}`}
+      </span>
+      <span className="text-muted-foreground block font-mono text-2xs">
+        seit {formatTimestamp(run.startedAt)}
+      </span>
+      <span className="text-muted-foreground block text-2xs">
+        {/*
+          `RunSummary` carries no agent count — only `RunDetail.counts` does, on
+          a different endpoint. The root agent is what the summary reports.
+        */}
+        Root: {run.rootAgentId ?? 'kein Root-Agent gemeldet'}
+      </span>
+    </Link>
+  )
+}

--- a/frontend/src/components/workspace/runAgents/agentHierarchy.test.ts
+++ b/frontend/src/components/workspace/runAgents/agentHierarchy.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RunAgent } from '@/api/types'
+import { agent } from '@/test/fixtures'
+
+import {
+  branchAgentIds,
+  buildAgentTree,
+  filterAgentTree,
+  visibleAgentRows,
+} from './agentHierarchy'
+
+/** Shorthand for one reported agent of the run under test. */
+function node(agentId: string, parentAgentId: string | null): RunAgent {
+  return agent({
+    agentId,
+    parentAgentId,
+    role: parentAgentId === null ? 'orchestrator' : 'subagent',
+    displayName: agentId,
+  })
+}
+
+describe('buildAgentTree — hierarchy', () => {
+  it('keeps a root agent and several nested subagents unambiguously assigned', () => {
+    // The shape the simulator reports: the reviewer is spawned by the
+    // implementer, not by the root, so the tree is three levels deep.
+    const tree = buildAgentTree([
+      node('orchestrator-root', null),
+      node('subagent-architect', 'orchestrator-root'),
+      node('subagent-implementer', 'orchestrator-root'),
+      node('subagent-reviewer', 'subagent-implementer'),
+      node('subagent-tester', 'subagent-reviewer'),
+    ])
+
+    expect(tree.roots).toHaveLength(1)
+    expect(tree.roots[0]?.agent.agentId).toBe('orchestrator-root')
+    expect(tree.maxDepth).toBe(3)
+
+    const byId = tree.nodesById
+    expect(byId.get('subagent-architect')?.depth).toBe(1)
+    expect(byId.get('subagent-implementer')?.depth).toBe(1)
+    expect(byId.get('subagent-reviewer')?.depth).toBe(2)
+    expect(byId.get('subagent-tester')?.depth).toBe(3)
+
+    // Each subagent hangs below the agent that reported it, not below the root.
+    expect(byId.get('subagent-implementer')?.children.map((c) => c.agent.agentId)).toEqual([
+      'subagent-reviewer',
+    ])
+    expect(byId.get('subagent-reviewer')?.children.map((c) => c.agent.agentId)).toEqual([
+      'subagent-tester',
+    ])
+    expect(byId.get('subagent-architect')?.children).toEqual([])
+
+    expect(byId.get('orchestrator-root')?.descendantCount).toBe(4)
+    expect(byId.get('subagent-implementer')?.descendantCount).toBe(2)
+    expect(byId.get('subagent-tester')?.descendantCount).toBe(0)
+
+    expect(tree.orphanedAgentIds).toEqual([])
+    expect(tree.cycleBrokenAgentIds).toEqual([])
+  })
+
+  it('keeps two concurrent root agents apart', () => {
+    const tree = buildAgentTree([
+      node('root-a', null),
+      node('root-b', null),
+      node('child-a', 'root-a'),
+      node('child-b', 'root-b'),
+    ])
+
+    expect(tree.roots.map((root) => root.agent.agentId)).toEqual(['root-a', 'root-b'])
+    expect(tree.nodesById.get('root-a')?.children.map((c) => c.agent.agentId)).toEqual([
+      'child-a',
+    ])
+    expect(tree.nodesById.get('root-b')?.children.map((c) => c.agent.agentId)).toEqual([
+      'child-b',
+    ])
+  })
+})
+
+describe('buildAgentTree — malformed parent references', () => {
+  it('renders an agent whose parent is not in the run as a flagged root', () => {
+    const tree = buildAgentTree([
+      node('orchestrator-root', null),
+      node('subagent-orphan', 'agent-of-another-run'),
+    ])
+
+    expect(tree.orphanedAgentIds).toEqual(['subagent-orphan'])
+    expect(tree.roots.map((root) => root.agent.agentId)).toEqual([
+      'orchestrator-root',
+      'subagent-orphan',
+    ])
+    expect(tree.nodesById.get('subagent-orphan')?.attachment).toBe('orphaned')
+    // The agent is kept, not dropped: hiding it would hide the malformed report.
+    expect(tree.nodesById.size).toBe(2)
+  })
+
+  it('breaks a cycle instead of looping, and keeps every agent of it', () => {
+    const tree = buildAgentTree([
+      node('cycle-a', 'cycle-c'),
+      node('cycle-b', 'cycle-a'),
+      node('cycle-c', 'cycle-b'),
+    ])
+
+    expect(tree.cycleBrokenAgentIds).toHaveLength(1)
+    expect(tree.roots).toHaveLength(1)
+    expect(tree.nodesById.size).toBe(3)
+    expect(tree.maxDepth).toBe(2)
+
+    // Every agent of the cycle is reachable exactly once from the surviving root.
+    const reached = visibleAgentRows(tree.roots, new Set()).map((row) => row.node.agent.agentId)
+    expect(reached).toHaveLength(3)
+    expect(new Set(reached)).toEqual(new Set(['cycle-a', 'cycle-b', 'cycle-c']))
+  })
+
+  it('breaks a self-referencing parent', () => {
+    const tree = buildAgentTree([node('self', 'self')])
+
+    expect(tree.cycleBrokenAgentIds).toEqual(['self'])
+    expect(tree.roots.map((root) => root.agent.agentId)).toEqual(['self'])
+    expect(tree.roots[0]?.children).toEqual([])
+  })
+
+  it('handles a cycle that hangs below a healthy root', () => {
+    const tree = buildAgentTree([
+      node('orchestrator-root', null),
+      node('healthy', 'orchestrator-root'),
+      node('loop-a', 'loop-b'),
+      node('loop-b', 'loop-a'),
+    ])
+
+    expect(tree.roots).toHaveLength(2)
+    expect(tree.cycleBrokenAgentIds).toHaveLength(1)
+    expect(visibleAgentRows(tree.roots, new Set())).toHaveLength(4)
+  })
+
+  it('keeps the first occurrence of a repeated agent id and reports the rest', () => {
+    const first = agent({ agentId: 'twin', displayName: 'first', parentAgentId: null })
+    const second = agent({ agentId: 'twin', displayName: 'second', parentAgentId: null })
+    const tree = buildAgentTree([first, second])
+
+    expect(tree.duplicateAgentIds).toEqual(['twin'])
+    expect(tree.roots).toHaveLength(1)
+    expect(tree.roots[0]?.agent.displayName).toBe('first')
+  })
+
+  it('returns an empty tree for an empty run', () => {
+    const tree = buildAgentTree([])
+
+    expect(tree.roots).toEqual([])
+    expect(tree.maxDepth).toBe(-1)
+    expect(visibleAgentRows(tree.roots, new Set())).toEqual([])
+  })
+})
+
+describe('navigation helpers', () => {
+  const tree = buildAgentTree([
+    node('orchestrator-root', null),
+    node('subagent-implementer', 'orchestrator-root'),
+    node('subagent-reviewer', 'subagent-implementer'),
+  ])
+
+  it('hides the subtree of a collapsed agent but keeps the agent itself', () => {
+    const rows = visibleAgentRows(tree.roots, new Set(['subagent-implementer']))
+
+    expect(rows.map((row) => row.node.agent.agentId)).toEqual([
+      'orchestrator-root',
+      'subagent-implementer',
+    ])
+    expect(rows[1]?.collapsed).toBe(true)
+  })
+
+  it('keeps the ancestors of a deep match when filtering', () => {
+    const filtered = filterAgentTree(tree.roots, 'reviewer')
+    const rows = visibleAgentRows(filtered, new Set())
+
+    expect(rows.map((row) => row.node.agent.agentId)).toEqual([
+      'orchestrator-root',
+      'subagent-implementer',
+      'subagent-reviewer',
+    ])
+  })
+
+  it('lists only the agents that actually have subagents', () => {
+    expect(branchAgentIds(tree.roots).sort()).toEqual([
+      'orchestrator-root',
+      'subagent-implementer',
+    ])
+  })
+})

--- a/frontend/src/components/workspace/runAgents/agentHierarchy.ts
+++ b/frontend/src/components/workspace/runAgents/agentHierarchy.ts
@@ -1,0 +1,298 @@
+import type { AgentId, RunAgent } from '@/api/types'
+
+/**
+ * Builds the agent/subagent tree of one run out of the **flat** list the read
+ * API answers with.
+ *
+ * `GET /runs/{runId}/agents` deliberately returns a flat list and expresses the
+ * hierarchy only through `parentAgentId` (ADR 0005): a server that nested the
+ * response would have to commit to a maximum spawn depth. Building the tree is
+ * therefore the client's job — and so is surviving a parent reference that does
+ * not resolve.
+ *
+ * Three malformed shapes are possible in principle, and all three are given a
+ * **defined** result rather than a crash or an endless walk:
+ *
+ * | Input | Result |
+ * | --- | --- |
+ * | `parentAgentId` names an agent that is not in the run | the agent becomes a root, flagged `orphaned` |
+ * | a parent chain closes a cycle (including self-parenting) | exactly one member of the cycle becomes a root, flagged `cycle_broken` |
+ * | the same `agentId` appears twice | the first occurrence wins, the rest are reported in `duplicateAgentIds` |
+ *
+ * Nothing is dropped: an orphan and a broken cycle stay visible, because the
+ * cockpit shows what was reported and hiding a malformed node would hide the
+ * fact that it was malformed. Only the *edge* the data could not support is
+ * removed, never the agent.
+ *
+ * The module is pure and free of React so the rules above are testable without
+ * rendering anything.
+ */
+
+/** How a node ended up where it is in the tree. */
+export type AgentAttachment =
+  /** `parentAgentId` is `null` — the agent reported itself as a root. */
+  | 'root'
+  /** Attached below the parent it named. */
+  | 'child'
+  /** Named a parent that is not part of this run. Rendered as a root. */
+  | 'orphaned'
+  /** Its parent chain closes a cycle; the edge was cut here. Rendered as a root. */
+  | 'cycle_broken'
+
+export interface AgentTreeNode {
+  agent: RunAgent
+  /** Zero for a root, incremented per level. */
+  depth: number
+  attachment: AgentAttachment
+  children: AgentTreeNode[]
+  /** Number of agents below this one, at any depth. */
+  descendantCount: number
+}
+
+export interface AgentTree {
+  roots: AgentTreeNode[]
+  /** Every node by `agentId`, including duplicates' first occurrence only. */
+  nodesById: Map<AgentId, AgentTreeNode>
+  /** Deepest level in the tree; `0` for a flat list, `-1` when there is none. */
+  maxDepth: number
+  /** Agents whose `parentAgentId` names an agent this run does not contain. */
+  orphanedAgentIds: AgentId[]
+  /** Agents whose parent edge was cut to break a cycle. */
+  cycleBrokenAgentIds: AgentId[]
+  /** Repeated `agentId`s; only their first occurrence is in the tree. */
+  duplicateAgentIds: AgentId[]
+}
+
+export function buildAgentTree(agents: readonly RunAgent[]): AgentTree {
+  const byId = new Map<AgentId, RunAgent>()
+  const duplicateAgentIds: AgentId[] = []
+
+  for (const agent of agents) {
+    if (byId.has(agent.agentId)) {
+      duplicateAgentIds.push(agent.agentId)
+      continue
+    }
+    byId.set(agent.agentId, agent)
+  }
+
+  const cutIds = findCycleCuts(byId)
+
+  // ---- classify every agent, then wire the surviving edges -----------------
+  const nodesById = new Map<AgentId, AgentTreeNode>()
+  const orphanedAgentIds: AgentId[] = []
+  const cycleBrokenAgentIds: AgentId[] = []
+  const roots: AgentTreeNode[] = []
+
+  for (const agent of byId.values()) {
+    const attachment = classify(agent, byId, cutIds)
+    if (attachment === 'orphaned') orphanedAgentIds.push(agent.agentId)
+    if (attachment === 'cycle_broken') cycleBrokenAgentIds.push(agent.agentId)
+
+    nodesById.set(agent.agentId, {
+      agent,
+      depth: 0,
+      attachment,
+      children: [],
+      descendantCount: 0,
+    })
+  }
+
+  for (const node of nodesById.values()) {
+    if (node.attachment !== 'child') {
+      roots.push(node)
+      continue
+    }
+    // `classify` returned `child`, so the parent exists and the edge is not cut.
+    const parent = nodesById.get(node.agent.parentAgentId as AgentId)
+    if (parent) parent.children.push(node)
+    else roots.push(node)
+  }
+
+  // ---- depth and descendant counts, iteratively ----------------------------
+  // A recursive walk would be the obvious implementation, but the input is
+  // untrusted; the loop below cannot recurse and cannot exceed the node count
+  // even if `findCycleCuts` were ever wrong.
+  let maxDepth = -1
+  const seen = new Set<AgentId>()
+  const stack: AgentTreeNode[] = [...roots].reverse()
+
+  while (stack.length > 0) {
+    const node = stack.pop() as AgentTreeNode
+    if (seen.has(node.agent.agentId)) {
+      // Defensive: a node reached twice would mean the tree is not a tree.
+      node.children = []
+      continue
+    }
+    seen.add(node.agent.agentId)
+    if (node.depth > maxDepth) maxDepth = node.depth
+
+    for (const child of node.children) {
+      child.depth = node.depth + 1
+      stack.push(child)
+    }
+  }
+
+  for (const node of postOrder(roots)) {
+    node.descendantCount = node.children.reduce(
+      (total, child) => total + child.descendantCount + 1,
+      0,
+    )
+  }
+
+  return {
+    roots,
+    nodesById,
+    maxDepth,
+    orphanedAgentIds,
+    cycleBrokenAgentIds,
+    duplicateAgentIds,
+  }
+}
+
+function classify(
+  agent: RunAgent,
+  byId: Map<AgentId, RunAgent>,
+  cutIds: ReadonlySet<AgentId>,
+): AgentAttachment {
+  if (cutIds.has(agent.agentId)) return 'cycle_broken'
+  if (agent.parentAgentId === null) return 'root'
+  if (!byId.has(agent.parentAgentId)) return 'orphaned'
+  return 'child'
+}
+
+/**
+ * Finds one agent per cycle whose parent edge has to be cut.
+ *
+ * Every agent has at most one parent, so the parent relation is a functional
+ * graph: each connected component contains at most one cycle. Walking upwards
+ * with an explicit "currently on the path" mark therefore finds each cycle once,
+ * in linear time, and the node the walk re-enters is the one that gets cut.
+ */
+function findCycleCuts(byId: Map<AgentId, RunAgent>): Set<AgentId> {
+  const cutIds = new Set<AgentId>()
+  const resolved = new Set<AgentId>()
+  const onPath = new Set<AgentId>()
+
+  for (const start of byId.values()) {
+    if (resolved.has(start.agentId)) continue
+
+    const path: AgentId[] = []
+    let current: RunAgent | undefined = start
+
+    while (current) {
+      if (resolved.has(current.agentId)) break
+      if (onPath.has(current.agentId)) {
+        // Re-entered a node of the walk we are on: cut its upward edge.
+        cutIds.add(current.agentId)
+        break
+      }
+
+      onPath.add(current.agentId)
+      path.push(current.agentId)
+
+      const parentId: AgentId | null = current.parentAgentId
+      current = parentId === null ? undefined : byId.get(parentId)
+    }
+
+    for (const id of path) {
+      onPath.delete(id)
+      resolved.add(id)
+    }
+  }
+
+  return cutIds
+}
+
+/** Children before parents, so descendant counts can be summed in one pass. */
+function postOrder(roots: readonly AgentTreeNode[]): AgentTreeNode[] {
+  const output: AgentTreeNode[] = []
+  const stack = [...roots]
+
+  while (stack.length > 0) {
+    const node = stack.pop() as AgentTreeNode
+    output.push(node)
+    stack.push(...node.children)
+  }
+
+  return output.reverse()
+}
+
+// ---------------------------------------------------------------------------
+// Navigation helpers
+// ---------------------------------------------------------------------------
+
+export interface VisibleAgentRow {
+  node: AgentTreeNode
+  /** `true` when the node has children and they are currently hidden. */
+  collapsed: boolean
+}
+
+/**
+ * Flattens the tree into the rows that are currently on screen.
+ *
+ * Collapsing is a property of the viewer, not of the data, so it is passed in
+ * rather than stored on the node. A collapsed node stays in the list — only its
+ * subtree disappears.
+ */
+export function visibleAgentRows(
+  roots: readonly AgentTreeNode[],
+  collapsedAgentIds: ReadonlySet<AgentId>,
+): VisibleAgentRow[] {
+  const rows: VisibleAgentRow[] = []
+
+  const walk = (nodes: readonly AgentTreeNode[]) => {
+    for (const node of nodes) {
+      const collapsed = node.children.length > 0 && collapsedAgentIds.has(node.agent.agentId)
+      rows.push({ node, collapsed })
+      if (!collapsed) walk(node.children)
+    }
+  }
+
+  walk(roots)
+  return rows
+}
+
+/**
+ * Narrows the tree to the agents matching `term`, keeping every ancestor of a
+ * match so a deep hit stays reachable instead of appearing at the root.
+ *
+ * Returns the tree unchanged for an empty term.
+ */
+export function filterAgentTree(
+  roots: readonly AgentTreeNode[],
+  term: string,
+): AgentTreeNode[] {
+  const needle = term.trim().toLowerCase()
+  if (needle === '') return [...roots]
+
+  const matches = (node: AgentTreeNode) =>
+    `${node.agent.agentId} ${node.agent.displayName} ${node.agent.assignedTask} ${node.agent.role}`
+      .toLowerCase()
+      .includes(needle)
+
+  const prune = (node: AgentTreeNode): AgentTreeNode | null => {
+    const children = node.children
+      .map(prune)
+      .filter((child): child is AgentTreeNode => child !== null)
+    if (children.length === 0 && !matches(node)) return null
+    return { ...node, children }
+  }
+
+  return roots.map(prune).filter((node): node is AgentTreeNode => node !== null)
+}
+
+/** Every `agentId` of the tree that has at least one child. */
+export function branchAgentIds(roots: readonly AgentTreeNode[]): AgentId[] {
+  const ids: AgentId[] = []
+  const stack = [...roots]
+
+  while (stack.length > 0) {
+    const node = stack.pop() as AgentTreeNode
+    if (node.children.length > 0) {
+      ids.push(node.agent.agentId)
+      stack.push(...node.children)
+    }
+  }
+
+  return ids
+}

--- a/frontend/src/components/workspace/runAgents/reporting.ts
+++ b/frontend/src/components/workspace/runAgents/reporting.ts
@@ -1,0 +1,189 @@
+import type {
+  AgentProgress,
+  Outcome,
+  PlanStepState,
+  RunAgent,
+  RunPlanRevision,
+  Timestamp,
+} from '@/api/types'
+
+/**
+ * The role and status vocabularies of the **read model**, which are wider than
+ * the ones of the event payloads: `RunAgent` adds `''` for "never reported".
+ * `AgentRole` / `AgentStatus` in `types.ts` are read off the payload schemas and
+ * therefore do not carry that case.
+ */
+type ReportedRole = RunAgent['role']
+type ReportedStatus = RunAgent['status']
+
+/**
+ * The vocabulary of the run/agent pane, and the one rule that governs it:
+ * **nothing here is derived**.
+ *
+ * The read models report "was never reported" as an empty string or as `null`
+ * (ADR 0005). Every label below therefore has an explicit entry for that case —
+ * "kein Status gemeldet" is a statement about the report, not about the agent.
+ * The pane never turns silence into `blocked`, `stalled`, `failed` or any other
+ * verdict, and there is deliberately no time comparison anywhere in this module:
+ * an old `lastEventAt` is shown as an old timestamp and nothing else.
+ */
+
+// ---------------------------------------------------------------------------
+// Closed vocabularies
+// ---------------------------------------------------------------------------
+
+export const AGENT_ROLE_LABEL: Record<ReportedRole, string> = {
+  '': 'keine Rolle gemeldet',
+  orchestrator: 'Orchestrator',
+  subagent: 'Subagent',
+}
+
+export const AGENT_STATUS_LABEL: Record<ReportedStatus, string> = {
+  '': 'kein Status gemeldet',
+  working: 'arbeitet',
+  waiting: 'wartet',
+  blocked: 'blockiert',
+  idle: 'untätig',
+  done: 'fertig',
+}
+
+export const OUTCOME_LABEL: Record<Outcome, string> = {
+  completed: 'abgeschlossen',
+  failed: 'fehlgeschlagen',
+  cancelled: 'abgebrochen',
+}
+
+export const PLAN_STEP_STATE_LABEL: Record<PlanStepState, string> = {
+  pending: 'offen',
+  in_progress: 'in Arbeit',
+  done: 'abgeschlossen',
+  skipped: 'übersprungen',
+}
+
+/**
+ * Second, colour-independent channel for a plan-step state — the same rule the
+ * work-state module follows (ADR 0003): the information has to survive
+ * greyscale.
+ */
+export const PLAN_STEP_STATE_GLYPH: Record<PlanStepState, string> = {
+  pending: '○',
+  in_progress: '◐',
+  done: '●',
+  skipped: '⊘',
+}
+
+// ---------------------------------------------------------------------------
+// Timestamps
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats a contract timestamp in UTC.
+ *
+ * The API normalises every timestamp to UTC (ADR 0005) and the cockpit renders
+ * it that way, labelled: a local-time rendering of an agent report is a
+ * different claim than the one the agent made, and the difference is invisible
+ * until it matters. Built from `Date.getUTC*` rather than `Intl`, so the output
+ * does not depend on the host's locale data.
+ */
+export function formatTimestamp(value: Timestamp): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  const pad = (part: number) => String(part).padStart(2, '0')
+  return (
+    `${pad(date.getUTCDate())}.${pad(date.getUTCMonth() + 1)}.${date.getUTCFullYear()}` +
+    `, ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())} UTC`
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Progress: two kinds of statement, never one
+// ---------------------------------------------------------------------------
+
+/**
+ * How a reported percentage may be rendered.
+ *
+ * * `counted` — the agent reported `basis: completed_steps` **for its own task**
+ *   (`scope: own_task`). That is a countable quantity about a bounded subject,
+ *   and it is the only case the pane draws as a filled meter.
+ * * `claim` — everything else: a free estimate, a percentage without a reported
+ *   basis, and *every* `scope: overall_estimate` regardless of its basis. No
+ *   meter, no track, no fill — a quoted number attributed to the agent that said
+ *   it.
+ *
+ * The second rule is the important one. An orchestrator's overall estimate is
+ * the agent's opinion about a run nobody can objectively measure in v0; drawing
+ * it as a bar next to a subagent's counted bar would let the reader add the two
+ * up. See `docs/decisions/0011-run-and-agent-hierarchy.md`.
+ */
+export type ProgressForm = 'counted' | 'claim'
+
+export interface ProgressStatement {
+  form: ProgressForm
+  percent: number
+  /** Contract value, or `'unreported'` when the agent did not send one. */
+  scope: 'own_task' | 'overall_estimate' | 'unreported'
+  basis: 'reported_estimate' | 'completed_steps' | 'unreported'
+  /** What the number is about, as a sentence fragment. */
+  subject: string
+  /** How the agent arrived at it. */
+  derivation: string
+}
+
+export function progressStatement(progress: AgentProgress): ProgressStatement {
+  const scope = progress.scope ?? 'unreported'
+  const basis = progress.basis ?? 'unreported'
+  const form: ProgressForm =
+    scope === 'own_task' && basis === 'completed_steps' ? 'counted' : 'claim'
+
+  return {
+    form,
+    percent: progress.percent,
+    scope,
+    basis,
+    subject: PROGRESS_SUBJECT[scope],
+    derivation: PROGRESS_DERIVATION[basis],
+  }
+}
+
+const PROGRESS_SUBJECT: Record<ProgressStatement['scope'], string> = {
+  own_task: 'für den eigenen Task',
+  overall_estimate: 'für den gesamten Run',
+  unreported: 'ohne gemeldeten Bezug',
+}
+
+const PROGRESS_DERIVATION: Record<ProgressStatement['basis'], string> = {
+  completed_steps: 'aus abgeschlossenen Schritten gezählt',
+  reported_estimate: 'frei geschätzt',
+  unreported: 'ohne gemeldete Herleitung',
+}
+
+// ---------------------------------------------------------------------------
+// Plan completion: the objective counterpart
+// ---------------------------------------------------------------------------
+
+export interface StepCompletion {
+  done: number
+  total: number
+  /** States in reported order, so a meter can show one segment per step. */
+  states: PlanStepState[]
+}
+
+/**
+ * Counts the steps of one plan revision that the agent explicitly marked `done`.
+ *
+ * This is the only "progress" number the cockpit computes itself, and it is a
+ * count of reported facts, not a projection: `skipped` is not `done`, and a
+ * revision with no steps is `0 von 0` rather than `100 %`.
+ */
+export function stepCompletion(revision: RunPlanRevision): StepCompletion {
+  const states = [...revision.steps]
+    .sort((left, right) => left.order - right.order)
+    .map((step) => step.state)
+
+  return {
+    done: states.filter((state) => state === 'done').length,
+    total: states.length,
+    states,
+  }
+}

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -151,6 +151,13 @@ export const runResponse: RunResponse = {
   },
 }
 
+/**
+ * `GET /runs/current`. The alias is a separate endpoint by contract (ADR 0005),
+ * so the fixture answers it separately instead of letting the run-id route match
+ * the literal `current`.
+ */
+export const currentRunResponse: RunResponse = runResponse
+
 export const agentsResponse: AgentListResponse = {
   projectPosition: 42,
   agents: [agent()],
@@ -191,10 +198,15 @@ export function createFakeFetch(
     const path = url.split('?')[0] ?? url
 
     for (const [pattern, body] of Object.entries(overrides)) {
-      if (path === pattern) return jsonResponse(body)
+      if (path !== pattern) continue
+      // A factory override lets a test answer with a non-200 — the contract's
+      // `404 current_run_not_found` is a state the UI has to render, not a bug.
+      return typeof body === 'function' ? (body as () => Response)() : jsonResponse(body)
     }
 
     if (path === '/api/v1/projects') return jsonResponse(projectsResponse)
+    if (path === `/api/v1/projects/${PROJECT_ID}/runs/current`)
+      return jsonResponse(currentRunResponse)
     if (path === `/api/v1/projects/${PROJECT_ID}`) return jsonResponse(projectResponse)
     if (path === `/api/v1/projects/${PROJECT_ID}/architecture`)
       return jsonResponse(architectureResponse)

--- a/frontend/src/test/runFixtures.ts
+++ b/frontend/src/test/runFixtures.ts
@@ -1,0 +1,282 @@
+import type {
+  AgentListResponse,
+  PlanListResponse,
+  RunListResponse,
+  RunResponse,
+} from '@/api/types'
+import { PROJECT_ID, RUN_ID, agent } from './fixtures'
+
+/**
+ * The run the pane tests read.
+ *
+ * It mirrors what the deterministic simulator reports for its `full` scenario,
+ * because that is the shape the visual acceptance runs against: five agents in a
+ * three-level tree, both progress scopes side by side, two plan revisions, and a
+ * run that never received `run.finished`.
+ *
+ * Test data only; never imported by application code.
+ */
+
+export const HISTORICAL_RUN_ID = 'run-2026-08-03-0001'
+
+export const runsWithHistoryResponse: RunListResponse = {
+  projectPosition: 62,
+  runs: [
+    {
+      runId: RUN_ID,
+      rootAgentId: 'orchestrator-root',
+      startedAt: '2026-08-04T09:00:01Z',
+      finishedAt: null,
+      outcome: null,
+      isOpen: true,
+      isCurrent: true,
+      position: 62,
+    },
+    {
+      runId: HISTORICAL_RUN_ID,
+      rootAgentId: 'orchestrator-yesterday',
+      startedAt: '2026-08-03T08:15:00Z',
+      finishedAt: '2026-08-03T11:42:00Z',
+      outcome: 'completed',
+      isOpen: false,
+      isCurrent: false,
+      position: 31,
+    },
+  ],
+  nextCursor: null,
+}
+
+/** The open run: no `finishedAt`, no `outcome`, `isOpen` stays `true`. */
+export const openRunResponse: RunResponse = {
+  projectPosition: 62,
+  run: {
+    ...runsWithHistoryResponse.runs[0]!,
+    counts: { agents: 5, plans: 1, workSteps: 6 },
+  },
+}
+
+export const historicalRunResponse: RunResponse = {
+  projectPosition: 62,
+  run: {
+    ...runsWithHistoryResponse.runs[1]!,
+    counts: { agents: 2, plans: 1, workSteps: 3 },
+  },
+}
+
+/**
+ * Five agents, three levels deep. The reviewer is spawned by the implementer and
+ * the tester by the reviewer, so the tree is not two flat generations.
+ */
+export const treeAgentsResponse: AgentListResponse = {
+  projectPosition: 62,
+  agents: [
+    agent({
+      agentId: 'orchestrator-root',
+      parentAgentId: null,
+      role: 'orchestrator',
+      displayName: 'Root Orchestrator',
+      assignedTask: 'VAT-Behandlung aus dem Pricing-Modul lösen.',
+      status: 'working',
+      statusNote: 'Wartet auf den Review.',
+      // An estimate about the whole run — the agent's own claim, not a measurement.
+      progress: { percent: 20, scope: 'overall_estimate', basis: 'reported_estimate' },
+      startedAt: '2026-08-04T09:00:01Z',
+      lastEventAt: '2026-08-04T09:04:12Z',
+      position: 30,
+    }),
+    agent({
+      agentId: 'subagent-architect',
+      parentAgentId: 'orchestrator-root',
+      role: 'subagent',
+      displayName: 'Architecture Mapper',
+      assignedTask: 'Angewandtes Architekturmodell veröffentlichen.',
+      status: 'done',
+      statusNote: '',
+      progress: { percent: 40, scope: 'own_task', basis: 'completed_steps' },
+      finishedOutcome: 'completed',
+      startedAt: '2026-08-04T09:00:03Z',
+      lastEventAt: '2026-08-04T09:02:40Z',
+      position: 18,
+    }),
+    agent({
+      agentId: 'subagent-implementer',
+      parentAgentId: 'orchestrator-root',
+      role: 'subagent',
+      displayName: 'Implementer',
+      assignedTask: 'VAT-Behandlung in ein eigenes Modul verschieben.',
+      status: 'working',
+      statusNote: 'Schreibt Total() um.',
+      progress: { percent: 70, scope: 'own_task', basis: 'completed_steps' },
+      startedAt: '2026-08-04T09:00:05Z',
+      lastEventAt: '2026-08-04T09:06:31Z',
+      position: 41,
+    }),
+    agent({
+      agentId: 'subagent-reviewer',
+      parentAgentId: 'subagent-implementer',
+      role: 'subagent',
+      displayName: 'Reviewer',
+      assignedTask: 'Die Extraktion prüfen.',
+      status: 'waiting',
+      statusNote: 'Wartet auf den Abschluss der Extraktion.',
+      progress: { percent: 30, scope: 'own_task', basis: 'completed_steps' },
+      startedAt: '2026-08-04T09:00:07Z',
+      lastEventAt: '2026-08-04T09:05:02Z',
+      position: 37,
+    }),
+    // Never reported a status and never reported a number. Both stay empty.
+    agent({
+      agentId: 'subagent-tester',
+      parentAgentId: 'subagent-reviewer',
+      role: 'subagent',
+      displayName: 'Test Engineer',
+      assignedTask: 'Das Tax-Modul mit Tabellentests abdecken.',
+      status: '',
+      statusNote: '',
+      progress: null,
+      startedAt: '2026-08-04T09:00:09Z',
+      lastEventAt: '2026-08-04T09:00:09Z',
+      position: 12,
+    }),
+  ],
+}
+
+export const historicalAgentsResponse: AgentListResponse = {
+  projectPosition: 62,
+  agents: [
+    agent({
+      agentId: 'orchestrator-yesterday',
+      runId: HISTORICAL_RUN_ID,
+      parentAgentId: null,
+      role: 'orchestrator',
+      displayName: 'Orchestrator vom Vortag',
+      assignedTask: 'Preislogik dokumentieren.',
+      status: 'done',
+      statusNote: '',
+      progress: { percent: 100, scope: 'overall_estimate', basis: 'reported_estimate' },
+      finishedOutcome: 'completed',
+      startedAt: '2026-08-03T08:15:00Z',
+      lastEventAt: '2026-08-03T11:42:00Z',
+      position: 31,
+    }),
+  ],
+}
+
+/**
+ * One plan with two revisions. Revision 1 keeps the four steps and the states it
+ * was last seen with; revision 2 adds a fifth step. Nothing about revision 1 is
+ * rewritten — that is what append-only means here.
+ */
+export const twoRevisionPlansResponse: PlanListResponse = {
+  projectPosition: 62,
+  plans: [
+    {
+      planId: 'plan-2026-08-04-0001',
+      runId: RUN_ID,
+      agentId: 'orchestrator-root',
+      currentRevision: 2,
+      position: 55,
+      revisions: [
+        {
+          revision: 1,
+          createdAt: '2026-08-04T09:01:00Z',
+          createdByAgentId: 'orchestrator-root',
+          isCurrent: false,
+          position: 22,
+          steps: [
+            {
+              stepId: 'step-map',
+              order: 0,
+              title: 'Angewandte Architektur kartieren',
+              state: 'done',
+              position: 22,
+            },
+            {
+              stepId: 'step-extract',
+              order: 1,
+              title: 'VAT in ein Tax-Modul extrahieren',
+              state: 'in_progress',
+              position: 22,
+            },
+            {
+              stepId: 'step-review',
+              order: 2,
+              title: 'Die Extraktion prüfen',
+              state: 'pending',
+              position: 22,
+            },
+            {
+              stepId: 'step-cover',
+              order: 3,
+              title: 'Tax-Modul mit Tabellentests abdecken',
+              state: 'pending',
+              position: 22,
+            },
+          ],
+        },
+        {
+          revision: 2,
+          createdAt: '2026-08-04T09:05:30Z',
+          createdByAgentId: 'orchestrator-root',
+          isCurrent: true,
+          position: 55,
+          steps: [
+            {
+              stepId: 'step-map',
+              order: 0,
+              title: 'Angewandte Architektur kartieren',
+              state: 'done',
+              position: 55,
+            },
+            {
+              stepId: 'step-extract',
+              order: 1,
+              title: 'VAT in ein Tax-Modul extrahieren',
+              state: 'done',
+              position: 55,
+            },
+            {
+              stepId: 'step-rates',
+              order: 2,
+              title: 'Länderspezifische Sätze auslagern',
+              state: 'in_progress',
+              position: 55,
+            },
+            {
+              stepId: 'step-review',
+              order: 3,
+              title: 'Die Extraktion prüfen',
+              state: 'pending',
+              position: 55,
+            },
+            {
+              stepId: 'step-cover',
+              order: 4,
+              title: 'Tax-Modul mit Tabellentests abdecken',
+              state: 'pending',
+              position: 55,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+export const historicalPlansResponse: PlanListResponse = {
+  projectPosition: 62,
+  plans: [],
+}
+
+/** Paths of the read API this fixture set answers for. */
+export const runPaths = {
+  runs: `/api/v1/projects/${PROJECT_ID}/runs`,
+  currentRun: `/api/v1/projects/${PROJECT_ID}/runs/current`,
+  runDetail: `/api/v1/projects/${PROJECT_ID}/runs/${RUN_ID}`,
+  agents: `/api/v1/projects/${PROJECT_ID}/runs/${RUN_ID}/agents`,
+  plans: `/api/v1/projects/${PROJECT_ID}/runs/${RUN_ID}/plans`,
+  architecture: `/api/v1/projects/${PROJECT_ID}/architecture`,
+  historicalRunDetail: `/api/v1/projects/${PROJECT_ID}/runs/${HISTORICAL_RUN_ID}`,
+  historicalAgents: `/api/v1/projects/${PROJECT_ID}/runs/${HISTORICAL_RUN_ID}/agents`,
+  historicalPlans: `/api/v1/projects/${PROJECT_ID}/runs/${HISTORICAL_RUN_ID}/plans`,
+} as const


### PR DESCRIPTION
Setzt das linke Pane vollständig um: projektbezogene Run-Auswahl, Agent-/Subagent-Baum, Planrevisionen und gemeldeter Fortschritt. Canvas/Overlays (#9/#10), Inspector (#12) und Backend sind nicht berührt.

## Wie Schätzwert und objektiver Fortschritt visuell getrennt sind

Zwei Darstellungen, die keine Geometrie teilen — die Unterscheidung trägt **nicht** die Farbe:

| | gezählte Tatsache | gemeldete Schätzung |
| --- | --- | --- |
| Form | Reihe diskreter Segmente, von links gefüllt | **keine** Skala, kein Track, keine Füllung |
| Semantik | `role="progressbar"` mit `aria-valuenow`/`aria-valuemax` | reiner Text, kein ARIA-Wert |
| Marker | – | führendes `≈` als Teil des Wertes |
| Zuschreibung | – | „Gemeldete Selbsteinschätzung von *Agent*“ |
| gilt für | `scope: own_task` **und** `basis: completed_steps`; abgeschlossene Planschritte je Revision | alles andere |

Ein Orchestratorwert mit `scope: overall_estimate` landet **immer** in der Claim-Form, auch wenn er `basis: completed_steps` meldet — in v0 kann niemand die Schritte eines ganzen Runs zählen. `scope: null` / `basis: null` ebenfalls. Segmente sind der Punkt: eine zählbare Größe wird als etwas gezeichnet, das man wirklich abzählen kann (10 Segmente je Prozentwert, ein Segment je Planschritt); eine Behauptung bekommt keinen Track, weil es nichts gibt, woran man sie messen könnte.

Die Tests prüfen das **strukturell**: Segmentanzahl, Abwesenheit der `progressbar`-Rolle auf einer Schätzung, `data-progress-form`/`data-progress-group` und dass keines der beiden Elemente das andere enthält.

## Weitere Entscheidungen

- **Keine Stall-Erkennung.** `reporting.ts` enthält keinerlei Zeitarithmetik. `lastEventAt` ist ein Zeitstempel, kein Urteil. Ein Run ohne `run.finished` heißt „offen — kein Terminalereignis gemeldet“. Ein Test prüft, dass das gerenderte Pane kein Wort aus dem abgeleiteten Verdikt-Vokabular enthält.
- **Baum clientseitig aus `parentAgentId`.** Da jeder Agent höchstens einen Parent hat, ist die Relation ein funktionaler Graph — ein Aufwärtslauf mit „aktuell auf diesem Pfad“-Markierung findet jeden Zyklus genau einmal in linearer Zeit. Verwaister Parent → geflaggte Wurzel mit Hinweis; Zyklus (auch Selbstreferenz) → genau ein Mitglied wird zur Wurzel, Kante getrennt, Hinweis; doppelte `agentId` → erste gewinnt. Kein Agent wird verworfen. Der Tiefenlauf ist iterativ mit Seen-Set statt rekursiv.
- **Historischer Run überlagert nie.** Aktueller Run über `/runs/current` (nicht durch Scan der gepagten Liste nach `isCurrent`); `404 current_run_not_found` ist ein Zustand, kein Fehler, und wird zu einem Leerzustand. Ein historischer Run ist eine eigene Route mit Banner, das den aktuellen Run benennt und den Rückweg trägt.
- **Live-Events nur auf betroffene Knoten.** `affectedQueryKeys` ist unverändert. Neu ist nur `queryKeys.currentRun()`, **unterhalb** von `runs(projectId)` — `run.finished` invalidiert dieses Präfix bereits, also braucht die Event→Key-Karte aus ADR 0003 keinen neuen Eintrag. Auswahl liegt in Component-State, Collapse im UI-Store — beides außerhalb des Caches, ein Refetch kann keines von beiden bewegen.

ADR: `docs/decisions/0011-run-and-agent-hierarchy.md`.

## Tests

24 neue Tests (11 rein auf dem Baum, 13 am gerenderten Pane), alle 105 bestehenden bleiben grün.

```
$ npm run lint      # eslint . — keine Ausgabe
$ npm run typecheck # tsc --build --force — keine Ausgabe
$ npm test
 Test Files  17 passed (17)
      Tests  129 passed (129)
   Duration  9.31s
$ npm run build
dist/assets/index-*.js   811.20 kB │ gzip: 256.42 kB
✓ built in 13.33s
```

Abgedeckt: gleichzeitiger Root + verschachtelte Subagents (Tiefe ≥ 3, eindeutig zuordenbar) · verwaister Parent und Zyklus mit definiertem Verhalten · Live-Event aktualisiert nur den betroffenen Knoten ohne Auswahlverlust · Run ohne Terminalevent bleibt offen · historischer Run überlagert nicht · Orchestrator- vs. Subagent-Prozentwert als unterschiedliche Aussagen · Schätzung vs. abgeschlossene Schritte strukturell getrennt · beide Planrevisionen vollständig und in Reihenfolge · Leerzustand ohne Run.

## Visuelle Prüfung — echte Simulatordaten, 1920 × 1080

```
FRONTEND_HTTP_PORT=8098 docker compose -p vai-issue11 up --build -d
cd simulator && npm run simulate -- --base http://localhost:8098 --speed 1   # 62 Events, 201 durchgängig
```

Gemessen im Browser bei exakt 1920 × 1080:

| Messung | Wert |
| --- | --- |
| `document.scrollWidth` vs. `clientWidth` | 1920 / 1920 → **kein horizontaler Seiten-Scrollbar** |
| Panebreiten links / Architektur / Inspector | **345 px / 1036 px / 537 px** — Architekturfläche bleibt dominant |
| horizontaler Overflow im linken Pane | keiner (`scrollWidth` 345 = `clientWidth` 345) |
| Agents / Baumtiefe | 5 Agents, `data-depth` 0,1,1,2,2 — `data-max-depth="2"` (drei Ebenen) |
| Fortschritts-Formen | `orchestrator-root` → `claim / overall_estimate / reported_estimate`; alle vier Subagents → `counted / own_task / completed_steps` |
| Planrevisionen | Revision 1 (4 Schritte, `frühere Fassung`) und Revision 2 (5 Schritte, `aktuell`) gleichzeitig sichtbar, aufsteigend |
| Runzustand | `data-open="true"`, „offen — kein Terminalereignis gemeldet“, „Ende: kein Ende gemeldet“ |

Zweiter Lauf (`--run run-2026-08-04-0002 --finish true`) für die historische Ansicht: Banner „Historischer Run … Aktuell ist run-2026-08-04-0002“, Rücklink auf `/projects/visualise-ai/runs/run-2026-08-04-0002`, kein „Aktueller Run“-Marker, und im Baum ausschließlich Agents mit `data-run-id="run-2026-08-04-0001"` — die beiden Runs mischen sich nicht. Weiterhin kein horizontaler Scrollbar.

## Berührte Dateien

Neu: `frontend/src/api/currentRun.ts`, `frontend/src/components/workspace/runAgents/{agentHierarchy.ts,reporting.ts,ProgressDisplay.tsx,AgentTree.tsx,AgentTreeItem.tsx,RunSelector.tsx,PlanRevisions.tsx}`, Tests, `frontend/src/test/runFixtures.ts`, ADR 0011.

Geändert: `RunAgentPane.tsx` (Neuaufbau) sowie minimal-additiv `api/queryKeys.ts` (ein Key) und `test/fixtures.ts` (`/runs/current`-Route, Factory-Overrides für Nicht-200-Antworten). `canvas/**`, `ArchitecturePane.tsx`, `InspectorPane.tsx`, `api/queries.ts`, `api/liveStream.ts`, `state/uiStore.ts`, `package.json`, `backend/`, `api/`, `simulator/` sind unberührt.

Closes #11
