### PR TITLE
[v0] Geplante, aktive und angewandte Änderungen live visualisieren

### DIFF
--- a/docs/decisions/0010-live-change-overlays.md
+++ b/docs/decisions/0010-live-change-overlays.md
@@ -1,0 +1,224 @@
+# 10. Live change overlays: a picture of the work, drawn beside the model
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #10 (part of the v0 epic #1)
+- **Builds on:** [0003 — Frontend state split and live updates](./0003-frontend-state-split-and-live-updates.md),
+  [0005 — Read API shape and run scoping](./0005-read-api-shape-and-run-scoping.md),
+  [0006 — SSE replay and in-process broker](./0006-sse-replay-and-in-process-broker.md),
+  [0008 — Architecture canvas](./0008-architecture-canvas-layout-and-edge-bundling.md),
+  [0009 — Generated frontend contract types](./0009-generated-frontend-contract-types.md)
+
+## Context
+
+The canvas (#9) draws what the agent *reported as the architecture*. This work
+package draws what the agents *are doing to it* — and the two must never be
+confused, because the whole product rests on the user being able to tell an
+announcement from a fact.
+
+Four things make that hard, and each of them is a decision below:
+
+1. A planned change is not part of the model, but it has to appear *somewhere on
+   the model* to be understandable at all.
+2. Several agents work at the same time, on the same components. The picture has
+   to merge them without any of them disappearing.
+3. Colour is the obvious encoding for four states and the worst one to rely on.
+4. Everything arrives while the user is reading something else.
+
+The read API gives one half of the answer and cannot give the other. It returns
+the applied model plus `activeChanges`, and `activeChanges` is filtered to
+`state = planned` server side (`readapi/projects.go`). It therefore has, by
+contract, no way to express
+
+- a work step that is **started and not completed** — the `active` state,
+- a change that was **just applied** — the `recently_applied` state, or
+- an element an applied change **removed** — the `removed` state, because a
+  removed component is precisely the one no longer in the response.
+
+## Decision
+
+### Proposals are drawn beside the model, never inside it
+
+`components`/`relationships` and `activeChanges` are two different statements,
+and `src/canvas/changeOverlays.ts` keeps them two. A proposal becomes its **own**
+node or edge with `applied: false`, built from `ActiveChange.snapshot` — the
+reported descriptor the contract carries verbatim exactly so the canvas can draw
+a proposal without a second lookup (ADR 0009). Proposal edges even live in their
+own id space (`overlay:src~>tgt` rather than `rel:src~>tgt`), so an announced
+edge and an applied edge between the same two components stay two lines: folding
+them into one would claim the proposal had already happened.
+
+The separation is visible from outside the component, which is what makes it
+testable: the canvas reports `data-node-count` (the applied model) and
+`data-overlay-node-count` (proposals and ghosts) as two different numbers. A
+`component.change_planned` moves the second and must leave the first untouched.
+
+The counterpart of a proposal is a **ghost**. When an applied change removes a
+component, the read model stops returning it — and a component that simply
+vanishes from the picture is the one case where the cockpit would be *less*
+informative than the log it is showing. The removed element therefore stays on
+the canvas, drawn from the descriptor the removing event carried, marked
+`presence: ghost` and dimmed. It is evidence of what disappeared, not a claim
+that it still exists.
+
+### A client-side change ledger for what the read API cannot say
+
+`src/state/changeLedger.ts` folds the SSE stream into the three facts listed
+above. It is not server state and deliberately not a query (ADR 0003): it must
+survive a refetch rather than be invalidated by one.
+
+Its scope is deliberate and worth stating, because it is the one place where
+this work package is *less* than it could be. A stream opened without a cursor
+starts at the live tail instead of replaying the project — `liveOnly` in
+`backend/internal/sse/connection.go`, an explicit decision of ADR 0006. The
+ledger therefore describes **what the cockpit watched happen**: opening it
+mid-run shows the applied model and the pending proposals from the read model,
+and every further state as its event arrives. That is exactly what "kürzlich
+angewandt" claims and no more. Asking for a full replay (`?lastEventPosition=0`)
+on every page load was rejected: it would fire an invalidation per historical
+event on every open, and it would change the streaming behaviour of every pane,
+not just this one. Replayed events after a *reconnect* are folded in
+idempotently — anything at or below `lastPosition` is ignored.
+
+Three rules hold inside it:
+
+- **Nothing is overwritten.** Every change event is appended. A retraction
+  *marks* its entry `retracted`, a correction *marks* its entry `superseded` and
+  appends the corrected content — the same append-only discipline the event log
+  itself follows (ADR 0002). A withdrawn proposal disappears from the overlay
+  and stays in the history.
+- **"Recent" is counted, not timed.** Only the newest `RECENT_APPLIED_LIMIT`
+  (8) applied changes contribute an overlay. A clock-based window was rejected
+  outright: it would make the picture change *without an event having arrived*,
+  which is the restless behaviour this cockpit exists to avoid, and it would
+  make the overlays depend on when the page happened to be opened.
+- **A replacing snapshot resets it.** `architecture.snapshot_published` replaces
+  the applied model entirely, so every earlier applied/removed statement
+  describes a model that no longer exists. Keeping them would draw a ghost of
+  something the new snapshot contains. Open work steps survive the reset,
+  because a work step is a statement about an agent, not about the model.
+
+The ledger is fed from `applyLiveEvent` — the one function every live event
+already passes through — so there is a single apply path and no second stream.
+
+### Concurrent agents are merged by keeping all of them
+
+An overlay is not "the last thing somebody said". `buildChangeOverlays` collects
+**every** contribution for a target — every pending proposal, every recent
+applied change, every open work step — into `contributions`, each with the agent
+that reported it. What gets condensed is only the single work state on the
+element, and that condensation is delegated to `resolveWorkState` in
+`src/state/workStates.ts`, the module that already owns the four states, so the
+canvas cannot invent a fifth or order them differently from the agent tree (#11)
+and the inspector (#12).
+
+Alternatives considered and rejected:
+
+- *Last writer wins.* One agent's proposal would silently vanish because another
+  agent touched the same component later. That is exactly the "silently
+  overwrite" failure the issue names.
+- *One overlay per agent, stacked.* Two boxes on one node, three on the next.
+  The picture stops being a graph long before an interesting run is over.
+
+What is drawn instead: one mark per element, carrying the dominant state, plus
+the **number of contributing agents** next to it whenever it is greater than one,
+plus every single contribution listed line by line in the mark's `title`. The
+count is the signal that there is more than one story here; the list is the
+story. A `data-agent-count` attribute makes both assertable.
+
+A bundle of parallel relationships resolves the same way, through
+`dominantOverlay`, which uses the same precedence as `resolveWorkState` — so a
+bundle can never announce a weaker phase than one of its members.
+
+### Colour is never the only channel, and the tests never look at colour
+
+Every state carries four channels: the colour, a **text label**, an **icon** and
+a **line style** (border style on a box, dash pattern on a line). They come from
+`WORK_STATES`, which already declared all four (ADR 0003); this work package
+renders them rather than adding new ones.
+
+The label is not just the state, it is the state **plus the operation** —
+`geplant · hinzufügen` versus `geplant · entfernen`. Those two are the same
+colour and the same border style on purpose: they are the same *phase*. What
+tells them apart is a word, and `changeOverlays.test.ts` asserts precisely that
+by comparing the two while checking that their state and border style are equal.
+
+The canvas-level test does the same job at the DOM level and reads only
+`data-work-state-label`, `data-border-style`, `data-operation` and the visible
+text. No assertion in the overlay tests reads a hue — a test that checked a
+colour would be proving the opposite of the requirement.
+
+Edges are the one place where two encodings compete for a channel: ADR 0008
+already spends the dash pattern on the *relationship kind*. An edge with a state
+therefore keeps its kind pattern on the line itself and gets a second, wider
+path underneath drawn in the **state's** dash pattern, plus the state mark next
+to the kind badge. Kind and phase each keep a channel of their own instead of
+fighting over one.
+
+### Status is a phase of work, never a verdict
+
+`WORK_STATE_DISCLAIMER` says it and the legend shows it; this package had to keep
+it true in the new strings. Red means "wird entfernt", green means "angewandt".
+`CHANGE_OPERATION_LABELS` are the three contract operations in plain German and
+nothing else, and a test asserts that the overlay text contains no word from a
+list of verdicts (`Fehler`, `falsch`, `schlecht`, `Risiko`, …). The cockpit
+performs no drift evaluation — the human reviewer judges (epic #1).
+
+One consequence is worth stating because it looks like an omission: a **planned
+removal is yellow, not red.** The four states are exclusive and
+`resolveWorkState` resolves them by phase; a removal that has only been announced
+is still a proposal, and colouring it like an accomplished removal would claim
+the component is already gone. That it is a removal is carried by the word
+`entfernen` in the label, by the operation glyph and by `data-operation` — the
+same three non-colour channels that carry everything else.
+
+### The camera still belongs to the user
+
+Nothing here calls `fitView`. A proposal arriving adds a node, ELK re-runs and
+the *model* moves under a camera that does not — that is `cameraPolicy.ts`
+unchanged from ADR 0008, and the overlay tests assert it again with the stricter
+case: a proposal component *and* a proposed relationship arrive at once,
+`data-fit-view-count` stays `1`, the rendered viewport transform is byte-identical
+and the selected component is still selected.
+
+A state change that does **not** change the structure must not re-run ELK at all.
+`projectionSignature` covers ids, nesting and sizes only, so a proposal turning
+into an applied change leaves the layout alone. That created a real defect —
+the laid-out nodes carried stale `data` — which `withCurrentData` in
+`useArchitectureGraph` fixes by putting the current data on the previous
+positions. States therefore update without a single node moving.
+
+Transitions are 150 ms on colour, border colour and opacity. There is no
+keyframe animation anywhere in the overlays, the counter or the marks, and a
+test asserts that the counter's markup contains no `animate-` class. The counter
+carries no `aria-live`: a screen reader announcing every incoming event is the
+auditory version of a camera that jumps. Its row keeps all four states with a
+count of zero rather than reflowing when one appears.
+
+## Consequences
+
+- The frontend now maintains a projection of the event log. It is bounded
+  (`HISTORY_LIMIT` 200, `RECENT_APPLIED_LIMIT` 8) and reset per project, but it
+  is a second place where event semantics live. Adding a change-carrying event
+  type means teaching `ingestEvent` about it as well as `affectedQueryKeys`.
+- `RECENT_APPLIED_LIMIT` is a product decision disguised as a constant. Eight is
+  enough to see a work package's worth of applied changes at once and small
+  enough that the canvas is not green everywhere after a long run.
+- `ComponentNodeData.component` widened to `AppliedComponent | Component`,
+  because an overlay-only node has no provenance — it was never applied. Code
+  that needs `appliedAt`/`position` must check `data.applied` first.
+- Proposals take part in the ELK layout. That is deliberate — a proposal drawn
+  outside the graph would not say *where* the component goes — but it means an
+  incoming proposal re-lays out the graph exactly like a real structural change
+  does. The camera stays put; the boxes move.
+- Ghosts accumulate until a replacing snapshot or the recency bound drops them.
+  A run that removes more than eight elements will stop showing the earliest
+  ones, which is the same bound as for applied changes and is why it is one
+  constant rather than two.
+- The overlay states `active` and `recently_applied` are only as good as the
+  stream. Against a backend that never delivers `work.step_started` the canvas
+  shows planned proposals and nothing else — correct, and visibly less, rather
+  than wrong. The same applies to a reload: the applied model and the pending
+  proposals come back, the three live states start empty again. Should that turn
+  out to be the wrong trade for a real reviewer, the fix is a bounded replay on
+  connect, and it belongs in the streaming layer rather than here.

--- a/frontend/src/api/useLiveStream.ts
+++ b/frontend/src/api/useLiveStream.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 
+import { ingestLiveEvent } from '@/state/changeLedgerStore'
 import { useLiveConnectionStore } from '@/state/liveConnectionStore'
 
 import {
@@ -13,17 +14,24 @@ import {
 import type { ProjectId, StreamedEvent } from './types'
 
 /**
- * Applies one live event to the query cache.
+ * Applies one live event to the client state.
  *
- * `invalidateQueries` marks the affected keys stale and refetches the ones that
- * are currently mounted. It never removes cached data, so the visible snapshot
- * stays on screen while the refetch is in flight — which is exactly the
- * behaviour the acceptance criteria demand for a flaky connection.
+ * Two destinations, and they stay strictly apart:
  *
- * Only the keys `affectedQueryKeys` returns are touched. There is no fallback
- * that invalidates everything.
+ * 1. **The query cache.** `invalidateQueries` marks the affected keys stale and
+ *    refetches the ones that are currently mounted. It never removes cached
+ *    data, so the visible snapshot stays on screen while the refetch is in
+ *    flight — which is exactly the behaviour the acceptance criteria demand for
+ *    a flaky connection. Only the keys `affectedQueryKeys` returns are touched;
+ *    there is no fallback that invalidates everything.
+ * 2. **The change ledger.** The three overlay states the read API cannot
+ *    express — a running work step, a just-applied change, an element a
+ *    removal took out of the model — are statements about the event log and are
+ *    folded there (`src/state/changeLedger.ts`). The ledger is not server state
+ *    and never enters the cache.
  */
 export function applyLiveEvent(queryClient: QueryClient, event: StreamedEvent): void {
+  ingestLiveEvent(event)
   for (const queryKey of affectedQueryKeys(event)) {
     void queryClient.invalidateQueries({ queryKey })
   }

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -236,14 +236,20 @@ function ArchitectureCanvasInner({
   const hasTemporaryPositions = Object.keys(nodePositions).length > 0
   const problemCount = diagnosticsCount(graph.diagnostics)
 
+  // The applied model and the overlay are counted separately on purpose: a
+  // planned change must become visible on the canvas **without** changing what
+  // the applied model contains, and these two numbers are how that stays
+  // checkable from the outside.
   return (
     <div
       className="relative h-full w-full min-w-0"
       data-testid="architecture-canvas"
       data-fit-view-count={fitViewCount}
       data-detail-level={detailLevel}
-      data-node-count={nodes.length}
-      data-edge-count={edges.length}
+      data-node-count={graph.appliedNodeCount}
+      data-edge-count={graph.appliedEdgeCount}
+      data-overlay-node-count={graph.overlayNodeCount}
+      data-overlay-edge-count={graph.overlayEdgeCount}
       data-layouting={graph.isRelayouting ? 'true' : 'false'}
     >
       <EdgeMarkerDefs />

--- a/frontend/src/canvas/ChangeOverlayMark.tsx
+++ b/frontend/src/canvas/ChangeOverlayMark.tsx
@@ -1,0 +1,83 @@
+import { Users } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+import { WORK_STATE_BY_ID } from '@/state/workStates'
+
+import { overlayLabel, overlayTitle, type ChangeOverlay } from './changeOverlays'
+
+/**
+ * The visible mark of a work state, on a node or on an edge.
+ *
+ * **Colour is never the only channel here, and the mark is the reason.** It
+ * always renders
+ *
+ * 1. the state's **icon** (a distinct glyph per state),
+ * 2. the state's **label as text** — `geplant`, `aktiv`, `kürzlich angewandt`,
+ *    `entfernt` — extended by the operation, so `geplant · entfernen` and
+ *    `geplant · hinzufügen` are told apart by words rather than by hue, and
+ * 3. a border in the state's **line style** (dashed, double, solid, dotted),
+ *
+ * with the colour on top of all three. A greyscale screenshot of the canvas
+ * loses nothing, and `data-work-state-label`, `data-border-style` and
+ * `data-operation` make that testable without looking at a single colour.
+ *
+ * When more than one agent reported for the same element, the count is shown
+ * next to the label and every single contribution is listed in the `title`.
+ * Nothing is merged away: two agents working on one component must be visible
+ * as two.
+ */
+export interface ChangeOverlayMarkProps {
+  overlay: ChangeOverlay
+  /** Drops the label text when the surrounding box is too small for it. */
+  compact?: boolean
+  className?: string
+}
+
+export function ChangeOverlayMark({
+  overlay,
+  compact = false,
+  className,
+}: ChangeOverlayMarkProps) {
+  const definition = WORK_STATE_BY_ID[overlay.state]
+  const Icon = definition.icon
+  const label = overlayLabel(overlay)
+  const agentCount = overlay.agentIds.length
+
+  return (
+    <span
+      className={cn(
+        'inline-flex max-w-full shrink-0 items-center gap-1 rounded-sm border px-1 py-px text-[10px] leading-tight',
+        'bg-card/90',
+        className,
+      )}
+      style={{
+        borderColor: `var(${definition.colorVar})`,
+        borderStyle: definition.borderStyle,
+        color: `var(${definition.colorVar})`,
+      }}
+      title={overlayTitle(overlay)}
+      data-testid={`overlay-mark-${overlay.targetKind}-${overlay.targetId}`}
+      data-work-state={overlay.state}
+      data-work-state-label={definition.label}
+      data-border-style={definition.borderStyle}
+      data-dasharray={definition.strokeDasharray}
+      data-operation={overlay.operation ?? 'none'}
+      data-presence={overlay.presence}
+      data-agent-count={agentCount}
+    >
+      <Icon className="size-3 shrink-0" aria-hidden="true" />
+      {compact ? (
+        <span className="sr-only">{label}</span>
+      ) : (
+        <span className="truncate">{label}</span>
+      )}
+      {agentCount > 1 && (
+        <span className="inline-flex shrink-0 items-center gap-0.5 font-medium">
+          <Users className="size-3" aria-hidden="true" />
+          {agentCount}
+          <span className="sr-only"> Agents melden zu diesem Element</span>
+        </span>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/canvas/ChangeOverlays.test.tsx
+++ b/frontend/src/canvas/ChangeOverlays.test.tsx
@@ -1,0 +1,697 @@
+import { act, screen, waitFor, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { ArchitectureResponse, Component } from '@/api/types'
+import { applyLiveEvent } from '@/api/useLiveStream'
+import { DEFAULT_CAMERA, useUiStore } from '@/state/uiStore'
+import { WORK_STATES } from '@/state/workStates'
+import {
+  NESTED_COMPONENTS,
+  NESTED_RELATIONSHIPS,
+  SHIPPING_BUS_RELATIONSHIP,
+  SHIPPING_COMPONENT,
+  activeChange,
+  architectureWithChanges,
+  grownArchitectureResponse,
+  nestedArchitectureResponse,
+} from '@/test/architectureFixtures'
+import { PROJECT_ID, RUN_ID, createFakeFetch, streamedEvent } from '@/test/fixtures'
+import { renderApp } from '@/test/renderApp'
+
+/**
+ * The live change overlays end to end: a committed event goes through the real
+ * SSE apply path, the read model refetches, and the canvas shows the reported
+ * work state.
+ *
+ * Every assertion about *what a state looks like* deliberately reads
+ * `data-work-state-label`, `data-border-style`, `data-operation` and the visible
+ * text. None of them reads a colour — that is the point of the encoding, and a
+ * test that checked a hue would prove the opposite of what is required.
+ */
+
+const WORKSPACE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}`
+const ARCHITECTURE_PATH = `/api/v1/projects/${PROJECT_ID}/architecture`
+const CANVAS_TIMEOUT = 15_000
+
+const PAYMENTS_DESCRIPTOR: Component = {
+  componentId: 'external.payments',
+  name: 'Payment Provider',
+  kind: 'external',
+  parentComponentId: null,
+}
+
+/** The nested model after the payment provider and its edge were removed. */
+const withoutPayments: ArchitectureResponse = {
+  projectPosition: 70,
+  components: NESTED_COMPONENTS.filter(
+    (one) => one.componentId !== 'external.payments',
+  ),
+  relationships: NESTED_RELATIONSHIPS.filter((one) => one.relationshipId !== 'r-08'),
+  activeChanges: [],
+}
+
+function architectureFetch(initial: ArchitectureResponse) {
+  const state = { response: initial }
+  const fetchImpl = createFakeFetch({
+    get [ARCHITECTURE_PATH]() {
+      return state.response
+    },
+  })
+  return {
+    fetchImpl,
+    publish(next: ArchitectureResponse) {
+      state.response = next
+    },
+  }
+}
+
+function renderCanvas(url = WORKSPACE_URL, initial = nestedArchitectureResponse) {
+  const architecture = architectureFetch(initial)
+  const app = renderApp(url, { fetchImpl: architecture.fetchImpl })
+  return { ...app, ...architecture }
+}
+
+async function waitForCanvas(): Promise<HTMLElement> {
+  const canvas = await screen.findByTestId('architecture-canvas', undefined, {
+    timeout: CANVAS_TIMEOUT,
+  })
+  await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'), {
+    timeout: CANVAS_TIMEOUT,
+  })
+  return canvas
+}
+
+async function waitForSettledLayout(canvas: HTMLElement): Promise<void> {
+  await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'), {
+    timeout: CANVAS_TIMEOUT,
+  })
+}
+
+/** The overlay mark of one component node, or `null` when it carries none. */
+function overlayMarkOf(componentId: string): HTMLElement | null {
+  const node = screen.queryByTestId(`canvas-node-${componentId}`)
+  if (!node) return null
+  return within(node).queryByTestId(`overlay-mark-component-${componentId}`)
+}
+
+// ---------------------------------------------------------------------------
+// The four states
+// ---------------------------------------------------------------------------
+
+describe('live change overlays — every state appears after its own event', () => {
+  it(
+    'geplant: a planned change is drawn as a proposal and leaves the applied model alone',
+    async () => {
+      const { queryClient, publish } = renderCanvas()
+      const canvas = await waitForCanvas()
+
+      const nodesBefore = canvas.getAttribute('data-node-count')
+      const edgesBefore = canvas.getAttribute('data-edge-count')
+      expect(nodesBefore).toBe(String(NESTED_COMPONENTS.length))
+      expect(canvas.getAttribute('data-overlay-node-count')).toBe('0')
+      expect(screen.queryByTestId('canvas-node-platform.core.shipping')).toBeNull()
+
+      // A planned change never enters `components`/`relationships` — the read
+      // API returns it under `activeChanges`, and this response says so.
+      publish(architectureWithChanges([activeChange({ operation: 'add' })]))
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'component.change_planned',
+            {
+              changeId: 'change-0001',
+              operation: 'add',
+              component: SHIPPING_COMPONENT,
+              rationale: 'Versand wird eigenständig.',
+            },
+            { position: 50, agentId: 'subagent-architecture-mapper' },
+          ),
+        )
+      })
+
+      const proposal = await screen.findByTestId(
+        'canvas-node-platform.core.shipping',
+        undefined,
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitForSettledLayout(canvas)
+
+      // The applied model is byte-identical to what it was…
+      expect(canvas.getAttribute('data-node-count')).toBe(nodesBefore)
+      expect(canvas.getAttribute('data-edge-count')).toBe(edgesBefore)
+      // …and the proposal is drawn next to it, marked as a proposal.
+      expect(canvas.getAttribute('data-overlay-node-count')).toBe('1')
+      expect(proposal).toHaveAttribute('data-work-state', 'planned')
+      expect(proposal).toHaveAttribute('data-work-state-label', 'geplant')
+      expect(proposal).toHaveAttribute('data-presence', 'proposal')
+      expect(proposal).toHaveAttribute('data-applied', 'false')
+      expect(overlayMarkOf('platform.core.shipping')).toHaveTextContent(
+        'geplant · hinzufügen',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'aktiv: a started work step marks the components it named',
+    async () => {
+      const { queryClient } = renderCanvas()
+      const canvas = await waitForCanvas()
+
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'work.step_started',
+            {
+              workStepId: 'work-1',
+              title: 'Bestellungen umbauen',
+              componentIds: ['platform.core.orders'],
+            },
+            { position: 51, agentId: 'subagent-implementer' },
+          ),
+        )
+      })
+
+      await waitFor(() =>
+        expect(screen.getByTestId('canvas-node-platform.core.orders')).toHaveAttribute(
+          'data-work-state',
+          'active',
+        ),
+      )
+      const node = screen.getByTestId('canvas-node-platform.core.orders')
+      expect(node).toHaveAttribute('data-work-state-label', 'aktiv')
+      expect(node).toHaveAttribute('data-presence', 'applied')
+      // A running work step reports work, not an operation on the model.
+      expect(node).toHaveAttribute('data-operation', 'none')
+      expect(overlayMarkOf('platform.core.orders')).toHaveTextContent('aktiv')
+      // The applied model did not change because work started on it.
+      expect(canvas.getAttribute('data-node-count')).toBe(
+        String(NESTED_COMPONENTS.length),
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'kürzlich angewandt: an applied change updates the model and keeps the component traceable',
+    async () => {
+      const { queryClient, publish } = renderCanvas()
+      const canvas = await waitForCanvas()
+      expect(canvas.getAttribute('data-node-count')).toBe(
+        String(NESTED_COMPONENTS.length),
+      )
+
+      publish(grownArchitectureResponse)
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'component.change_applied',
+            {
+              changeId: 'change-0001',
+              operation: 'add',
+              component: SHIPPING_COMPONENT,
+            },
+            { position: 52, agentId: 'subagent-architecture-mapper' },
+          ),
+        )
+      })
+
+      const node = await screen.findByTestId(
+        'canvas-node-platform.core.shipping',
+        undefined,
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitForSettledLayout(canvas)
+
+      // The applied model really grew — this is not an overlay any more.
+      expect(canvas.getAttribute('data-node-count')).toBe(
+        String(NESTED_COMPONENTS.length + 1),
+      )
+      expect(canvas.getAttribute('data-overlay-node-count')).toBe('0')
+      expect(node).toHaveAttribute('data-work-state', 'recently_applied')
+      expect(node).toHaveAttribute('data-work-state-label', 'kürzlich angewandt')
+      expect(node).toHaveAttribute('data-presence', 'applied')
+      expect(node).toHaveAttribute('data-applied', 'true')
+      // The component reference stays readable: the mark names the operation and
+      // its title names the agent that applied it.
+      expect(overlayMarkOf('platform.core.shipping')).toHaveTextContent(
+        'kürzlich angewandt · hinzugefügt',
+      )
+      expect(overlayMarkOf('platform.core.shipping')).toHaveAttribute(
+        'title',
+        expect.stringContaining('subagent-architecture-mapper'),
+      )
+      expect(within(node).getByTestId('node-name')).toHaveTextContent('Shipping')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'Entfernung: a removed component stays visible as what disappeared',
+    async () => {
+      const { queryClient, publish } = renderCanvas()
+      const canvas = await waitForCanvas()
+
+      publish(withoutPayments)
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'component.change_applied',
+            { operation: 'remove', component: PAYMENTS_DESCRIPTOR },
+            { position: 53, agentId: 'subagent-architecture-mapper' },
+          ),
+        )
+      })
+
+      await waitFor(
+        () =>
+          expect(canvas.getAttribute('data-node-count')).toBe(
+            String(NESTED_COMPONENTS.length - 1),
+          ),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitForSettledLayout(canvas)
+
+      const ghost = screen.getByTestId('canvas-node-external.payments')
+      expect(ghost).toHaveAttribute('data-work-state', 'removed')
+      expect(ghost).toHaveAttribute('data-presence', 'ghost')
+      expect(ghost).toHaveAttribute('data-applied', 'false')
+      // Red is one channel. The dotted border, the label and the icon are three
+      // more, and this assertion uses only those.
+      expect(ghost).toHaveAttribute('data-border-style', 'dotted')
+      expect(ghost).toHaveAttribute('data-work-state-label', 'entfernt')
+      expect(ghost).toHaveAttribute('data-operation', 'remove')
+      expect(overlayMarkOf('external.payments')).toHaveTextContent(
+        'entfernt · entfernt',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Colour-independence
+// ---------------------------------------------------------------------------
+
+describe('live change overlays — distinguishable without colour', () => {
+  it(
+    'tells two proposals of the same colour apart by their words alone',
+    async () => {
+      const { queryClient, publish } = renderCanvas()
+      const canvas = await waitForCanvas()
+
+      publish(
+        architectureWithChanges([
+          activeChange({ changeId: 'change-add', operation: 'add' }),
+          activeChange({
+            changeId: 'change-remove',
+            targetId: 'platform.db',
+            operation: 'remove',
+            agentId: 'subagent-implementer',
+            position: 51,
+          }),
+        ]),
+      )
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'component.change_planned',
+            { changeId: 'change-add', operation: 'add', component: SHIPPING_COMPONENT },
+            { position: 54 },
+          ),
+        )
+      })
+
+      await screen.findByTestId('canvas-node-platform.core.shipping', undefined, {
+        timeout: CANVAS_TIMEOUT,
+      })
+      await waitForSettledLayout(canvas)
+
+      const added = overlayMarkOf('platform.core.shipping')
+      const removed = overlayMarkOf('platform.db')
+
+      // Same state, therefore the same colour and the same border style…
+      expect(added).toHaveAttribute('data-work-state', 'planned')
+      expect(removed).toHaveAttribute('data-work-state', 'planned')
+      expect(added?.getAttribute('data-border-style')).toBe(
+        removed?.getAttribute('data-border-style'),
+      )
+      // …and still unmistakable, because the operation is written out.
+      expect(added).toHaveTextContent('geplant · hinzufügen')
+      expect(removed).toHaveTextContent('geplant · entfernen')
+      expect(added).toHaveAttribute('data-operation', 'add')
+      expect(removed).toHaveAttribute('data-operation', 'remove')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it('gives the four states four distinct non-colour signatures', () => {
+    // Label, icon and line style each separate all four states on their own, so
+    // no state depends on being seen in colour.
+    const signatures = WORK_STATES.map(
+      (state) => `${state.label}|${state.borderStyle}|${state.strokeDasharray}`,
+    )
+    expect(new Set(signatures).size).toBe(4)
+    expect(new Set(WORK_STATES.map((state) => state.icon)).size).toBe(4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Concurrency, retraction, snapshots, camera, counter
+// ---------------------------------------------------------------------------
+
+describe('live change overlays — concurrent agents', () => {
+  it(
+    'shows both agents when two of them change the same component',
+    async () => {
+      const { queryClient, publish } = renderCanvas()
+      await waitForCanvas()
+
+      publish(
+        architectureWithChanges([
+          activeChange({
+            changeId: 'change-a',
+            targetId: 'platform.core.orders',
+            operation: 'modify',
+            agentId: 'subagent-implementer',
+            position: 50,
+          }),
+          activeChange({
+            changeId: 'change-b',
+            targetId: 'platform.core.orders',
+            operation: 'modify',
+            agentId: 'subagent-reviewer',
+            position: 51,
+          }),
+        ]),
+      )
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'component.change_planned',
+            {
+              changeId: 'change-b',
+              operation: 'modify',
+              component: {
+                componentId: 'platform.core.orders',
+                name: 'Orders',
+                kind: 'module',
+                parentComponentId: 'platform.core',
+              },
+            },
+            { position: 55, agentId: 'subagent-reviewer' },
+          ),
+        )
+      })
+
+      await waitFor(() =>
+        expect(screen.getByTestId('canvas-node-platform.core.orders')).toHaveAttribute(
+          'data-agent-count',
+          '2',
+        ),
+      )
+
+      const mark = overlayMarkOf('platform.core.orders')
+      // The count is on screen, not only in the DOM…
+      expect(mark).toHaveTextContent('2')
+      // …and neither proposal was dropped in favour of the other.
+      const title = mark?.getAttribute('title') ?? ''
+      expect(title).toContain('subagent-implementer')
+      expect(title).toContain('subagent-reviewer')
+      expect(title).toContain('2 Agents')
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('live change overlays — retraction', () => {
+  it(
+    'removes the overlay of a withdrawn proposal and keeps the model untouched',
+    async () => {
+      const { queryClient, publish } = renderCanvas(
+        WORKSPACE_URL,
+        architectureWithChanges([activeChange({ operation: 'add' })]),
+      )
+      const canvas = await waitForCanvas()
+
+      const proposal = await screen.findByTestId('canvas-node-platform.core.shipping')
+      expect(proposal).toHaveAttribute('data-presence', 'proposal')
+      expect(canvas.getAttribute('data-node-count')).toBe(
+        String(NESTED_COMPONENTS.length),
+      )
+
+      // The agent withdraws the proposal. The server stops reporting it under
+      // `activeChanges`; the event log keeps both events.
+      publish(nestedArchitectureResponse)
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'retraction.issued',
+            {
+              retractsClientEventId: '3f2504e0-4f89-41d3-9a0c-0305e82c3301',
+              reason: 'Versand bleibt vorerst in den Bestellungen.',
+            },
+            { position: 56 },
+          ),
+        )
+      })
+
+      await waitFor(
+        () =>
+          expect(
+            screen.queryByTestId('canvas-node-platform.core.shipping'),
+          ).not.toBeInTheDocument(),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitForSettledLayout(canvas)
+
+      // The applied model was never involved in any of this.
+      expect(canvas.getAttribute('data-node-count')).toBe(
+        String(NESTED_COMPONENTS.length),
+      )
+      expect(canvas.getAttribute('data-overlay-node-count')).toBe('0')
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('live change overlays — a replacing snapshot', () => {
+  it(
+    'leaves consistent overlays behind: no ghost of something the snapshot contains',
+    async () => {
+      const { queryClient, publish } = renderCanvas()
+      const canvas = await waitForCanvas()
+
+      // First a removal, which leaves a ghost on the canvas.
+      publish(withoutPayments)
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'component.change_applied',
+            { operation: 'remove', component: PAYMENTS_DESCRIPTOR },
+            { position: 57 },
+          ),
+        )
+      })
+      await waitFor(() =>
+        expect(screen.getByTestId('canvas-node-external.payments')).toHaveAttribute(
+          'data-presence',
+          'ghost',
+        ),
+      )
+
+      // Then a snapshot that contains the component again. A ghost of it would
+      // now contradict the model on screen.
+      publish(nestedArchitectureResponse)
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'architecture.snapshot_published',
+            {
+              snapshotId: 'snapshot-2',
+              components: NESTED_COMPONENTS,
+              relationships: NESTED_RELATIONSHIPS,
+            },
+            { position: 58 },
+          ),
+        )
+      })
+
+      await waitFor(
+        () =>
+          expect(screen.getByTestId('canvas-node-external.payments')).toHaveAttribute(
+            'data-applied',
+            'true',
+          ),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitForSettledLayout(canvas)
+
+      expect(screen.getByTestId('canvas-node-external.payments')).not.toHaveAttribute(
+        'data-work-state',
+      )
+      expect(canvas.getAttribute('data-overlay-node-count')).toBe('0')
+      expect(canvas.getAttribute('data-node-count')).toBe(
+        String(NESTED_COMPONENTS.length),
+      )
+      expect(screen.getByTestId('change-counter')).toHaveAttribute('data-total', '0')
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('live change overlays — the camera and the selection stay put', () => {
+  it(
+    'draws a new proposal without moving zoom, pan or selection',
+    async () => {
+      const { queryClient, publish } = renderCanvas(
+        `${WORKSPACE_URL}?component=platform.db`,
+      )
+      const canvas = await waitForCanvas()
+
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+      await waitFor(
+        () => expect(useUiStore.getState().camera).not.toEqual(DEFAULT_CAMERA),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      let previous = useUiStore.getState().camera
+      await waitFor(
+        () => {
+          const current = useUiStore.getState().camera
+          const settled = current === previous
+          previous = current
+          expect(settled).toBe(true)
+        },
+        { timeout: CANVAS_TIMEOUT, interval: 40 },
+      )
+
+      const cameraBefore = useUiStore.getState().camera
+      const transformBefore =
+        document.querySelector<HTMLElement>('.react-flow__viewport')?.style.transform ?? ''
+      expect(transformBefore).not.toBe('')
+
+      // A proposed component *and* a proposed relationship: both add elements to
+      // the picture, so the layout really does change under the camera.
+      publish(
+        architectureWithChanges([
+          activeChange({ changeId: 'change-add', operation: 'add' }),
+          activeChange({
+            changeId: 'change-rel',
+            targetKind: 'relationship',
+            targetId: SHIPPING_BUS_RELATIONSHIP.relationshipId,
+            agentId: 'subagent-architecture-mapper',
+            snapshot: SHIPPING_BUS_RELATIONSHIP as unknown as Record<string, unknown>,
+            position: 51,
+          }),
+        ]),
+      )
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'component.change_planned',
+            { changeId: 'change-add', operation: 'add', component: SHIPPING_COMPONENT },
+            { position: 59 },
+          ),
+        )
+      })
+
+      await screen.findByTestId('canvas-node-platform.core.shipping', undefined, {
+        timeout: CANVAS_TIMEOUT,
+      })
+      await waitForSettledLayout(canvas)
+
+      expect(canvas.getAttribute('data-overlay-node-count')).toBe('1')
+      expect(canvas.getAttribute('data-overlay-edge-count')).toBe('1')
+      // Nothing about the camera or the selection moved with it.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+      expect(
+        document.querySelector<HTMLElement>('.react-flow__viewport')?.style.transform,
+      ).toBe(transformBefore)
+      expect(useUiStore.getState().camera).toEqual(cameraBefore)
+      expect(useUiStore.getState().selectedComponentId).toBe('platform.db')
+      expect(screen.getByTestId('canvas-node-platform.db')).toHaveAttribute(
+        'data-selected',
+        'true',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('live change overlays — the quiet counter', () => {
+  it(
+    'counts the running changes per state without demanding attention',
+    async () => {
+      const { queryClient, publish } = renderCanvas()
+      await waitForCanvas()
+
+      const counter = screen.getByTestId('change-counter')
+      expect(counter).toHaveAttribute('data-total', '0')
+
+      publish(
+        architectureWithChanges([
+          activeChange({ changeId: 'change-add', operation: 'add' }),
+          activeChange({
+            changeId: 'change-rel',
+            targetKind: 'relationship',
+            targetId: SHIPPING_BUS_RELATIONSHIP.relationshipId,
+            snapshot: SHIPPING_BUS_RELATIONSHIP as unknown as Record<string, unknown>,
+            position: 51,
+          }),
+        ]),
+      )
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'component.change_planned',
+            { changeId: 'change-add', operation: 'add', component: SHIPPING_COMPONENT },
+            { position: 60 },
+          ),
+        )
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'work.step_started',
+            {
+              workStepId: 'work-1',
+              title: 'Bestellungen umbauen',
+              componentIds: ['platform.core.orders'],
+            },
+            { position: 61, agentId: 'subagent-implementer' },
+          ),
+        )
+      })
+
+      await waitFor(() =>
+        expect(screen.getByTestId('change-counter-planned')).toHaveAttribute(
+          'data-count',
+          '2',
+        ),
+      )
+      expect(screen.getByTestId('change-counter-active')).toHaveAttribute(
+        'data-count',
+        '1',
+      )
+      expect(screen.getByTestId('change-counter')).toHaveTextContent('2geplant')
+      expect(screen.getByTestId('change-counter')).toHaveTextContent('1aktiv')
+
+      // Quiet by construction: no animation class anywhere on the counter, and
+      // no live region that would interrupt a screen reader on every event.
+      const html = screen.getByTestId('change-counter').outerHTML
+      expect(html).not.toContain('animate-')
+      expect(screen.getByTestId('change-counter')).not.toHaveAttribute('aria-live')
+    },
+    CANVAS_TIMEOUT,
+  )
+})

--- a/frontend/src/canvas/ComponentNode.tsx
+++ b/frontend/src/canvas/ComponentNode.tsx
@@ -2,7 +2,10 @@ import { Handle, Position, type NodeProps } from '@xyflow/react'
 import { memo } from 'react'
 
 import { cn } from '@/lib/utils'
+import { WORK_STATE_BY_ID } from '@/state/workStates'
 
+import { ChangeOverlayMark } from './ChangeOverlayMark'
+import type { ChangeOverlay } from './changeOverlays'
 import { componentKindStyle, componentTags, technologyParts } from './componentKinds'
 import { showsTags, showsTechnology } from './detailLevel'
 import { HANDLE_IDS, type ArchitectureNode } from './graphProjection'
@@ -15,7 +18,42 @@ import { useDetailLevel } from './useDetailLevel'
  * container around its children. Both take their size from the layout and
  * **never change it with the detail level** — the box is a fixed part of the
  * layout, only its content grows with the zoom (see `./detailLevel`).
+ *
+ * A reported work state is drawn **onto** the box: the border takes the state's
+ * line style and colour and a `ChangeOverlayMark` adds the icon and the label.
+ * The box size is untouched by it, so a change arriving cannot move the layout
+ * under the camera. A node that is not part of the applied model — an announced
+ * component, or one an applied change removed — is drawn dimmed and marked as
+ * such, so a proposal is never mistaken for something that already exists.
  */
+
+/** Border, tint and data attributes an overlay puts on a node box. */
+function overlayBoxProps(overlay: ChangeOverlay | null, applied: boolean) {
+  if (!overlay) {
+    return {
+      className: '',
+      style: undefined,
+      attributes: { 'data-applied': applied ? 'true' : 'false' } as Record<string, string>,
+    }
+  }
+  const definition = WORK_STATE_BY_ID[overlay.state]
+  return {
+    className: cn('border-2', overlay.presence !== 'applied' && 'opacity-80'),
+    style: {
+      borderColor: `var(${definition.colorVar})`,
+      borderStyle: definition.borderStyle,
+    } as const,
+    attributes: {
+      'data-applied': applied ? 'true' : 'false',
+      'data-work-state': overlay.state,
+      'data-work-state-label': definition.label,
+      'data-border-style': definition.borderStyle,
+      'data-operation': overlay.operation ?? 'none',
+      'data-presence': overlay.presence,
+      'data-agent-count': String(overlay.agentIds.length),
+    } as Record<string, string>,
+  }
+}
 
 /** Invisible, non-interactive connection points. v0 is read-only. */
 function NodeHandles() {
@@ -92,23 +130,30 @@ export const ComponentNode = memo(function ComponentNode({
   selected,
 }: NodeProps<ArchitectureNode>) {
   const level = useDetailLevel()
-  const { component } = data
+  const { component, overlay, applied } = data
   const kind = componentKindStyle(component.kind)
   const Icon = kind.icon
   const technology = technologyParts(component.technology)
   const tags = componentTags(component)
+  const box = overlayBoxProps(overlay, applied)
 
   return (
     <div
       className={cn(
-        'bg-card/95 border-border flex h-full w-full flex-col gap-1 overflow-hidden rounded-md border px-2.5 py-2 text-left shadow-sm transition-colors',
+        'bg-card/95 border-border flex h-full w-full flex-col gap-1 overflow-hidden rounded-md border px-2.5 py-2 text-left shadow-sm',
+        // Colour and border only, and only over 150 ms: a state arriving must
+        // read as a quiet change of appearance, never as motion.
+        'transition-[color,background-color,border-color,opacity] duration-150',
         'hover:border-muted-foreground/60',
+        box.className,
         selected && 'ring-ring border-ring/70 ring-2',
       )}
+      style={box.style}
       data-testid={`canvas-node-${component.componentId}`}
       data-component-id={component.componentId}
       data-detail-level={level}
       data-selected={selected ? 'true' : 'false'}
+      {...box.attributes}
     >
       <div className="flex items-start gap-1.5">
         <Icon className="text-muted-foreground mt-px size-3.5 shrink-0" aria-hidden="true" />
@@ -122,6 +167,7 @@ export const ComponentNode = memo(function ComponentNode({
         <KindBadge label={kind.label} />
       </div>
 
+      {overlay && <ChangeOverlayMark overlay={overlay} className="self-start" />}
       {showsTechnology(level) && <TechnologyRow parts={technology} />}
       {showsTags(level) && <TagRow tags={tags} />}
 
@@ -135,22 +181,27 @@ export const CompoundNode = memo(function CompoundNode({
   selected,
 }: NodeProps<ArchitectureNode>) {
   const level = useDetailLevel()
-  const { component, childCount } = data
+  const { component, childCount, overlay, applied } = data
   const kind = componentKindStyle(component.kind)
   const Icon = kind.icon
   const technology = technologyParts(component.technology)
+  const box = overlayBoxProps(overlay, applied)
 
   return (
     <div
       className={cn(
         'border-border/90 bg-card/35 h-full w-full rounded-lg border',
+        'transition-[border-color,opacity] duration-150',
+        box.className,
         selected && 'ring-ring border-ring/70 ring-2',
       )}
+      style={box.style}
       data-testid={`canvas-node-${component.componentId}`}
       data-component-id={component.componentId}
       data-detail-level={level}
       data-compound="true"
       data-selected={selected ? 'true' : 'false'}
+      {...box.attributes}
     >
       {/* Header row. The ELK padding reserves exactly this height at the top of
           the container, so it never overlaps a child. */}
@@ -171,6 +222,7 @@ export const CompoundNode = memo(function CompoundNode({
             {technology.join(' · ')}
           </span>
         )}
+        {overlay && <ChangeOverlayMark overlay={overlay} />}
         <span className="text-muted-foreground shrink-0 text-[10px]">
           {childCount} Kinder
         </span>

--- a/frontend/src/canvas/RelationshipEdge.tsx
+++ b/frontend/src/canvas/RelationshipEdge.tsx
@@ -4,7 +4,10 @@ import { memo, type ReactNode } from 'react'
 import type { Relationship } from '@/api/types'
 import { cn } from '@/lib/utils'
 import { useUiStore } from '@/state/uiStore'
+import { WORK_STATE_BY_ID } from '@/state/workStates'
 
+import { ChangeOverlayMark } from './ChangeOverlayMark'
+import { dominantOverlay, type ChangeOverlay } from './changeOverlays'
 import { unfoldsBundles } from './detailLevel'
 import {
   fallbackRoute,
@@ -49,11 +52,19 @@ interface EdgeRouteProps {
   interactive: boolean
   testId?: string
   kind?: string
+  /** Reported work state of this line, if any. */
+  overlay?: ChangeOverlay | null
 }
 
 /**
  * One drawn line. The wide transparent path underneath is the hit area: a 1.5 px
  * line is not a pointer target.
+ *
+ * A line that carries a work state gets **two** colour-independent markers on
+ * top of the state colour: a second path underneath drawn in the state's own
+ * dash pattern, and the label badge next to it. The line keeps its kind pattern,
+ * because that pattern is what identifies the *kind* — the two encodings must
+ * not fight over the same channel.
  */
 function EdgeRoute({
   points,
@@ -63,9 +74,12 @@ function EdgeRoute({
   interactive,
   testId,
   kind,
+  overlay = null,
 }: EdgeRouteProps) {
   const path = roundedPolylinePath(points)
   if (path === '') return null
+
+  const state = overlay ? WORK_STATE_BY_ID[overlay.state] : null
 
   return (
     <>
@@ -78,21 +92,39 @@ function EdgeRoute({
           className="react-flow__edge-interaction"
         />
       )}
+      {state && (
+        <path
+          d={path}
+          fill="none"
+          stroke={`var(${state.colorVar})`}
+          strokeWidth={5}
+          strokeOpacity={0.35}
+          strokeDasharray={
+            state.strokeDasharray === '0' ? undefined : state.strokeDasharray
+          }
+          strokeLinecap="round"
+          data-testid={testId ? `${testId}-state` : undefined}
+          data-work-state={overlay?.state}
+          data-state-dasharray={state.strokeDasharray}
+        />
+      )}
       <path
         d={path}
         fill="none"
-        stroke="currentColor"
+        stroke={state ? `var(${state.colorVar})` : 'currentColor'}
         strokeWidth={emphasised ? 2.25 : 1.5}
         strokeDasharray={strokeDasharray === '0' ? undefined : strokeDasharray}
         strokeLinecap="round"
         markerEnd={markerUrl(marker, emphasised)}
         className={cn(
-          'transition-colors',
-          emphasised ? 'text-ring' : 'text-muted-foreground',
+          'transition-colors duration-150',
+          !state && (emphasised ? 'text-ring' : 'text-muted-foreground'),
         )}
         data-testid={testId}
         data-relationship-kind={kind}
         data-dasharray={strokeDasharray}
+        data-work-state={overlay?.state}
+        data-presence={overlay?.presence}
       />
     </>
   )
@@ -148,6 +180,32 @@ function EdgeBadge({
   )
 }
 
+/**
+ * The work state of an edge, anchored to a point on its route.
+ *
+ * Positioned away from the kind badge so both stay readable: the kind badge
+ * sits at the middle of the line, the state mark closer to the target.
+ */
+function EdgeOverlayMark({
+  point,
+  overlay,
+}: {
+  point: LayoutPoint
+  overlay: ChangeOverlay
+}) {
+  return (
+    <span
+      style={{
+        position: 'absolute',
+        transform: `translate(-50%, -50%) translate(${point.x}px, ${point.y}px)`,
+      }}
+      className="pointer-events-auto"
+    >
+      <ChangeOverlayMark overlay={overlay} />
+    </span>
+  )
+}
+
 export const RelationshipEdge = memo(function RelationshipEdge({
   id,
   data,
@@ -172,10 +230,12 @@ export const RelationshipEdge = memo(function RelationshipEdge({
   const route: LayoutPoint[] =
     data.route ?? fallbackRoute({ x: sourceX, y: sourceY }, { x: targetX, y: targetY })
 
+  const overlays = data.overlays ?? {}
   const bundled = resolved.length > 1
   const unfolded = bundled && (unfoldsBundles(level) || expandedEdgeIds.includes(id))
 
   if (!bundled || !unfolded) {
+    const edgeOverlay = dominantOverlay(Object.values(overlays))
     const kinds = [...new Set(resolved.map((entry) => entry.relationship.kind))]
     const onlyKind = kinds.length === 1 ? kinds[0] : null
     const style = onlyKind ? RELATIONSHIP_KIND_STYLE_BY_ID[onlyKind] : null
@@ -204,9 +264,13 @@ export const RelationshipEdge = memo(function RelationshipEdge({
           emphasised={emphasised}
           interactive
           testId={`edge-path-${id}`}
+          overlay={edgeOverlay}
           {...(onlyKind ? { kind: onlyKind } : {})}
         />
         <EdgeLabelRenderer>
+          {edgeOverlay && (
+            <EdgeOverlayMark point={pointAtRatio(route, 0.74)} overlay={edgeOverlay} />
+          )}
           {bundled ? (
             <EdgeBadge
               point={badgePoint}
@@ -259,10 +323,23 @@ export const RelationshipEdge = memo(function RelationshipEdge({
             interactive={false}
             testId={`edge-path-${entry.relationship.relationshipId}`}
             kind={entry.relationship.kind}
+            overlay={overlays[entry.relationship.relationshipId] ?? null}
           />
         )
       })}
       <EdgeLabelRenderer>
+        {resolved.map((entry) => {
+          const overlay = overlays[entry.relationship.relationshipId]
+          if (!overlay) return null
+          const fanned = fanRoute(route, fanOffset(entry.index, entry.total))
+          return (
+            <EdgeOverlayMark
+              key={`state-${entry.relationship.relationshipId}`}
+              point={pointAtRatio(fanned, 0.74)}
+              overlay={overlay}
+            />
+          )
+        })}
         {resolved.map((entry) => {
           const style = RELATIONSHIP_KIND_STYLE_BY_ID[entry.relationship.kind]
           const fanned = fanRoute(route, fanOffset(entry.index, entry.total))

--- a/frontend/src/canvas/changeOverlays.test.ts
+++ b/frontend/src/canvas/changeOverlays.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it } from 'vitest'
+
+import type { StreamedEvent } from '@/api/types'
+import { EMPTY_LEDGER, ingestEvent, type ChangeLedger } from '@/state/changeLedger'
+import { WORK_STATES } from '@/state/workStates'
+import {
+  NESTED_COMPONENTS,
+  NESTED_RELATIONSHIPS,
+  SHIPPING_BUS_RELATIONSHIP,
+  SHIPPING_COMPONENT,
+  activeChange,
+} from '@/test/architectureFixtures'
+import { streamedEvent } from '@/test/fixtures'
+
+import {
+  buildChangeOverlays,
+  overlayLabel,
+  overlayTitle,
+  type ChangeOverlayInput,
+} from './changeOverlays'
+
+function fold(...events: StreamedEvent[]): ChangeLedger {
+  return events.reduce(ingestEvent, EMPTY_LEDGER)
+}
+
+function input(overrides: Partial<ChangeOverlayInput> = {}): ChangeOverlayInput {
+  return {
+    components: NESTED_COMPONENTS,
+    relationships: NESTED_RELATIONSHIPS,
+    activeChanges: [],
+    ledger: EMPTY_LEDGER,
+    ...overrides,
+  }
+}
+
+describe('change overlays — the applied model is never touched', () => {
+  it('draws a planned addition as its own node, outside the applied model', () => {
+    const model = buildChangeOverlays(
+      input({ activeChanges: [activeChange({ operation: 'add' })] }),
+    )
+
+    // Nothing was attached to an applied component…
+    expect(model.components.size).toBe(0)
+    // …the proposal became a separate element instead.
+    expect(model.extraComponents).toHaveLength(1)
+    const entry = model.extraComponents[0]
+    expect(entry?.component.componentId).toBe(SHIPPING_COMPONENT.componentId)
+    expect(entry?.overlay.state).toBe('planned')
+    expect(entry?.overlay.presence).toBe('proposal')
+    expect(model.counts.planned).toBe(1)
+  })
+
+  it('draws a planned relationship from the reported snapshot alone', () => {
+    const model = buildChangeOverlays(
+      input({
+        activeChanges: [
+          activeChange({
+            changeId: 'change-rel',
+            targetKind: 'relationship',
+            targetId: SHIPPING_BUS_RELATIONSHIP.relationshipId,
+            snapshot: SHIPPING_BUS_RELATIONSHIP as unknown as Record<string, unknown>,
+          }),
+        ],
+      }),
+    )
+
+    expect(model.extraRelationships).toHaveLength(1)
+    expect(model.extraRelationships[0]?.relationship.channel).toBe('shipping.dispatched')
+  })
+
+  it('marks a component of the applied model that a work step is running on', () => {
+    const model = buildChangeOverlays(
+      input({
+        ledger: fold(
+          streamedEvent(
+            'work.step_started',
+            {
+              workStepId: 'work-1',
+              title: 'Bestellungen umbauen',
+              componentIds: ['platform.core.orders'],
+            },
+            { position: 10 },
+          ),
+        ),
+      }),
+    )
+
+    const overlay = model.components.get('platform.core.orders')
+    expect(overlay?.state).toBe('active')
+    expect(overlay?.presence).toBe('applied')
+    expect(overlay?.operation).toBeNull()
+  })
+
+  it('keeps a removed component visible as a ghost of what disappeared', () => {
+    const removed = NESTED_COMPONENTS.filter(
+      (one) => one.componentId !== 'platform.core.billing',
+    )
+    const model = buildChangeOverlays(
+      input({
+        components: removed,
+        ledger: fold(
+          streamedEvent(
+            'component.change_applied',
+            {
+              operation: 'remove',
+              component: {
+                componentId: 'platform.core.billing',
+                name: 'Billing',
+                kind: 'module',
+                parentComponentId: 'platform.core',
+              },
+            },
+            { position: 10 },
+          ),
+        ),
+      }),
+    )
+
+    const ghost = model.extraComponents[0]
+    expect(ghost?.overlay.state).toBe('removed')
+    expect(ghost?.overlay.presence).toBe('ghost')
+    expect(ghost?.overlay.operation).toBe('remove')
+    expect(model.counts.removed).toBe(1)
+  })
+
+  it('reports an applied addition as recently applied on the model element', () => {
+    const model = buildChangeOverlays(
+      input({
+        components: [...NESTED_COMPONENTS],
+        ledger: fold(
+          streamedEvent(
+            'component.change_applied',
+            { operation: 'modify', component: { ...SHIPPING_COMPONENT } },
+            { position: 10 },
+          ),
+        ),
+      }),
+    )
+
+    // The component is not in this applied model, so it is a proposal-shaped
+    // leftover rather than a model element — the overlay says so instead of
+    // pretending the model contains it.
+    expect(model.components.size).toBe(0)
+    expect(model.extraComponents[0]?.overlay.state).toBe('recently_applied')
+  })
+})
+
+describe('change overlays — concurrent agents', () => {
+  const twoAgents = () =>
+    buildChangeOverlays(
+      input({
+        activeChanges: [
+          activeChange({
+            changeId: 'change-a',
+            targetId: 'platform.core.orders',
+            operation: 'modify',
+            agentId: 'subagent-implementer',
+            position: 50,
+          }),
+          activeChange({
+            changeId: 'change-b',
+            targetId: 'platform.core.orders',
+            operation: 'modify',
+            agentId: 'subagent-reviewer',
+            position: 51,
+          }),
+        ],
+      }),
+    )
+
+  it('keeps both agents on the same component instead of letting one win', () => {
+    const overlay = twoAgents().components.get('platform.core.orders')
+
+    expect(overlay?.contributions).toHaveLength(2)
+    expect(overlay?.agentIds).toEqual(['subagent-implementer', 'subagent-reviewer'])
+  })
+
+  it('names every contributing agent in the text of the overlay', () => {
+    const overlay = twoAgents().components.get('platform.core.orders')
+    const title = overlayTitle(overlay!)
+
+    expect(title).toContain('2 Agents')
+    expect(title).toContain('subagent-implementer')
+    expect(title).toContain('subagent-reviewer')
+  })
+
+  it('does not lose the earlier proposal when a later change is applied', () => {
+    const model = buildChangeOverlays(
+      input({
+        activeChanges: [
+          activeChange({
+            changeId: 'change-b',
+            targetId: 'platform.core.orders',
+            operation: 'modify',
+            agentId: 'subagent-reviewer',
+            position: 50,
+          }),
+        ],
+        ledger: fold(
+          streamedEvent(
+            'component.change_applied',
+            {
+              operation: 'modify',
+              component: {
+                componentId: 'platform.core.orders',
+                name: 'Orders',
+                kind: 'module',
+                parentComponentId: 'platform.core',
+              },
+            },
+            { position: 60, agentId: 'subagent-implementer' },
+          ),
+        ),
+      }),
+    )
+
+    const overlay = model.components.get('platform.core.orders')
+    // The newest statement decides the state…
+    expect(overlay?.state).toBe('recently_applied')
+    // …and the other agent's still-standing proposal is right next to it.
+    expect(overlay?.agentIds).toHaveLength(2)
+    expect(
+      overlay?.contributions.map((contribution) => contribution.source),
+    ).toEqual(['planned_change', 'applied_change'])
+  })
+})
+
+describe('change overlays — retraction and replacing snapshots', () => {
+  it('drops a retracted proposal from the overlay', () => {
+    const withProposal = buildChangeOverlays(input({ activeChanges: [activeChange()] }))
+    expect(withProposal.total).toBe(1)
+
+    // The read API stops reporting a retracted change; nothing else is needed.
+    const afterRetraction = buildChangeOverlays(input({ activeChanges: [] }))
+    expect(afterRetraction.total).toBe(0)
+  })
+
+  it('ignores a change whose reporting event was retracted', () => {
+    const ledger = fold(
+      streamedEvent(
+        'component.change_applied',
+        { operation: 'remove', component: SHIPPING_COMPONENT },
+        { position: 10, clientEventId: 'aaaaaaaa-0000-4000-8000-000000000003' },
+      ),
+      streamedEvent(
+        'retraction.issued',
+        {
+          retractsClientEventId: 'aaaaaaaa-0000-4000-8000-000000000003',
+          reason: 'Falsch gemeldet.',
+        },
+        { position: 11 },
+      ),
+    )
+
+    expect(buildChangeOverlays(input({ ledger })).total).toBe(0)
+    // The history itself is untouched.
+    expect(ledger.history).toHaveLength(1)
+  })
+
+  it('is consistent again after a replacing snapshot', () => {
+    const ledger = fold(
+      streamedEvent(
+        'component.change_applied',
+        {
+          operation: 'remove',
+          component: {
+            componentId: 'platform.db',
+            name: 'Orders DB',
+            kind: 'datastore',
+            parentComponentId: 'platform',
+          },
+        },
+        { position: 10 },
+      ),
+      streamedEvent(
+        'architecture.snapshot_published',
+        {
+          snapshotId: 'snapshot-2',
+          components: NESTED_COMPONENTS,
+          relationships: NESTED_RELATIONSHIPS,
+        },
+        { position: 11 },
+      ),
+    )
+
+    // The snapshot contains `platform.db` again. A ghost of it would contradict
+    // the model that is now on screen, so the ledger dropped the statement.
+    const model = buildChangeOverlays(input({ ledger }))
+    expect(model.total).toBe(0)
+    expect(model.extraComponents).toHaveLength(0)
+  })
+})
+
+describe('change overlays — readable without colour', () => {
+  it('gives every state a distinct label, icon and line style', () => {
+    const labels = WORK_STATES.map((state) => state.label)
+    const icons = WORK_STATES.map((state) => state.icon)
+    const borders = WORK_STATES.map((state) => state.borderStyle)
+    const dashes = WORK_STATES.map((state) => state.strokeDasharray)
+
+    expect(new Set(labels).size).toBe(WORK_STATES.length)
+    expect(new Set(icons).size).toBe(WORK_STATES.length)
+    expect(new Set(borders).size).toBe(WORK_STATES.length)
+    expect(new Set(dashes).size).toBe(WORK_STATES.length)
+  })
+
+  it('spells the operation out, so two proposals of the same colour differ in words', () => {
+    const added = buildChangeOverlays(
+      input({ activeChanges: [activeChange({ operation: 'add' })] }),
+    ).extraComponents[0]?.overlay
+    const removedProposal = buildChangeOverlays(
+      input({
+        activeChanges: [
+          activeChange({ targetId: 'platform.db', operation: 'remove', changeId: 'change-rm' }),
+        ],
+      }),
+    ).components.get('platform.db')
+
+    expect(added && overlayLabel(added)).toBe('geplant · hinzufügen')
+    expect(removedProposal && overlayLabel(removedProposal)).toBe('geplant · entfernen')
+    // Same state, same colour — the words are what tells them apart.
+    expect(added?.state).toBe(removedProposal?.state)
+  })
+
+  it('never states a judgement, only a phase of work', () => {
+    const model = buildChangeOverlays(
+      input({ activeChanges: [activeChange({ operation: 'remove', targetId: 'platform.db' })] }),
+    )
+    const text = overlayTitle(model.components.get('platform.db')!)
+
+    for (const verdict of ['Fehler', 'falsch', 'schlecht', 'Risiko', 'gefährlich', 'gut']) {
+      expect(text.toLowerCase()).not.toContain(verdict.toLowerCase())
+    }
+  })
+})

--- a/frontend/src/canvas/changeOverlays.ts
+++ b/frontend/src/canvas/changeOverlays.ts
@@ -1,0 +1,434 @@
+import {
+  changeSnapshot,
+  type ActiveChange,
+  type AgentId,
+  type AppliedComponent,
+  type AppliedRelationship,
+  type ChangeOperation,
+  type Component,
+  type ComponentId,
+  type Identifier,
+  type Relationship,
+  type RunId,
+  type Timestamp,
+} from '@/api/types'
+import {
+  openWorkSteps as openWorkStepsOf,
+  recentAppliedChanges,
+  type ChangeLedger,
+} from '@/state/changeLedger'
+import { resolveWorkState, WORK_STATE_BY_ID, type WorkStateId } from '@/state/workStates'
+
+/**
+ * Builds the change overlay of one architecture snapshot.
+ *
+ * The overlay is drawn **next to and on top of** the applied model, never inside
+ * it. That separation is not a style choice: the read API delivers the applied
+ * model in `components`/`relationships` and the proposals in `activeChanges`,
+ * and a planned change is by contract not part of the model. Merging the two
+ * here would make the canvas assert something the agent never reported — that
+ * the change already happened.
+ *
+ * Three kinds of element come out of this module:
+ *
+ * | presence   | what it is                                            |
+ * | ---------- | ----------------------------------------------------- |
+ * | `applied`  | an element of the applied model, with a state on it   |
+ * | `proposal` | announced, not in the applied model — drawn from `ActiveChange.snapshot` |
+ * | `ghost`    | removed by an applied change — kept as evidence of what disappeared |
+ *
+ * **Concurrent work is merged, never collapsed.** Every reported contribution
+ * for the same target is kept in `contributions`, together with the agent that
+ * reported it. The single work state on the element is the dominant phase
+ * (`resolveWorkState` decides), but the agents behind it stay countable and
+ * listable, so one agent's change can never silently overwrite another's.
+ */
+
+export type OverlayPresence = 'applied' | 'proposal' | 'ghost'
+
+export type ContributionSource = 'planned_change' | 'applied_change' | 'work_step'
+
+/** One reported statement about a target, kept verbatim. */
+export interface OverlayContribution {
+  source: ContributionSource
+  agentId: AgentId
+  runId: RunId
+  /** `null` for a work step — it reports work, not an operation on the model. */
+  operation: ChangeOperation | null
+  at: Timestamp
+  position: number
+  /** Change id, work step id, or `null` when the agent reported none. */
+  reference: Identifier | null
+  /** Short human-readable description of what was reported. */
+  detail: string
+}
+
+export interface ChangeOverlay {
+  targetKind: 'component' | 'relationship'
+  targetId: string
+  state: WorkStateId
+  presence: OverlayPresence
+  /** Operation of the newest change; `null` when only a work step is running. */
+  operation: ChangeOperation | null
+  /** Every reported contribution, oldest first. Nothing is dropped. */
+  contributions: OverlayContribution[]
+  /** Distinct agents behind those contributions, in first-seen order. */
+  agentIds: AgentId[]
+  /**
+   * The reported descriptor of a `proposal` or a `ghost`. `null` for an applied
+   * element — that one is already in the model.
+   */
+  descriptor: Component | Relationship | null
+}
+
+export interface OverlayComponent {
+  component: Component
+  overlay: ChangeOverlay
+}
+
+export interface OverlayRelationship {
+  relationship: Relationship
+  overlay: ChangeOverlay
+}
+
+export type WorkStateCounts = Record<WorkStateId, number>
+
+export const EMPTY_WORK_STATE_COUNTS: WorkStateCounts = {
+  planned: 0,
+  active: 0,
+  recently_applied: 0,
+  removed: 0,
+}
+
+export interface ChangeOverlayModel {
+  /** Overlay of an applied component, by component id. */
+  components: ReadonlyMap<ComponentId, ChangeOverlay>
+  /** Overlay of an applied relationship, by relationship id. */
+  relationships: ReadonlyMap<Identifier, ChangeOverlay>
+  /** Components to draw that the applied model does not contain. */
+  extraComponents: OverlayComponent[]
+  /** Relationships to draw that the applied model does not contain. */
+  extraRelationships: OverlayRelationship[]
+  counts: WorkStateCounts
+  /** Total number of elements carrying an overlay. */
+  total: number
+}
+
+export const EMPTY_OVERLAY_MODEL: ChangeOverlayModel = {
+  components: new Map(),
+  relationships: new Map(),
+  extraComponents: [],
+  extraRelationships: [],
+  counts: EMPTY_WORK_STATE_COUNTS,
+  total: 0,
+}
+
+/**
+ * German verbs for the three contract operations.
+ *
+ * They describe the operation and nothing else. No word here may suggest a
+ * verdict: the cockpit reports what an agent is doing, it does not grade it.
+ */
+export const CHANGE_OPERATION_LABELS: Record<ChangeOperation, string> = {
+  add: 'hinzufügen',
+  modify: 'ändern',
+  remove: 'entfernen',
+}
+
+export const CHANGE_OPERATION_PARTICIPLES: Record<ChangeOperation, string> = {
+  add: 'hinzugefügt',
+  modify: 'geändert',
+  remove: 'entfernt',
+}
+
+/**
+ * The label an overlay carries on the canvas — always text, never only colour.
+ *
+ * `geplant · entfernen` and `geplant · hinzufügen` are the same colour and the
+ * same border style; the operation is what tells them apart, so it is spelled
+ * out rather than encoded.
+ */
+export function overlayLabel(overlay: ChangeOverlay): string {
+  const state = WORK_STATE_BY_ID[overlay.state].label
+  if (overlay.operation === null) return state
+  const operation =
+    overlay.state === 'planned'
+      ? CHANGE_OPERATION_LABELS[overlay.operation]
+      : CHANGE_OPERATION_PARTICIPLES[overlay.operation]
+  return `${state} · ${operation}`
+}
+
+/**
+ * Precedence when several relationships of one drawn edge carry a state.
+ *
+ * Identical to the precedence `resolveWorkState` applies to a single element,
+ * so a bundle can never announce a weaker phase than one of its members.
+ */
+const STATE_PRECEDENCE: readonly WorkStateId[] = [
+  'removed',
+  'active',
+  'planned',
+  'recently_applied',
+]
+
+/** The state a bundle of overlays shows on its line. `null` when there is none. */
+export function dominantOverlay(
+  overlays: readonly ChangeOverlay[],
+): ChangeOverlay | null {
+  let best: ChangeOverlay | null = null
+  for (const overlay of overlays) {
+    if (
+      best === null ||
+      STATE_PRECEDENCE.indexOf(overlay.state) < STATE_PRECEDENCE.indexOf(best.state)
+    ) {
+      best = overlay
+    }
+  }
+  return best
+}
+
+/**
+ * The full text an overlay carries in its `title`.
+ *
+ * Every contribution is listed with the agent that reported it, so two agents
+ * working on the same component are readable line by line instead of being
+ * summarised into one. The text is plain prose and states phases only — it
+ * never says whether a change is good, risky or right.
+ */
+export function overlayTitle(overlay: ChangeOverlay): string {
+  const definition = WORK_STATE_BY_ID[overlay.state]
+  const lines = [`${overlayLabel(overlay)} — ${definition.description}`]
+  if (overlay.presence === 'proposal') {
+    lines.push('Vorschlag: nicht Teil des angewandten Architekturmodells.')
+  }
+  if (overlay.presence === 'ghost') {
+    lines.push('Nicht mehr Teil des angewandten Architekturmodells.')
+  }
+  if (overlay.agentIds.length > 1) {
+    lines.push(`${overlay.agentIds.length} Agents melden zu diesem Element:`)
+  }
+  for (const contribution of overlay.contributions) {
+    lines.push(`• ${contribution.agentId}: ${contribution.detail}`)
+  }
+  return lines.join('\n')
+}
+
+export interface ChangeOverlayInput {
+  components: readonly AppliedComponent[]
+  relationships: readonly AppliedRelationship[]
+  /** Pending proposals, as the read API returns them (state `planned` only). */
+  activeChanges: readonly ActiveChange[]
+  ledger: ChangeLedger
+}
+
+interface Draft {
+  targetKind: 'component' | 'relationship'
+  targetId: string
+  contributions: OverlayContribution[]
+  /** Newest non-work-step contribution, which decides the state. */
+  latestChange: { state: 'planned' | 'applied'; operation: ChangeOperation } | null
+  latestChangePosition: number
+  hasActiveWorkStep: boolean
+  descriptor: Component | Relationship | null
+}
+
+export function buildChangeOverlays(input: ChangeOverlayInput): ChangeOverlayModel {
+  const appliedComponentIds = new Set(input.components.map((one) => one.componentId))
+  const appliedRelationshipIds = new Set(
+    input.relationships.map((one) => one.relationshipId),
+  )
+
+  const drafts = new Map<string, Draft>()
+  const draftFor = (
+    targetKind: 'component' | 'relationship',
+    targetId: string,
+  ): Draft => {
+    const key = `${targetKind}:${targetId}`
+    const existing = drafts.get(key)
+    if (existing) return existing
+    const created: Draft = {
+      targetKind,
+      targetId,
+      contributions: [],
+      latestChange: null,
+      latestChangePosition: -1,
+      hasActiveWorkStep: false,
+      descriptor: null,
+    }
+    drafts.set(key, created)
+    return created
+  }
+
+  const recordChange = (
+    draft: Draft,
+    phase: 'planned' | 'applied',
+    operation: ChangeOperation,
+    position: number,
+    descriptor: Component | Relationship | null,
+  ): void => {
+    if (position < draft.latestChangePosition) return
+    draft.latestChange = { state: phase, operation }
+    draft.latestChangePosition = position
+    if (descriptor !== null) draft.descriptor = descriptor
+  }
+
+  // ---- 1. pending proposals, straight from the read model -----------------
+  // These are authoritative: the server drops a change from `activeChanges` the
+  // moment it is applied or retracted, so a withdrawn proposal disappears here
+  // without the client having to remember anything.
+  for (const change of input.activeChanges) {
+    if (change.state !== 'planned') continue
+    const draft = draftFor(change.targetKind, change.targetId)
+    draft.contributions.push({
+      source: 'planned_change',
+      agentId: change.agentId,
+      runId: change.runId,
+      operation: change.operation,
+      at: change.plannedAt ?? '',
+      position: change.position,
+      reference: change.changeId,
+      detail: `Änderung angekündigt: ${CHANGE_OPERATION_LABELS[change.operation]}`,
+    })
+    recordChange(
+      draft,
+      'planned',
+      change.operation,
+      change.position,
+      changeSnapshot(change),
+    )
+  }
+
+  // ---- 2. recently applied changes, from the event log --------------------
+  for (const entry of recentAppliedChanges(input.ledger)) {
+    const draft = draftFor(entry.targetKind, entry.targetId)
+    draft.contributions.push({
+      source: 'applied_change',
+      agentId: entry.agentId,
+      runId: entry.runId,
+      operation: entry.operation,
+      at: entry.occurredAt,
+      position: entry.position,
+      reference: entry.changeId,
+      detail: `Änderung angewandt: ${CHANGE_OPERATION_PARTICIPLES[entry.operation]}`,
+    })
+    recordChange(draft, 'applied', entry.operation, entry.position, entry.snapshot)
+  }
+
+  // ---- 3. open work steps -------------------------------------------------
+  for (const step of openWorkStepsOf(input.ledger)) {
+    for (const componentId of step.componentIds) {
+      const draft = draftFor('component', componentId)
+      draft.hasActiveWorkStep = true
+      draft.contributions.push({
+        source: 'work_step',
+        agentId: step.agentId,
+        runId: step.runId,
+        operation: null,
+        at: step.occurredAt,
+        position: step.position,
+        reference: step.workStepId,
+        detail: `Arbeitsschritt läuft: ${step.title}`,
+      })
+    }
+  }
+
+  // ---- 4. resolve --------------------------------------------------------
+  const components = new Map<ComponentId, ChangeOverlay>()
+  const relationships = new Map<Identifier, ChangeOverlay>()
+  const extraComponents: OverlayComponent[] = []
+  const extraRelationships: OverlayRelationship[] = []
+  const counts: WorkStateCounts = { ...EMPTY_WORK_STATE_COUNTS }
+
+  for (const draft of [...drafts.values()].sort((a, b) =>
+    a.targetId < b.targetId ? -1 : a.targetId > b.targetId ? 1 : 0,
+  )) {
+    const state = resolveWorkState({
+      hasActiveWorkStep: draft.hasActiveWorkStep,
+      change: draft.latestChange,
+    })
+    if (state === null) continue
+
+    const inAppliedModel =
+      draft.targetKind === 'component'
+        ? appliedComponentIds.has(draft.targetId)
+        : appliedRelationshipIds.has(draft.targetId)
+
+    const presence: OverlayPresence = inAppliedModel
+      ? 'applied'
+      : state === 'removed'
+        ? 'ghost'
+        : 'proposal'
+
+    // A proposal or a ghost can only be drawn when the agent actually reported
+    // a descriptor for it. Without one there is nothing to place on the canvas,
+    // and inventing a box would be inventing a component.
+    if (!inAppliedModel && draft.descriptor === null) continue
+
+    const contributions = [...draft.contributions].sort((a, b) => a.position - b.position)
+    const agentIds: AgentId[] = []
+    for (const contribution of contributions) {
+      if (!agentIds.includes(contribution.agentId)) agentIds.push(contribution.agentId)
+    }
+
+    const overlay: ChangeOverlay = {
+      targetKind: draft.targetKind,
+      targetId: draft.targetId,
+      state,
+      presence,
+      operation: draft.latestChange?.operation ?? null,
+      contributions,
+      agentIds,
+      descriptor: inAppliedModel ? null : draft.descriptor,
+    }
+
+    counts[state] += 1
+
+    if (draft.targetKind === 'component') {
+      if (inAppliedModel) components.set(draft.targetId, overlay)
+      else
+        extraComponents.push({
+          component: draft.descriptor as Component,
+          overlay,
+        })
+    } else {
+      if (inAppliedModel) relationships.set(draft.targetId, overlay)
+      else
+        extraRelationships.push({
+          relationship: draft.descriptor as Relationship,
+          overlay,
+        })
+    }
+  }
+
+  return {
+    components,
+    relationships,
+    extraComponents,
+    extraRelationships,
+    counts,
+    total: components.size + relationships.size + extraComponents.length + extraRelationships.length,
+  }
+}
+
+/**
+ * Compact fingerprint of an overlay model.
+ *
+ * Used to decide whether a re-render is worth it. It covers exactly what is
+ * drawn — target, state, presence, operation and the number of agents behind it
+ * — and nothing that only exists in a tooltip.
+ */
+export function overlaySignature(model: ChangeOverlayModel): string {
+  const parts: string[] = []
+  const push = (overlay: ChangeOverlay): void => {
+    parts.push(
+      `${overlay.targetKind}:${overlay.targetId}=${overlay.state}/${overlay.presence}/${
+        overlay.operation ?? '-'
+      }/${overlay.agentIds.length}`,
+    )
+  }
+  for (const overlay of model.components.values()) push(overlay)
+  for (const overlay of model.relationships.values()) push(overlay)
+  for (const entry of model.extraComponents) push(entry.overlay)
+  for (const entry of model.extraRelationships) push(entry.overlay)
+  return parts.sort().join('|')
+}

--- a/frontend/src/canvas/graphProjection.ts
+++ b/frontend/src/canvas/graphProjection.ts
@@ -3,10 +3,13 @@ import type { Edge, Node, NodeHandle, Position } from '@xyflow/react'
 import type {
   AppliedComponent,
   AppliedRelationship,
+  Component,
   ComponentId,
   Identifier,
+  Relationship,
 } from '@/api/types'
 
+import type { ChangeOverlay, ChangeOverlayModel } from './changeOverlays'
 import { relationshipDiscriminator, relationshipDisplayName } from './relationshipKinds'
 
 /**
@@ -86,13 +89,22 @@ export function nodeHandles(width: number, height: number): NodeHandle[] {
 }
 
 export interface ComponentNodeData extends Record<string, unknown> {
-  component: AppliedComponent
+  /**
+   * The applied component, or — for an overlay-only node — the descriptor the
+   * agent reported with the change. Both satisfy `Component`; only an applied
+   * one carries provenance.
+   */
+  component: AppliedComponent | Component
+  /** `true` when this node is part of the applied architecture model. */
+  applied: boolean
   /** 0 for a root component, 1 for its children, and so on. */
   depth: number
   /** Number of direct children rendered inside this node. */
   childCount: number
   /** `true` when this node is a compound container. */
   isCompound: boolean
+  /** Reported work state of this component, or `null` when none was reported. */
+  overlay: ChangeOverlay | null
 }
 
 export type ArchitectureNode = Node<ComponentNodeData, ArchitectureNodeType>
@@ -105,7 +117,11 @@ export interface RelationshipEdgeData extends Record<string, unknown> {
    * `relationshipId`. Always at least one entry — this is the list the UI
    * resolves a bundle back into.
    */
-  relationships: AppliedRelationship[]
+  relationships: (AppliedRelationship | Relationship)[]
+  /** `true` when every relationship of this edge is part of the applied model. */
+  applied: boolean
+  /** Reported work state per `relationshipId`. Empty when none was reported. */
+  overlays: Record<Identifier, ChangeOverlay>
   /** `true` when more than one relationship shares this pair of components. */
   bundled: boolean
   /**
@@ -206,6 +222,13 @@ export function diagnosticsCount(diagnostics: ProjectionDiagnostics): number {
 export interface ArchitectureModel {
   components: readonly AppliedComponent[]
   relationships: readonly AppliedRelationship[]
+  /**
+   * The live change overlay, if one was built. It never enters `components` or
+   * `relationships`: proposals and ghosts become their **own** nodes and edges,
+   * marked `applied: false`, so the applied model stays exactly what the read
+   * API reported.
+   */
+  overlay?: ChangeOverlayModel | undefined
 }
 
 export interface ArchitectureProjection {
@@ -215,7 +238,15 @@ export interface ArchitectureProjection {
   edges: ArchitectureEdge[]
   diagnostics: ProjectionDiagnostics
   /** Components by id, for lookups that would otherwise re-scan the list. */
-  componentsById: Map<ComponentId, AppliedComponent>
+  componentsById: Map<ComponentId, AppliedComponent | Component>
+  /** Nodes that are part of the applied model. */
+  appliedNodeCount: number
+  /** Nodes drawn only because a change was reported (proposals and ghosts). */
+  overlayNodeCount: number
+  /** Edges of the applied model. */
+  appliedEdgeCount: number
+  /** Edges drawn only because a change was reported. */
+  overlayEdgeCount: number
 }
 
 export const EMPTY_DIAGNOSTICS: ProjectionDiagnostics = {
@@ -230,6 +261,17 @@ export const EMPTY_DIAGNOSTICS: ProjectionDiagnostics = {
 /** Builds the id of the edge that carries the relationships of one node pair. */
 export function bundleEdgeId(source: ComponentId, target: ComponentId): string {
   return `rel:${source}~>${target}`
+}
+
+/**
+ * Id of the edge that carries the *proposed* relationships of one node pair.
+ *
+ * Deliberately a different id space from `bundleEdgeId`: an announced edge and
+ * an applied edge between the same two components are two separate statements,
+ * and bundling them into one line would claim the proposal already happened.
+ */
+export function overlayEdgeId(source: ComponentId, target: ComponentId): string {
+  return `overlay:${source}~>${target}`
 }
 
 const compareIds = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
@@ -250,8 +292,16 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
     selfReferences: [],
   }
 
+  const overlay = model.overlay
+
   // ---- 1. canonical component index ---------------------------------------
-  const componentsById = new Map<ComponentId, AppliedComponent>()
+  // The applied model first, the overlay-only components after it. An overlay
+  // component whose id is already applied is skipped rather than merged: the
+  // applied row is what the read API reported and it wins, always.
+  const componentsById = new Map<ComponentId, AppliedComponent | Component>()
+  const appliedComponentIds = new Set<ComponentId>()
+  const overlayOfComponent = new Map<ComponentId, ChangeOverlay>()
+
   const sortedComponents = [...model.components].sort((a, b) =>
     compareIds(a.componentId, b.componentId),
   )
@@ -263,6 +313,22 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
       continue
     }
     componentsById.set(component.componentId, component)
+    appliedComponentIds.add(component.componentId)
+  }
+
+  if (overlay) {
+    for (const [componentId, entry] of overlay.components) {
+      if (appliedComponentIds.has(componentId)) overlayOfComponent.set(componentId, entry)
+    }
+    const extras = [...overlay.extraComponents].sort((a, b) =>
+      compareIds(a.component.componentId, b.component.componentId),
+    )
+    for (const extra of extras) {
+      const componentId = extra.component.componentId
+      if (componentsById.has(componentId)) continue
+      componentsById.set(componentId, extra.component)
+      overlayOfComponent.set(componentId, extra.overlay)
+    }
   }
 
   // ---- 2. resolve parents, cutting links that point nowhere ---------------
@@ -270,8 +336,9 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
   for (const [componentId, component] of componentsById) {
     // The contract types `parentComponentId` as `ComponentId | null` and always
     // sends the field; `ComponentId` has `minLength: 1`, so "no parent" is
-    // `null` and never an empty string. There is nothing else to guard against.
-    const parentId = component.parentComponentId
+    // `null` and never an empty string. A reported descriptor may omit it
+    // entirely, which means the same thing.
+    const parentId = component.parentComponentId ?? null
     if (parentId === null) {
       parentOf.set(componentId, null)
       continue
@@ -358,9 +425,11 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
       handles: nodeHandles(size.width, size.height),
       data: {
         component,
+        applied: appliedComponentIds.has(entry.componentId),
         depth: entry.depth,
         childCount: children.length,
         isCompound,
+        overlay: overlayOfComponent.get(entry.componentId) ?? null,
       },
       ...(parentId !== null ? { parentId, extent: 'parent' as const } : {}),
     }
@@ -373,7 +442,10 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
   }
 
   // ---- 6. relationships -> bundled edges ----------------------------------
-  const relationshipsById = new Map<Identifier, AppliedRelationship>()
+  const relationshipsById = new Map<Identifier, AppliedRelationship | Relationship>()
+  const appliedRelationshipIds = new Set<Identifier>()
+  const overlayOfRelationship = new Map<Identifier, ChangeOverlay>()
+
   const sortedRelationships = [...model.relationships].sort((a, b) =>
     compareIds(a.relationshipId, b.relationshipId),
   )
@@ -385,9 +457,27 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
       continue
     }
     relationshipsById.set(relationship.relationshipId, relationship)
+    appliedRelationshipIds.add(relationship.relationshipId)
   }
 
-  const bundles = new Map<string, AppliedRelationship[]>()
+  if (overlay) {
+    for (const [relationshipId, entry] of overlay.relationships) {
+      if (appliedRelationshipIds.has(relationshipId)) {
+        overlayOfRelationship.set(relationshipId, entry)
+      }
+    }
+    const extras = [...overlay.extraRelationships].sort((a, b) =>
+      compareIds(a.relationship.relationshipId, b.relationship.relationshipId),
+    )
+    for (const extra of extras) {
+      const relationshipId = extra.relationship.relationshipId
+      if (relationshipsById.has(relationshipId)) continue
+      relationshipsById.set(relationshipId, extra.relationship)
+      overlayOfRelationship.set(relationshipId, extra.overlay)
+    }
+  }
+
+  const bundles = new Map<string, (AppliedRelationship | Relationship)[]>()
   for (const relationship of relationshipsById.values()) {
     const { sourceComponentId, targetComponentId, relationshipId } = relationship
 
@@ -411,18 +501,30 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
       diagnostics.selfReferences.push(relationshipId)
     }
 
-    const key = bundleEdgeId(sourceComponentId, targetComponentId)
+    const key = appliedRelationshipIds.has(relationshipId)
+      ? bundleEdgeId(sourceComponentId, targetComponentId)
+      : overlayEdgeId(sourceComponentId, targetComponentId)
     const existing = bundles.get(key)
     if (existing) existing.push(relationship)
     else bundles.set(key, [relationship])
   }
 
+  let overlayEdgeCount = 0
   const edges: ArchitectureEdge[] = [...bundles.keys()]
     .sort(compareIds)
     .map((edgeId) => {
       // Non-null: the key came from this very map.
-      const relationships = bundles.get(edgeId) as AppliedRelationship[]
-      const first = relationships[0] as AppliedRelationship
+      const relationships = bundles.get(edgeId) as (AppliedRelationship | Relationship)[]
+      const first = relationships[0] as AppliedRelationship | Relationship
+      const applied = appliedRelationshipIds.has(first.relationshipId)
+      if (!applied) overlayEdgeCount += 1
+
+      const overlays: Record<Identifier, ChangeOverlay> = {}
+      for (const relationship of relationships) {
+        const entry = overlayOfRelationship.get(relationship.relationshipId)
+        if (entry) overlays[relationship.relationshipId] = entry
+      }
+
       return {
         id: edgeId,
         type: RELATIONSHIP_EDGE_TYPE,
@@ -434,12 +536,25 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
           sourceComponentId: first.sourceComponentId,
           targetComponentId: first.targetComponentId,
           relationships,
+          applied,
+          overlays,
           bundled: relationships.length > 1,
         },
       }
     })
 
-  return { nodes, edges, diagnostics, componentsById }
+  const overlayNodeCount = nodes.filter((node) => node.data.applied === false).length
+
+  return {
+    nodes,
+    edges,
+    diagnostics,
+    componentsById,
+    appliedNodeCount: nodes.length - overlayNodeCount,
+    overlayNodeCount,
+    appliedEdgeCount: edges.length - overlayEdgeCount,
+    overlayEdgeCount,
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -447,7 +562,7 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
 // ---------------------------------------------------------------------------
 
 export interface ResolvedRelationship {
-  relationship: AppliedRelationship
+  relationship: AppliedRelationship | Relationship
   /** Index within the bundle, used for the fan-out offset. */
   index: number
   /** Number of relationships in the bundle this one belongs to. */
@@ -476,7 +591,7 @@ export function resolveEdgeBundle(edge: ArchitectureEdge): ResolvedRelationship[
 
 /** Same as `resolveEdgeBundle`, for callers that already hold the list. */
 export function resolveRelationships(
-  relationships: readonly AppliedRelationship[],
+  relationships: readonly (AppliedRelationship | Relationship)[],
 ): ResolvedRelationship[] {
   return relationships.map((relationship, index) => ({
     relationship,

--- a/frontend/src/canvas/useArchitectureGraph.ts
+++ b/frontend/src/canvas/useArchitectureGraph.ts
@@ -29,6 +29,14 @@ export interface ArchitectureGraph {
   error: unknown
   /** Structural fingerprint of the model currently laid out. */
   signature: string
+  /** Nodes that belong to the applied architecture model. */
+  appliedNodeCount: number
+  /** Nodes drawn only because a change was reported (proposals and ghosts). */
+  overlayNodeCount: number
+  /** Edges of the applied model. */
+  appliedEdgeCount: number
+  /** Edges drawn only because a change was reported. */
+  overlayEdgeCount: number
 }
 
 const EMPTY_MODEL: ArchitectureModel = { components: [], relationships: [] }
@@ -95,7 +103,11 @@ export function useArchitectureGraph(
     const isCurrent = laidOut !== null && laidOut.signature === signature
 
     return {
-      nodes: isEmpty ? [] : isCurrent ? laidOut.nodes : (laidOut?.nodes ?? []),
+      nodes: isEmpty
+        ? []
+        : isCurrent
+          ? withCurrentData(laidOut.nodes, projection.nodes)
+          : (laidOut?.nodes ?? []),
       edges: projection.edges,
       routes: isCurrent ? laidOut.routes : {},
       diagnostics: projection.diagnostics ?? EMPTY_DIAGNOSTICS,
@@ -103,8 +115,34 @@ export function useArchitectureGraph(
       isRelayouting: !isEmpty && !isCurrent,
       error,
       signature,
+      appliedNodeCount: projection.appliedNodeCount,
+      overlayNodeCount: projection.overlayNodeCount,
+      appliedEdgeCount: projection.appliedEdgeCount,
+      overlayEdgeCount: projection.overlayEdgeCount,
     }
   }, [laidOut, projection, signature, error])
+}
+
+/**
+ * Puts the current node data on the laid-out nodes.
+ *
+ * A work state changes far more often than the structure does — a planned
+ * change becomes active, an active one becomes applied — and none of that moves
+ * a node: `projectionSignature` covers ids, nesting and sizes only, so ELK is
+ * deliberately not re-run for it. The positions therefore stay the ones from the
+ * last layout while the data comes from the current projection. Without this
+ * step a state change would be invisible until something structural happened to
+ * force a new layout.
+ */
+function withCurrentData(
+  laidOut: readonly ArchitectureNode[],
+  current: readonly ArchitectureNode[],
+): ArchitectureNode[] {
+  const dataById = new Map(current.map((node) => [node.id, node.data]))
+  return laidOut.map((node) => {
+    const data = dataById.get(node.id)
+    return data === undefined || data === node.data ? node : { ...node, data }
+  })
 }
 
 interface LayoutState {

--- a/frontend/src/canvas/useChangeOverlays.ts
+++ b/frontend/src/canvas/useChangeOverlays.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+
+import type { ArchitectureResponse, ProjectId } from '@/api/types'
+import { selectLedgerFor, useChangeLedgerStore } from '@/state/changeLedgerStore'
+
+import {
+  buildChangeOverlays,
+  EMPTY_OVERLAY_MODEL,
+  type ChangeOverlayModel,
+} from './changeOverlays'
+
+/**
+ * The change overlay of one project, from the two sources it has.
+ *
+ * * `architecture.activeChanges` — the **pending proposals**, authoritative and
+ *   server-side: the read API drops a change from that list the moment it is
+ *   applied or retracted, so a withdrawn proposal disappears without the client
+ *   remembering anything.
+ * * the **change ledger** — the states the read API cannot express, folded out
+ *   of the SSE stream: a work step that is running, a change that was just
+ *   applied, an element an applied change removed.
+ *
+ * Both are read-only inputs. Nothing here writes back into the query cache, and
+ * the overlay never becomes part of `components`/`relationships`.
+ */
+export function useChangeOverlays(
+  projectId: ProjectId,
+  architecture: ArchitectureResponse | undefined,
+): ChangeOverlayModel {
+  const ledger = useChangeLedgerStore((state) => selectLedgerFor(state, projectId))
+
+  return useMemo(() => {
+    // Nothing loaded yet: an overlay without a model to put it on would be a
+    // claim about components the cockpit has not seen.
+    if (!architecture) return EMPTY_OVERLAY_MODEL
+    return buildChangeOverlays({
+      components: architecture.components,
+      relationships: architecture.relationships,
+      activeChanges: architecture.activeChanges,
+      ledger,
+    })
+  }, [architecture, ledger])
+}

--- a/frontend/src/components/workspace/ArchitecturePane.tsx
+++ b/frontend/src/components/workspace/ArchitecturePane.tsx
@@ -3,8 +3,10 @@ import { useMemo } from 'react'
 import { useArchitecture } from '@/api/queries'
 import type { ComponentId, ProjectId } from '@/api/types'
 import { ArchitectureCanvas } from '@/canvas/ArchitectureCanvas'
+import { useChangeOverlays } from '@/canvas/useChangeOverlays'
 import { AsyncState } from '@/components/AsyncState'
 import { StatusLegend } from '@/components/StatusLegend'
+import { ChangeCounter } from '@/components/workspace/ChangeCounter'
 import { PaneHeader } from '@/components/workspace/PaneHeader'
 import { RelationshipLegend } from '@/components/workspace/RelationshipLegend'
 import { Badge } from '@/components/ui/badge'
@@ -32,19 +34,22 @@ export function ArchitecturePane({
   onSelectComponent,
 }: ArchitecturePaneProps) {
   const architecture = useArchitecture(projectId)
+  const overlay = useChangeOverlays(projectId, architecture.data)
 
   const componentCount = architecture.data?.components.length ?? 0
   const relationshipCount = architecture.data?.relationships.length ?? 0
-  const activeChangeCount = architecture.data?.activeChanges.length ?? 0
 
   // Kept stable across refetches: TanStack Query's structural sharing returns
   // the same arrays when nothing changed, so the canvas does not re-layout.
+  // The overlay travels alongside the applied model, never inside it — a
+  // proposal must not turn into a component of the reported architecture.
   const model = useMemo(
     () => ({
       components: architecture.data?.components ?? [],
       relationships: architecture.data?.relationships ?? [],
+      overlay,
     }),
-    [architecture.data?.components, architecture.data?.relationships],
+    [architecture.data?.components, architecture.data?.relationships, overlay],
   )
 
   return (
@@ -58,15 +63,14 @@ export function ArchitecturePane({
         subtitle={projectId}
         actions={
           architecture.isSuccess && (
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-2">
+              <ChangeCounter counts={overlay.counts} />
+              <span className="bg-border h-4 w-px" aria-hidden="true" />
               <Badge variant="outline" className="text-2xs font-normal">
                 {componentCount} Komponenten
               </Badge>
               <Badge variant="outline" className="text-2xs font-normal">
                 {relationshipCount} Beziehungen
-              </Badge>
-              <Badge variant="outline" className="text-2xs font-normal">
-                {activeChangeCount} aktive Änderungen
               </Badge>
             </div>
           )

--- a/frontend/src/components/workspace/ChangeCounter.tsx
+++ b/frontend/src/components/workspace/ChangeCounter.tsx
@@ -1,0 +1,68 @@
+import type { WorkStateCounts } from '@/canvas/changeOverlays'
+import { cn } from '@/lib/utils'
+import { WORK_STATES } from '@/state/workStates'
+
+/**
+ * The live counter of what the agents are currently doing to the model.
+ *
+ * Deliberately unexciting. It is read while an agent works and it changes
+ * whenever an event arrives, so it must never draw the eye away from the
+ * canvas:
+ *
+ * * no animation, no flashing, no counting-up — the number simply is what it is,
+ * * the row does not reflow when a state appears or disappears, because a state
+ *   with a count of zero keeps its place and only goes quiet,
+ * * `aria-live` is off. A screen reader announcing every incoming event would be
+ *   the auditory version of a camera that jumps.
+ *
+ * Each entry carries its icon and its label, so the counter is readable without
+ * colour like everything else in this product.
+ */
+export interface ChangeCounterProps {
+  counts: WorkStateCounts
+  className?: string
+}
+
+export function ChangeCounter({ counts, className }: ChangeCounterProps) {
+  const total = WORK_STATES.reduce((sum, state) => sum + counts[state.id], 0)
+
+  return (
+    <span
+      className={cn('flex items-center gap-2', className)}
+      data-testid="change-counter"
+      data-total={total}
+      aria-label={
+        total === 0
+          ? 'Keine gemeldeten Änderungen'
+          : WORK_STATES.filter((state) => counts[state.id] > 0)
+              .map((state) => `${counts[state.id]} ${state.label}`)
+              .join(', ')
+      }
+    >
+      {WORK_STATES.map((state) => {
+        const count = counts[state.id]
+        const Icon = state.icon
+        return (
+          <span
+            key={state.id}
+            className={cn(
+              'flex items-center gap-1 text-[11px] whitespace-nowrap',
+              'transition-opacity duration-150',
+              count === 0 ? 'text-muted-foreground/45' : 'text-muted-foreground',
+            )}
+            data-testid={`change-counter-${state.id}`}
+            data-count={count}
+            title={state.description}
+          >
+            <Icon
+              className={cn('size-3.5 shrink-0', count > 0 && state.colorClass)}
+              aria-hidden="true"
+            />
+            <span className="tabular-nums">{count}</span>
+            <span>{state.label}</span>
+          </span>
+        )
+      })}
+    </span>
+  )
+}

--- a/frontend/src/state/changeLedger.test.ts
+++ b/frontend/src/state/changeLedger.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest'
+
+import type { StreamedEvent } from '@/api/types'
+import { PROJECT_ID, streamedEvent } from '@/test/fixtures'
+
+import {
+  EMPTY_LEDGER,
+  RECENT_APPLIED_LIMIT,
+  ingestEvent,
+  openWorkSteps,
+  recentAppliedChanges,
+  standingChanges,
+  type ChangeLedger,
+} from './changeLedger'
+
+const COMPONENT = {
+  componentId: 'platform.core.shipping',
+  name: 'Shipping',
+  kind: 'module' as const,
+  parentComponentId: 'platform.core',
+}
+
+function fold(...events: StreamedEvent[]): ChangeLedger {
+  return events.reduce(ingestEvent, EMPTY_LEDGER)
+}
+
+describe('change ledger — what the read API cannot answer', () => {
+  it('records a started work step and drops it again when it completes', () => {
+    const started = fold(
+      streamedEvent(
+        'work.step_started',
+        {
+          workStepId: 'work-1',
+          title: 'VAT-Extraktion',
+          componentIds: ['platform.core.orders', 'platform.db'],
+        },
+        { position: 10 },
+      ),
+    )
+    expect(openWorkSteps(started)).toHaveLength(1)
+    expect(openWorkSteps(started)[0]?.componentIds).toEqual([
+      'platform.core.orders',
+      'platform.db',
+    ])
+
+    const completed = ingestEvent(
+      started,
+      streamedEvent(
+        'work.step_completed',
+        { workStepId: 'work-1', summary: 'fertig' },
+        { position: 11 },
+      ),
+    )
+    expect(openWorkSteps(completed)).toHaveLength(0)
+  })
+
+  it('appends every reported change instead of overwriting the previous one', () => {
+    const ledger = fold(
+      streamedEvent(
+        'component.change_planned',
+        { changeId: 'c-1', operation: 'add', component: COMPONENT },
+        { position: 10, agentId: 'agent-a' },
+      ),
+      streamedEvent(
+        'component.change_applied',
+        { changeId: 'c-1', operation: 'add', component: COMPONENT },
+        { position: 11, agentId: 'agent-b' },
+      ),
+    )
+
+    expect(ledger.history).toHaveLength(2)
+    expect(ledger.history.map((entry) => entry.phase)).toEqual(['planned', 'applied'])
+    expect(ledger.history.map((entry) => entry.agentId)).toEqual(['agent-a', 'agent-b'])
+  })
+
+  it('marks a retracted change instead of deleting it — the history survives', () => {
+    const planned = streamedEvent(
+      'component.change_planned',
+      { changeId: 'c-1', operation: 'add', component: COMPONENT },
+      { position: 10, clientEventId: 'aaaaaaaa-0000-4000-8000-000000000001' },
+    )
+    const ledger = fold(
+      planned,
+      streamedEvent(
+        'retraction.issued',
+        {
+          retractsClientEventId: 'aaaaaaaa-0000-4000-8000-000000000001',
+          reason: 'Doch nicht nötig.',
+        },
+        { position: 11 },
+      ),
+    )
+
+    // Still there, still inspectable…
+    expect(ledger.history).toHaveLength(1)
+    expect(ledger.history[0]?.retracted).toBe(true)
+    // …but it no longer stands, so it contributes nothing to an overlay.
+    expect(standingChanges(ledger)).toHaveLength(0)
+  })
+
+  it('supersedes the corrected event and folds in the corrected content', () => {
+    const original = streamedEvent(
+      'component.change_applied',
+      { operation: 'add', component: { ...COMPONENT, name: 'Shiping' } },
+      { position: 10, clientEventId: 'aaaaaaaa-0000-4000-8000-000000000002' },
+    )
+    const ledger = fold(
+      original,
+      streamedEvent(
+        'correction.issued',
+        {
+          correctsClientEventId: 'aaaaaaaa-0000-4000-8000-000000000002',
+          reason: 'Tippfehler im Namen.',
+          correctedType: 'component.change_applied',
+          correctedPayload: { operation: 'add', component: COMPONENT },
+        },
+        { position: 11 },
+      ),
+    )
+
+    expect(ledger.history).toHaveLength(2)
+    expect(ledger.history[0]?.superseded).toBe(true)
+    const standing = standingChanges(ledger)
+    expect(standing).toHaveLength(1)
+    expect((standing[0]?.snapshot as { name: string }).name).toBe('Shipping')
+  })
+
+  it('resets the applied history when a snapshot replaces the model', () => {
+    const ledger = fold(
+      streamedEvent(
+        'component.change_applied',
+        { operation: 'remove', component: COMPONENT },
+        { position: 10 },
+      ),
+      streamedEvent(
+        'architecture.snapshot_published',
+        { snapshotId: 'snapshot-2', components: [], relationships: [] },
+        { position: 11 },
+      ),
+    )
+
+    expect(ledger.history).toHaveLength(0)
+  })
+
+  it('keeps an open work step across a replacing snapshot', () => {
+    const ledger = fold(
+      streamedEvent(
+        'work.step_started',
+        { workStepId: 'work-1', title: 'Umbau', componentIds: ['platform.db'] },
+        { position: 10 },
+      ),
+      streamedEvent(
+        'architecture.snapshot_published',
+        { snapshotId: 'snapshot-2', components: [], relationships: [] },
+        { position: 11 },
+      ),
+    )
+
+    // A work step is a statement about an agent, not about the model.
+    expect(openWorkSteps(ledger)).toHaveLength(1)
+  })
+
+  it('ignores a replayed event, so a reconnect cannot double-count', () => {
+    const event = streamedEvent(
+      'component.change_applied',
+      { operation: 'add', component: COMPONENT },
+      { position: 10 },
+    )
+    const once = ingestEvent(EMPTY_LEDGER, event)
+    const twice = ingestEvent(once, event)
+
+    expect(twice).toBe(once)
+    expect(twice.history).toHaveLength(1)
+  })
+
+  it('starts over when an event of another project arrives', () => {
+    const ledger = fold(
+      streamedEvent(
+        'component.change_applied',
+        { operation: 'add', component: COMPONENT },
+        { position: 10 },
+      ),
+      streamedEvent(
+        'component.change_applied',
+        { operation: 'add', component: COMPONENT },
+        { position: 3, projectId: 'other-project' },
+      ),
+    )
+
+    expect(ledger.projectId).toBe('other-project')
+    expect(ledger.history).toHaveLength(1)
+  })
+
+  it('counts recency instead of timing it', () => {
+    let ledger = EMPTY_LEDGER
+    for (let index = 0; index < RECENT_APPLIED_LIMIT + 3; index += 1) {
+      ledger = ingestEvent(
+        ledger,
+        streamedEvent(
+          'component.change_applied',
+          {
+            operation: 'add',
+            component: { ...COMPONENT, componentId: `component-${index}` },
+          },
+          { position: 10 + index },
+        ),
+      )
+    }
+
+    const recent = recentAppliedChanges(ledger)
+    expect(recent).toHaveLength(RECENT_APPLIED_LIMIT)
+    // The oldest three fell out; nothing expired because time passed.
+    expect(recent[0]?.targetId).toBe('component-3')
+    expect(ledger.history).toHaveLength(RECENT_APPLIED_LIMIT + 3)
+  })
+
+  it('leaves the ledger untouched for an event it has nothing to say about', () => {
+    const before = fold(
+      streamedEvent(
+        'component.change_applied',
+        { operation: 'add', component: COMPONENT },
+        { position: 10 },
+      ),
+    )
+    const after = ingestEvent(
+      before,
+      streamedEvent(
+        'agent.progress_reported',
+        { percent: 40, scope: 'own_task', basis: 'completed_steps' },
+        { position: 11 },
+      ),
+    )
+
+    // Same object identity: an unrelated event cannot cause a re-render.
+    expect(after.history).toBe(before.history)
+    expect(after.projectId).toBe(PROJECT_ID)
+  })
+})

--- a/frontend/src/state/changeLedger.ts
+++ b/frontend/src/state/changeLedger.ts
@@ -1,0 +1,320 @@
+import type {
+  AgentId,
+  ChangeOperation,
+  Component,
+  Identifier,
+  ProjectId,
+  Relationship,
+  RunId,
+  StreamedEvent,
+  Timestamp,
+  Uuid,
+} from '@/api/types'
+
+/**
+ * The client-side ledger of everything the overlays need and the read API
+ * cannot answer.
+ *
+ * `GET /architecture` returns the applied model plus the proposals that are
+ * still `planned` — and nothing else. It has, by contract, no notion of
+ *
+ * * a work step that is **started and not yet completed** (the `active` state),
+ * * a change that was **just applied** (the `recently_applied` state), or
+ * * an element that an applied change **removed** (the `removed` state), because
+ *   a removed component is exactly the one that is no longer in the response.
+ *
+ * All three are statements about the *event log*, and the log is what the SSE
+ * stream delivers.
+ *
+ * **The ledger describes what the cockpit watched happen.** A stream opened
+ * without a cursor starts at the live tail rather than replaying the project
+ * (`liveOnly` in `backend/internal/sse/connection.go`, ADR 0006), so opening the
+ * cockpit mid-run shows the applied model, the pending proposals from the read
+ * model — and from that moment on every state as its event arrives. That is what
+ * "kürzlich angewandt" means, and it is the honest reading: the ledger never
+ * claims to know a phase it did not see reported. A reconnect *does* replay the
+ * gap, and replayed events are folded in idempotently.
+ *
+ * Three properties hold, and each of them is a rule of the product:
+ *
+ * 1. **Nothing is overwritten.** Every change event is appended to `history`.
+ *    A retraction *marks* its entry, a correction *supersedes* its entry — both
+ *    keep the original inspectable, exactly as the append-only log does.
+ * 2. **"Recent" is counted, never timed.** Only the newest
+ *    `RECENT_APPLIED_LIMIT` applied changes contribute an overlay. A clock-based
+ *    window would make the picture change without an event having arrived, which
+ *    is precisely the restless behaviour the cockpit must not produce.
+ * 3. **A replacing snapshot resets it.** `architecture.snapshot_published`
+ *    replaces the applied model entirely, so every earlier "applied" or
+ *    "removed" statement is a statement about a model that no longer exists.
+ *    Keeping them would draw a ghost of something the new model contains.
+ */
+
+/** Newest applied changes that still contribute an overlay. */
+export const RECENT_APPLIED_LIMIT = 8
+
+/** Hard cap on the retained history, so a long run cannot grow without bound. */
+export const HISTORY_LIMIT = 200
+
+export type ChangePhase = 'planned' | 'applied'
+
+/** One reported change, kept verbatim. */
+export interface LedgerChange {
+  /** `clientEventId` of the reporting event — the key a retraction names. */
+  clientEventId: Uuid
+  /** Agent-assigned change id, or `null` when the agent reported none. */
+  changeId: Identifier | null
+  targetKind: 'component' | 'relationship'
+  targetId: string
+  operation: ChangeOperation
+  phase: ChangePhase
+  agentId: AgentId
+  runId: RunId
+  occurredAt: Timestamp
+  position: number
+  /** The reported descriptor, exactly as it arrived. */
+  snapshot: Component | Relationship
+  /** `true` once a `retraction.issued` withdrew the reporting event. */
+  retracted: boolean
+  /** `true` once a `correction.issued` replaced the reporting event. */
+  superseded: boolean
+}
+
+/** A work step that was started and has not been completed. */
+export interface LedgerWorkStep {
+  workStepId: Identifier
+  clientEventId: Uuid
+  title: string
+  agentId: AgentId
+  runId: RunId
+  componentIds: readonly string[]
+  occurredAt: Timestamp
+  position: number
+}
+
+export interface ChangeLedger {
+  /** Project the ledger describes. `null` before the first event. */
+  projectId: ProjectId | null
+  /** Highest position ingested; replayed events at or below it are ignored. */
+  lastPosition: number
+  /** Every change event seen, oldest first. Append-only. */
+  history: readonly LedgerChange[]
+  /** Work steps that are started and not completed, keyed by `workStepId`. */
+  openWorkSteps: Readonly<Record<Identifier, LedgerWorkStep>>
+}
+
+export const EMPTY_LEDGER: ChangeLedger = {
+  projectId: null,
+  lastPosition: 0,
+  history: [],
+  openWorkSteps: {},
+}
+
+/** Guards against a pathological chain of corrections correcting corrections. */
+const MAX_CORRECTION_DEPTH = 4
+
+/**
+ * Folds one streamed event into the ledger.
+ *
+ * Pure and total: an event the ledger has nothing to say about returns the very
+ * same object, so a caller can use identity to decide whether anything changed.
+ * Replayed events (`position <= lastPosition`) are ignored, which makes the
+ * reconnect path of ADR 0006 idempotent here as well.
+ */
+export function ingestEvent(ledger: ChangeLedger, event: StreamedEvent): ChangeLedger {
+  const base =
+    ledger.projectId !== null && ledger.projectId !== event.projectId
+      ? { ...EMPTY_LEDGER, projectId: event.projectId }
+      : { ...ledger, projectId: event.projectId }
+
+  if (event.position <= base.lastPosition) return ledger
+
+  const next = applyEvent(base, event, 0)
+  return { ...next, lastPosition: event.position }
+}
+
+function applyEvent(
+  ledger: ChangeLedger,
+  event: StreamedEvent,
+  depth: number,
+): ChangeLedger {
+  switch (event.type) {
+    case 'work.step_started': {
+      const { workStepId, title, componentIds } = event.payload
+      return {
+        ...ledger,
+        openWorkSteps: {
+          ...ledger.openWorkSteps,
+          [workStepId]: {
+            workStepId,
+            clientEventId: event.clientEventId,
+            title,
+            agentId: event.agentId,
+            runId: event.runId,
+            componentIds: [...componentIds],
+            occurredAt: event.occurredAt,
+            position: event.position,
+          },
+        },
+      }
+    }
+
+    case 'work.step_completed':
+      return withoutWorkStep(ledger, event.payload.workStepId)
+
+    case 'component.change_planned':
+      return appendChange(ledger, event, {
+        changeId: event.payload.changeId,
+        targetKind: 'component',
+        targetId: event.payload.component.componentId,
+        operation: event.payload.operation,
+        phase: 'planned',
+        snapshot: event.payload.component,
+      })
+
+    case 'component.change_applied':
+      return appendChange(ledger, event, {
+        changeId: event.payload.changeId ?? null,
+        targetKind: 'component',
+        targetId: event.payload.component.componentId,
+        operation: event.payload.operation,
+        phase: 'applied',
+        snapshot: event.payload.component,
+      })
+
+    case 'relationship.change_planned':
+      return appendChange(ledger, event, {
+        changeId: event.payload.changeId,
+        targetKind: 'relationship',
+        targetId: event.payload.relationship.relationshipId,
+        operation: event.payload.operation,
+        phase: 'planned',
+        snapshot: event.payload.relationship,
+      })
+
+    case 'relationship.change_applied':
+      return appendChange(ledger, event, {
+        changeId: event.payload.changeId ?? null,
+        targetKind: 'relationship',
+        targetId: event.payload.relationship.relationshipId,
+        operation: event.payload.operation,
+        phase: 'applied',
+        snapshot: event.payload.relationship,
+      })
+
+    // A snapshot replaces the applied model entirely (contract). Every earlier
+    // applied change described a model that no longer exists, so the overlays
+    // derived from them would contradict what is now on screen. Open work steps
+    // survive: a work step is a statement about an agent, not about the model.
+    case 'architecture.snapshot_published':
+      return { ...ledger, history: [] }
+
+    // The log stays append-only: a retraction never deletes, it marks.
+    case 'retraction.issued': {
+      const retracted = event.payload.retractsClientEventId
+      return {
+        ...withoutWorkStepOfEvent(ledger, retracted),
+        history: ledger.history.map((entry) =>
+          entry.clientEventId === retracted ? { ...entry, retracted: true } : entry,
+        ),
+      }
+    }
+
+    // A correction replaces the *content* of an earlier event. The original
+    // stays in `history`, flagged, and the corrected content is ingested under
+    // the correction's own client event id.
+    case 'correction.issued': {
+      if (depth >= MAX_CORRECTION_DEPTH) return ledger
+      const correctedId = event.payload.correctsClientEventId
+      const marked: ChangeLedger = {
+        ...withoutWorkStepOfEvent(ledger, correctedId),
+        history: ledger.history.map((entry) =>
+          entry.clientEventId === correctedId ? { ...entry, superseded: true } : entry,
+        ),
+      }
+      const corrected = {
+        ...event,
+        type: event.payload.correctedType,
+        payload: event.payload.correctedPayload,
+      } as unknown as StreamedEvent
+      return applyEvent(marked, corrected, depth + 1)
+    }
+
+    default:
+      return ledger
+  }
+}
+
+interface ChangeFields {
+  changeId: Identifier | null
+  targetKind: 'component' | 'relationship'
+  targetId: string
+  operation: ChangeOperation
+  phase: ChangePhase
+  snapshot: Component | Relationship
+}
+
+function appendChange(
+  ledger: ChangeLedger,
+  event: StreamedEvent,
+  fields: ChangeFields,
+): ChangeLedger {
+  const entry: LedgerChange = {
+    ...fields,
+    clientEventId: event.clientEventId,
+    agentId: event.agentId,
+    runId: event.runId,
+    occurredAt: event.occurredAt,
+    position: event.position,
+    retracted: false,
+    superseded: false,
+  }
+  const history = [...ledger.history, entry]
+  return {
+    ...ledger,
+    history: history.length > HISTORY_LIMIT ? history.slice(-HISTORY_LIMIT) : history,
+  }
+}
+
+function withoutWorkStep(ledger: ChangeLedger, workStepId: Identifier): ChangeLedger {
+  if (!(workStepId in ledger.openWorkSteps)) return ledger
+  const openWorkSteps = { ...ledger.openWorkSteps }
+  delete openWorkSteps[workStepId]
+  return { ...ledger, openWorkSteps }
+}
+
+/** Drops the open work step a withdrawn or corrected event had started. */
+function withoutWorkStepOfEvent(ledger: ChangeLedger, clientEventId: Uuid): ChangeLedger {
+  const match = Object.values(ledger.openWorkSteps).find(
+    (step) => step.clientEventId === clientEventId,
+  )
+  return match ? withoutWorkStep(ledger, match.workStepId) : ledger
+}
+
+// ---------------------------------------------------------------------------
+// Derived views
+// ---------------------------------------------------------------------------
+
+/** Every change still in force: neither withdrawn nor replaced. */
+export function standingChanges(ledger: ChangeLedger): LedgerChange[] {
+  return ledger.history.filter((entry) => !entry.retracted && !entry.superseded)
+}
+
+/**
+ * The newest applied changes that still count as "recent", oldest first.
+ *
+ * Bounded by count rather than by a clock, so the picture only ever changes
+ * because an event arrived.
+ */
+export function recentAppliedChanges(
+  ledger: ChangeLedger,
+  limit = RECENT_APPLIED_LIMIT,
+): LedgerChange[] {
+  const applied = standingChanges(ledger).filter((entry) => entry.phase === 'applied')
+  return applied.slice(-limit)
+}
+
+/** Open work steps, sorted by position so the result is order-independent. */
+export function openWorkSteps(ledger: ChangeLedger): LedgerWorkStep[] {
+  return Object.values(ledger.openWorkSteps).sort((a, b) => a.position - b.position)
+}

--- a/frontend/src/state/changeLedgerStore.ts
+++ b/frontend/src/state/changeLedgerStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand'
+
+import type { ProjectId, StreamedEvent } from '@/api/types'
+
+import { EMPTY_LEDGER, ingestEvent, type ChangeLedger } from './changeLedger'
+
+/**
+ * Holds the change ledger of the project currently being watched.
+ *
+ * Like the live connection state, this is **not** server state and therefore
+ * deliberately not a query: it is a projection the client folds out of the SSE
+ * stream, and it must survive a refetch without being invalidated by one. It is
+ * also never persisted — the SSE stream replays the project from position 0 on
+ * a fresh connection (ADR 0006), so a reload rebuilds it exactly rather than
+ * restoring a stale copy of it.
+ *
+ * The store scopes itself: an event from another project resets the ledger, so
+ * switching projects cannot leave a foreign overlay behind.
+ */
+export interface ChangeLedgerStore {
+  ledger: ChangeLedger
+  ingest: (event: StreamedEvent) => void
+  reset: () => void
+}
+
+export const useChangeLedgerStore = create<ChangeLedgerStore>((set) => ({
+  ledger: EMPTY_LEDGER,
+
+  // `ingestEvent` returns the identical object when it had nothing to record,
+  // so an unrelated event (an agent status, a diff) causes no re-render at all.
+  ingest: (event) =>
+    set((state) => {
+      const next = ingestEvent(state.ledger, event)
+      return next === state.ledger ? state : { ledger: next }
+    }),
+
+  reset: () => set({ ledger: EMPTY_LEDGER }),
+}))
+
+/** Folds one live event into the ledger. Called from the SSE apply path. */
+export function ingestLiveEvent(event: StreamedEvent): void {
+  useChangeLedgerStore.getState().ingest(event)
+}
+
+/**
+ * The ledger of one project.
+ *
+ * Returns the empty ledger while the store still describes another project, so
+ * a pane can never render the overlays of the project the user just left.
+ */
+export function selectLedgerFor(
+  state: ChangeLedgerStore,
+  projectId: ProjectId,
+): ChangeLedger {
+  return state.ledger.projectId === null || state.ledger.projectId === projectId
+    ? state.ledger
+    : EMPTY_LEDGER
+}

--- a/frontend/src/test/architectureFixtures.ts
+++ b/frontend/src/test/architectureFixtures.ts
@@ -1,4 +1,5 @@
 import type {
+  ActiveChange,
   AppliedComponent,
   AppliedRelationship,
   ArchitectureResponse,
@@ -311,6 +312,72 @@ export const grownArchitectureResponse: ArchitectureResponse = {
     ),
   ],
   activeChanges: [],
+}
+
+// ---------------------------------------------------------------------------
+// Change proposals
+// ---------------------------------------------------------------------------
+
+/** The component the overlay tests propose adding. Not in the applied model. */
+export const SHIPPING_COMPONENT: Component = {
+  componentId: 'platform.core.shipping',
+  name: 'Shipping',
+  kind: 'module',
+  parentComponentId: 'platform.core',
+  description: 'Versandabwicklung.',
+  technology: { language: 'Go' },
+  tags: ['domain'],
+}
+
+/** The relationship the overlay tests propose adding, next to the applied ones. */
+export const SHIPPING_BUS_RELATIONSHIP: Relationship = {
+  relationshipId: 'r-09',
+  sourceComponentId: 'platform.core.shipping',
+  targetComponentId: 'platform.bus',
+  kind: 'nats_topic',
+  protocol: 'NATS',
+  channel: 'shipping.dispatched',
+  operation: 'publish',
+  label: '',
+}
+
+/**
+ * A pending proposal as the read API returns it.
+ *
+ * `snapshot` carries the reported descriptor verbatim, exactly as the contract
+ * specifies — that is what lets the canvas draw a proposal for a component the
+ * applied model does not contain, without a second lookup.
+ */
+export function activeChange(overrides: Partial<ActiveChange> = {}): ActiveChange {
+  return {
+    changeId: 'change-0001',
+    targetKind: 'component',
+    targetId: SHIPPING_COMPONENT.componentId,
+    operation: 'add',
+    state: 'planned',
+    runId: 'run-2026-08-04-0001',
+    agentId: 'subagent-architecture-mapper',
+    plannedAt: '2026-08-04T09:10:00Z',
+    appliedAt: null,
+    retractedAt: null,
+    snapshot: SHIPPING_COMPONENT as unknown as Record<string, unknown>,
+    position: 50,
+    ...overrides,
+  }
+}
+
+/** The nested model with a list of pending proposals on top of it. */
+export function architectureWithChanges(
+  changes: readonly ActiveChange[],
+  overrides: Partial<ArchitectureResponse> = {},
+): ArchitectureResponse {
+  return {
+    projectPosition: 60,
+    components: NESTED_COMPONENTS,
+    relationships: NESTED_RELATIONSHIPS,
+    activeChanges: [...changes],
+    ...overrides,
+  }
 }
 
 /** Shuffles deterministically, so a re-ordered input list is reproducible. */

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { afterEach, beforeEach, vi } from 'vitest'
 
+import { useChangeLedgerStore } from '@/state/changeLedgerStore'
 import { useLiveConnectionStore } from '@/state/liveConnectionStore'
 import { resetUiStore } from '@/state/uiStore'
 
@@ -50,6 +51,7 @@ beforeEach(() => {
   localStorage.clear()
   resetUiStore()
   useLiveConnectionStore.getState().reset()
+  useChangeLedgerStore.getState().reset()
 })
 
 afterEach(() => {


### PR DESCRIPTION
Closes #10

Der Canvas (#9) zeigt, was die Agents als Architektur gemeldet haben. Diese
Overlays zeigen, was sie gerade damit tun — und beides bleibt getrennt.

## Was drin ist

**Vorschläge stehen neben dem Modell, nie darin.** `activeChanges` und
`components`/`relationships` sind zwei Aussagen, also werden daraus zwei Dinge:
eine geplante Komponente wird ein eigener Knoten mit `applied: false`, gebaut
aus `ActiveChange.snapshot` — genau dafür führt der Vertrag den Deskriptor
wörtlich mit (ADR 0009), ein zweiter Lookup entfällt. Geplante Kanten liegen in
einem eigenen Id-Raum (`overlay:` statt `rel:`), damit eine angekündigte und
eine angewandte Kante zwischen denselben Komponenten zwei Linien bleiben. Der
Canvas meldet `data-node-count` und `data-overlay-node-count` getrennt, womit
von außen prüfbar ist, dass ein `component.change_planned` das angewandte
Modell nicht anfasst.

**Geister.** Entfernt eine angewandte Änderung eine Komponente, verschwindet sie
aus dem Read Model — und wäre damit der einzige Fall, in dem das Cockpit
weniger zeigt als das Log, das es darstellt. Sie bleibt aus dem Deskriptor des
entfernenden Events gezeichnet stehen, gedimmt und als `ghost` markiert.

**Ein Client-Ledger für das, was die Read API nicht sagen kann.**
`GET /architecture` filtert `activeChanges` serverseitig auf `state = planned`
und kann daher weder einen laufenden Arbeitsschritt noch eine gerade angewandte
Änderung noch ein entferntes Element ausdrücken. `src/state/changeLedger.ts`
faltet den SSE-Strom dazu. Nichts wird überschrieben: eine Retraktion markiert,
eine Korrektur ersetzt und hängt an — dieselbe Append-only-Disziplin wie im Log.
„Kürzlich" wird **gezählt, nicht getaktet** (die letzten acht angewandten
Änderungen); ein Zeitfenster würde das Bild ohne eintreffendes Ereignis ändern.
Ein `architecture.snapshot_published` setzt die Historie zurück, weil sonst ein
Geist von etwas gezeichnet würde, das der neue Snapshot enthält.

**Konkurrierende Agents werden zusammengeführt, indem alle erhalten bleiben.**
Jeder gemeldete Beitrag steht in `contributions` mit seinem Agent. Verdichtet
wird nur der eine Arbeitszustand, und das entscheidet `resolveWorkState` in
`state/workStates.ts` — der Canvas erfindet keinen fünften Zustand und keine
eigene Reihenfolge. Sichtbar sind die Zahl der beteiligten Agents am Element
(`data-agent-count`) und im Titel jeder einzelne Beitrag Zeile für Zeile. „Last
writer wins" wäre genau das stille Überschreiben, das das Issue ausschließt;
ein Kasten pro Agent hört auf, ein Graph zu sein.

**Farbe trägt nie allein.** Label, Icon und Linienart kommen aus `WORK_STATES`
(ADR 0003). Das Label nennt zusätzlich die Operation: `geplant · hinzufügen`
gegen `geplant · entfernen` — gleiche Farbe, gleicher Rahmen, andere Worte. Bei
Kanten ist die Strichart schon an die Beziehungsart vergeben (ADR 0008), also
behält die Linie ihr Kind-Muster und bekommt einen zweiten, breiteren Pfad
darunter im Muster des *Zustands*.

**Keine Kamerafahrt.** `fitView` wird nirgends aufgerufen. Ein Zustandswechsel
ohne Strukturänderung löst kein ELK aus (`projectionSignature`); dafür legt
`withCurrentData` in `useArchitectureGraph` die aktuellen Daten auf die alten
Positionen — Zustände aktualisieren sich, ohne dass sich ein Knoten bewegt.
Übergänge sind 150 ms auf Farbe, Rahmenfarbe und Deckkraft, keine Keyframes,
kein `aria-live` am Zähler.

**Bewusste Grenze:** Ein Stream ohne Cursor startet am Live-Ende statt zu
replayen (`liveOnly`, ADR 0006). Das Ledger beschreibt daher, was das Cockpit
mitangesehen hat; nach einem Reload sind angewandtes Modell und offene
Vorschläge wieder da, die drei Live-Zustände beginnen leer. Ein Voll-Replay pro
Seitenaufruf wurde verworfen — es würde pro historischem Event invalidieren und
das Streaming-Verhalten aller Panes ändern. Begründung im ADR.

## Tests

35 neue Tests, alle vorhandenen bleiben grün.

```
$ npm test
 Test Files  20 passed (20)
      Tests  164 passed (164)
```

```
$ npm run lint
> eslint .
(keine Ausgabe)

$ npm run build
✓ built in 13.11s
```

Abgedeckt: jeder der vier Zustände nach seinem committed Event;
`component.change_planned` lässt Knoten- und Kantenzahl des angewandten Modells
unverändert und erzeugt nur ein Overlay; `component.change_applied` aktualisiert
das Modell und behält den Komponentenbezug (Operation im Label, Agent im Titel);
Entfernung mit Rahmenart `dotted` plus Label plus Operation; zwei Agents auf
derselben Komponente bleiben beide erkennbar; Retraktion entfernt das Overlay,
das Ledger behält den Eintrag markiert; ersetzender Snapshot lässt konsistente
Overlays zurück; ein Live-Event bewegt weder Kamera noch Auswahl.

**„Ohne Farbe unterscheidbar" ist so nachgewiesen:** kein Assert der
Overlay-Tests liest einen Farbwert. Sie prüfen ausschließlich
`data-work-state-label`, `data-border-style`, `data-operation`,
`data-dasharray` und den sichtbaren Text. Ein Test vergleicht zwei Vorschläge
*derselben* Farbe und *desselben* Rahmens und belegt, dass nur die Worte sie
trennen.

Gegenprobe: mit neutralisiertem `buildChangeOverlays` fallen 10 der 11
Integrationstests um — die verbleibende prüft eine reine Eigenschaft von
`WORK_STATES`.

## Visuelle Prüfung

Eigener Stack (`docker compose -p vai-issue10`, Port 8097), Simulator
`--speed 1`, 62 Events, Chromium bei exakt 1920 × 1080. Über den gesamten Lauf
gesampelt:

| Messung | Ergebnis |
| --- | --- |
| beobachtete Zustände | `geplant` (dashed, `6 4`, „geplant · hinzufügen"), `aktiv` (double, `2 3`), `kürzlich angewandt` (solid, `0`), `entfernt` (dotted, `1 4`, ghost) |
| mehrere Agents | bis zu 3 auf `…domain.tax`, 2 auf `…domain.pricing` und `…legacy-tax-rates` |
| `data-fit-view-count` | `1` in **jedem** Sample |
| Viewport-Transform | genau **ein** Wert über den ganzen Lauf: `translate(37.0212px, 291.871px) scale(0.399153)` |
| angewandtes Modell | konstant `17/11`, während Overlay-Knoten/-Kanten `1 → 2` gehen |
| horizontaler Scrollbalken | keiner — `scrollWidth` 1920 = `clientWidth` 1920 |
| Panes | 345 \| **1036** \| 537 px, Canvas 1036 × 933 |
| Ruhezustand | Zähler „2 geplant · 0 aktiv · 2 kürzlich angewandt · 2 entfernt" |

Die zurückgezogene Beziehung (`rel-notifications-orders-http`) war in einem
Sample als `geplant` sichtbar und im nächsten verschwunden — die Retraktion
live im Bild.

## ADR

`docs/decisions/0010-live-change-overlays.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
