### PR TITLE
[v0] Lokale Betriebs- und Agent-Integrationsdokumentation schreiben

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,116 +1,124 @@
 # Visualise AI — Agent Project Cockpit
 
-Observability cockpit for agent work on a software project. It shows the whole
-application architecture, the running agents and subagents, their reported work
-steps, component-scoped AI feedback and unified diffs.
+Beobachtungs-Cockpit für Agentenarbeit an einem Softwareprojekt. Es zeigt die
+gesamte Anwendungsarchitektur, die laufenden Agents und Subagents, deren
+gemeldete Arbeitsschritte, komponentenbezogenes KI-Feedback und Unified Diffs.
 
-The cockpit **observes**; it never drives the agent. Users cannot prompt from
-inside the application, and the system never judges whether the agent's work is
-right or wrong.
+Das Cockpit **beobachtet**; es steuert den Agenten nie. Nutzer können aus der
+Anwendung heraus nicht prompten, und das System bewertet nie, ob die Arbeit des
+Agenten richtig ist.
 
-> **Trust boundary:** v0 is meant for a local machine or a private network. It
-> has no authentication, no authorisation and no multi-tenancy. Do not expose it
-> to the public internet.
+> **Vertrauensgrenze:** v0 ist für einen lokalen Rechner oder ein privates
+> Netzwerk gedacht. Es gibt keine Authentifizierung, keine Autorisierung und
+> keine Multi-Tenancy. **Nicht ins öffentliche Internet stellen.**
+> Details und die vollständigen Produktgrenzen:
+> [`docs/security-and-boundaries.md`](docs/security-and-boundaries.md).
 
-## Repository layout
+## Dokumentation
 
-| Path              | Contents                                                   |
-| ----------------- | ---------------------------------------------------------- |
-| `backend/`        | Go module: Gin HTTP surface, zerolog, GORM/PostgreSQL       |
-| `frontend/`       | React + TypeScript application, built by Vite               |
-| `frontend/nginx/` | Nginx site config — the only external entry point           |
-| `simulator/`      | Node/TypeScript event simulator — the deterministic demo client |
-| `docker-compose.yml` | `frontend`, `backend` and `postgres` services           |
-| `docs/decisions/` | Architecture decision records                               |
+| Dokument | Inhalt |
+| --- | --- |
+| [`docs/operations.md`](docs/operations.md) | Voraussetzungen, Compose-Start, alle Umgebungsvariablen, Healthchecks, Datenpersistenz, Simulator, End-to-End-Test |
+| [`docs/agent-integration.md`](docs/agent-integration.md) | Eventvertrag in der Praxis: Lifecycle, Idempotenz, Fehlercodes, SSE-Reconnect, eine minimale gültige Sequenz |
+| [`docs/security-and-boundaries.md`](docs/security-and-boundaries.md) | Vertrauensgrenze, Angriffsfläche, v0-Ausschlüsse, `RepositoryProvider`-Grenze |
+| [`api/README.md`](api/README.md) | Der Vertrag selbst: Schemata, Beispiele, Ablehnungs-Fixtures |
+| [`api/openapi.yaml`](api/openapi.yaml) | OpenAPI 3.1 — die maßgebliche Quelle für alle Feldnamen und Formate |
+| [`simulator/README.md`](simulator/README.md) | Flags und Szenarien des Simulators |
+| [`docs/decisions/`](docs/decisions/) | Architecture Decision Records (englisch) |
 
-## Quick start
+## Quick Start
+
+Voraussetzung ist ausschließlich Docker mit Compose v2 (siehe
+[`docs/operations.md`](docs/operations.md#voraussetzungen)).
 
 ```bash
-cp .env.example .env   # optional, defaults work as-is
+cp .env.example .env   # optional, die Defaults funktionieren unverändert
 docker compose up --build
 ```
 
-Then open <http://localhost:8080>.
+Danach <http://localhost:8080> öffnen. Ist Port 8080 belegt, setze
+`FRONTEND_HTTP_PORT` — siehe
+[Portkonflikte](docs/operations.md#portkonflikte).
 
-A fresh database is empty, so the cockpit has nothing to show until an agent
-reports something. The bundled simulator fills it deterministically through the
-public route:
+Eine frische Datenbank ist leer, das Cockpit hat also nichts zu zeigen, bis ein
+Agent etwas meldet. Der mitgelieferte Simulator füllt sie deterministisch über
+die öffentliche Route:
 
 ```bash
 cd simulator
 npm install
-npm run simulate                # or: npm run simulate -- --base http://localhost:8091
+npm run simulate
 ```
 
-See [`simulator/README.md`](simulator/README.md) for the scenarios and flags.
+Danach zeigt <http://localhost:8080/projects/visualise-ai> den vollständigen
+Demo-Run. Details:
+[Demo ausführen](docs/operations.md#demo-ausfuehren).
 
-The full operations and agent-integration guide is delivered separately; this
-file covers the scaffold only.
+## Repository-Struktur
 
-## Network topology
+| Pfad | Inhalt |
+| --- | --- |
+| `api/` | OpenAPI-Vertrag, Beispiel-Payloads, Ablehnungs-Fixtures |
+| `backend/` | Go-Modul: Gin-HTTP-Oberfläche, zerolog, GORM/PostgreSQL |
+| `frontend/` | React- und TypeScript-Anwendung, gebaut mit Vite |
+| `frontend/nginx/` | Nginx-Site-Konfiguration — der einzige externe Einstiegspunkt |
+| `simulator/` | Node/TypeScript-Eventsimulator — der deterministische Demo-Client |
+| `e2e/` | Playwright-Abnahmetest gegen das echte Compose-System |
+| `docker-compose.yml` | Die Services `frontend`, `backend` und `postgres` |
+| `docs/` | Betriebs- und Integrationsdokumentation, Decision Records |
+
+## Netzwerktopologie
 
 ```
-host :8080
+Host :8080
      │
      ▼
 ┌──────────────┐        ┌─────────────┐        ┌──────────────┐
 │  frontend    │ ─────▶ │  backend    │ ─────▶ │  postgres    │
 │  (nginx)     │        │  (go/gin)   │        │              │
-│  published   │        │  internal   │        │  internal    │
+│  published   │        │  intern     │        │  intern      │
 └──────────────┘        └─────────────┘        └──────────────┘
 ```
 
-Nginx serves the production bundle and proxies three kinds of traffic to the
-backend:
+Nginx liefert das Produktions-Bundle aus und proxyt vier Arten von Verkehr an
+das Backend:
 
-| Route                                | Purpose                                  |
-| ------------------------------------ | ---------------------------------------- |
-| `/api/v1/events`                     | agent event ingestion                    |
-| `/api/v1/…`                          | UI read models                           |
-| `/api/v1/projects/{id}/stream`       | SSE live stream, proxied **unbuffered**  |
-| `/healthz`, `/readyz`                | backend probes                           |
+| Route | Zweck |
+| --- | --- |
+| `POST /api/v1/events` | Agent-Event-Ingestion |
+| `GET /api/v1/…` | Read Models für die Oberfläche |
+| `GET /api/v1/projects/{id}/stream` | SSE-Livestream, **ungepuffert** geproxyt |
+| `GET /healthz`, `GET /readyz` | Backend-Probes |
 
-Neither `backend` nor `postgres` publishes a host port.
+Weder `backend` noch `postgres` veröffentlichen einen Host-Port. Warum das eine
+Sicherheitseigenschaft und keine Bequemlichkeit ist, steht in
+[`docs/security-and-boundaries.md`](docs/security-and-boundaries.md#nginx-ist-der-einzige-einstiegspunkt).
 
-## Health and readiness
+## Lokale Entwicklung
 
-- `GET /healthz` — the process is alive. Always `200` while it serves.
-- `GET /readyz` — the backend finished startup **and** PostgreSQL answers.
-  Returns `503` otherwise.
-
-The backend container healthcheck probes `/readyz`, and the frontend container
-starts only once the backend is healthy. A backend that fails to start is
-therefore never routed to as ready.
-
-## Data persistence
-
-PostgreSQL stores its data in the named volume `pgdata`. It survives
-`docker compose down`; use `docker compose down -v` to start from an empty
-database.
-
-## Configuration
-
-All settings are environment variables and documented in
-[`.env.example`](.env.example).
-
-## Local development
+Nur nötig, wenn du am Code arbeitest; für den reinen Betrieb genügt Docker.
 
 ```bash
-# Backend
+# Backend (Go 1.25.7, siehe backend/go.mod)
 cd backend
 go build ./... && go vet ./... && go test ./...
 
-# Frontend
+# Frontend (Node 22, wie im Container-Build)
 cd frontend
 npm ci
 npm run lint && npm run typecheck && npm run test && npm run build
 
-# Simulator
+# Simulator (Node 22)
 cd simulator
 npm ci
 npm run lint && npm run typecheck && npm test
+
+# Vertrag
+cd api
+npm ci
+npm test
 ```
 
-`npm run dev` starts Vite on port 5173 and proxies `/api`, `/healthz` and
-`/readyz` to a backend on `localhost:8080`, so paths match the Compose
-deployment.
+`npm run dev` im `frontend/` startet Vite auf Port 5173 und proxyt `/api`,
+`/healthz` und `/readyz` an ein Backend auf `localhost:8080`, sodass die Pfade
+denen der Compose-Bereitstellung entsprechen.

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,0 +1,431 @@
+# Agent-Integration
+
+Für Autoren von Agenten, die an das Cockpit melden wollen. Alles, was hier
+steht, lässt sich allein mit [`api/openapi.yaml`](../api/openapi.yaml)
+umsetzen — dieser Text erklärt die Regeln, die aus dem Schema allein nicht
+hervorgehen, und nennt die Fehler, die man sonst der Reihe nach macht.
+
+Ein Agent braucht genau eine URL: `POST <base>/api/v1/events`. Alles andere —
+Datenbank, interne Ports, Read Models — geht ihn nichts an.
+
+## Grundregeln in vier Sätzen
+
+1. **Ein Request, ein Event.** Kein Batching.
+2. **`Content-Type: application/json`**, sonst `415`.
+3. **Der Katalog ist geschlossen.** 20 Eventtypen, keine Erweiterung, kein
+   Freiform-Fallback.
+4. **Es wird nur gemeldet, nie abgeleitet.** Was der Agent nicht sendet,
+   existiert für das Cockpit nicht.
+
+## Der Umschlag
+
+Jedes Event hat denselben Umschlag; nur `payload` hängt vom `type` ab. Unbekannte
+Felder sind auf jeder Ebene verboten (`additionalProperties: false`).
+
+| Feld | Pflicht | Bedeutung |
+| --- | --- | --- |
+| `schemaVersion` | ja | v0 akzeptiert ausschließlich `"1.0"` |
+| `clientEventId` | ja | UUID, vom Agenten vergeben. Der Idempotenzschlüssel — siehe [Idempotenz](#idempotenz-und-retries) |
+| `projectId` | ja | Projekt-Slug |
+| `runId` | ja | Run-Slug |
+| `agentId` | ja | Der **meldende** Agent |
+| `parentAgentId` | nein | Der delegierende Agent; `null` oder weggelassen beim Root-Orchestrator. Gehört in **jedes** Event des Subagenten, nicht nur in sein `agent.started` |
+| `occurredAt` | ja | RFC-3339-Zeitstempel in UTC (`Z`-Suffix), aus Sicht des Agenten. Unabhängig vom serverseitigen `receivedAt` |
+| `type` | ja | Einer der 20 Katalogtypen |
+| `payload` | ja | Vom `type` bestimmtes Objekt |
+
+### Zwei verschiedene ID-Formate — eine häufige Stolperfalle
+
+`projectId`, `runId`, `agentId` und `componentId` sind **Slugs** mit einem
+strengen Muster: Kleinbuchstaben, Ziffern und Bindestriche, mindestens 3
+Zeichen, Anfang und Ende alphanumerisch (`componentId` erlaubt zusätzlich `.`
+und `_`). `MyAgent`, `agent_1` oder `ab` werden mit `400` abgelehnt.
+
+`feedbackId`, `diffId`, `planId`, `workStepId`, `relationshipId`, `changeId`,
+`snapshotId` dagegen sind freie `Identifier`: 1 bis 128 beliebige Zeichen.
+
+## Lifecycle
+
+Die Reihenfolge der Events ist keine Empfehlung. Sie wird beim Schreiben
+erzwungen, innerhalb derselben Transaktion, die das Event anhängt — ein
+abgelehntes Event hinterlässt keine Spur und verbraucht keine Position.
+
+### Ein Run wird vom Root-Orchestrator eröffnet
+
+Das **erste** Event eines Runs muss ein `agent.started` mit
+`payload.role: "orchestrator"` und `parentAgentId: null` sein. Jedes andere
+Event davor wird mit `422 run_not_started` abgelehnt. Ein Run hat genau einen
+Root-Orchestrator; ein zweites solches Event ergibt
+`422 run_already_started`.
+
+### Jeder Agent meldet sich selbst an — der häufigste Anfängerfehler
+
+> **Jeder Agent muss vorher selbst `agent.started` gesendet haben**, bevor er
+> irgendetwas anderes meldet. Sonst antwortet der Server mit
+> **`422 unknown_agent`**.
+
+Das ist der Fehler, den praktisch jede erste Integration macht: Der
+Orchestrator startet, delegiert, und der Subagent meldet direkt seinen ersten
+`work.step_started` — abgelehnt, weil dieser Agent für das Cockpit noch nicht
+existiert. `agent.started` ist die einzige Ausnahme von der Regel, weil es den
+Agenten überhaupt erst einführt.
+
+Dieselbe Prüfung gilt für `parentAgentId`: Der genannte Elternagent muss im
+selben Run bereits `agent.started` gesendet haben, sonst
+`422 parent_agent_unknown`.
+
+Praktisch heißt das: **Vor dem ersten Event eines Subagenten steht immer dessen
+eigenes `agent.started`.**
+
+### Nur der Orchestrator darf den Run schließen
+
+`run.finished` ist optional und darf ausschließlich vom Root-Orchestrator des
+Runs kommen; von jedem anderen Agenten ergibt es
+`422 terminal_event_not_allowed`.
+
+Nach `run.finished` werden **Work-Events abgelehnt** (`422
+run_already_finished`). Genau zwei Typen bleiben erlaubt:
+`correction.issued` und `retraction.issued` — ein geschlossener Run muss
+korrigierbar bleiben, denn der Log ist append-only und es gibt keinen anderen
+Weg, eine falsche Meldung geradezurücken.
+
+`correction.issued` und `retraction.issued` verweisen über
+`correctsClientEventId` bzw. `retractsClientEventId` auf ein Event, das im
+selben **Projekt** bereits akzeptiert wurde — sonst
+`422 correction_target_unknown`. Beide ersetzen nichts: Das Original bleibt im
+Log stehen und wird im Cockpit als korrigiert bzw. zurückgezogen markiert.
+
+### Status wird gemeldet, nie abgeleitet
+
+Es gibt **keine Stall-Erkennung**, keine Timeouts, keine Heuristik. Aus Stille
+entsteht kein Status: Der zuletzt gemeldete `agent.status_reported` bleibt
+gültig, bis der Agent einen neuen sendet. **Ein Run ohne Terminalevent bleibt
+offen** und zeigt seinen letzten gemeldeten Stand — das Cockpit erfindet weder
+„fertig" noch „abgestürzt".
+
+Auch `risk.reported` und `problem.reported` sind Aussagen des Agenten über sich
+selbst. Das System bewertet nichts. Wer den Zustand eines Runs im Cockpit
+sichtbar haben will, muss ihn melden.
+
+## Relevante statt rohe Events
+
+Der Katalog umfasst genau diese 20 Typen:
+
+| Gruppe | Typen |
+| --- | --- |
+| Agent | `agent.started`, `agent.status_reported`, `agent.progress_reported`, `agent.finished` |
+| Plan | `plan.published`, `plan.step_updated` |
+| Arbeit | `work.step_started`, `work.step_completed` |
+| Feedback | `feedback.published` |
+| Architektur | `architecture.snapshot_published` |
+| Komponenten | `component.change_planned`, `component.change_applied` |
+| Beziehungen | `relationship.change_planned`, `relationship.change_applied` |
+| Diff | `diff.reported` |
+| Risiko / Problem | `risk.reported`, `problem.reported` |
+| Korrektur | `correction.issued`, `retraction.issued` |
+| Run | `run.finished` |
+
+**Low-Level-Tool-Aufrufe, Terminalkommandos, Datei-Lesevorgänge, Token-Verbrauch
+und rohe Modellausgaben sind kein Bestandteil des Vertrags** und werden
+strukturell abgelehnt, nicht bloß ignoriert: `type` ist eine Enumeration, jedes
+Payload-Schema ist geschlossen, und der Request-Body ist eine diskriminierte
+`oneOf`-Union. Es gibt kein Feld, in das sich Terminalausgabe schmuggeln ließe.
+
+Gemeldet wird, was ein menschlicher Reviewer der beobachteten Anwendung braucht:
+was gearbeitet wird, woran, mit welchem Ergebnis. Wer 200 Tool-Aufrufe pro
+Minute meldet, hat das Werkzeug missverstanden — und bekommt für jeden davon
+ein `400 unsupported_event_type`.
+
+### Regeln, die man beim ersten Mal übersieht
+
+- **Ein `diff.reported` trägt genau eine repository-relative Datei** plus ihren
+  Unified Diff. Eine Änderung an drei Dateien sind drei Events mit je eigener
+  `diffId` und derselben `changeId`; die `changeId` ist das Einzige, was sie
+  zusammenhält. Absolute Pfade und `..`-Segmente lehnt schon das Muster von
+  `filePath` ab.
+- **Jedes NATS-Topic ist eine eigene Beziehung** mit eigener `relationshipId`,
+  `kind: nats_topic` und dem Topic-Namen in `channel`. Topics werden nie zu
+  einer „Messaging"-Kante zusammengefasst.
+- **`architecture.snapshot_published` ersetzt das angewandte Modell
+  vollständig.** Was nicht im Snapshot steht, existiert danach nicht mehr. Für
+  inkrementelle Änderungen gibt es `component.change_*` und
+  `relationship.change_*`.
+- **`parentComponentId` ist ein Pflichtfeld**, auch für Wurzelkomponenten. Dort
+  steht dann explizit `null`; weglassen ist ein `400`.
+- **Geplant ist nicht angewandt.** `*.change_planned` meldet einen Vorschlag und
+  ändert das Modell nicht; erst `*.change_applied` tut das. Das Cockpit zeichnet
+  Vorschläge neben das Modell, nie hinein.
+
+## Idempotenz und Retries
+
+`clientEventId` ist der Schlüssel. Er ist pro Projekt eindeutig, und ein Retry
+muss denselben Wert **und** denselben Inhalt tragen.
+
+| Fall | Antwort |
+| --- | --- |
+| Erste Zustellung | `201` mit `duplicate: false` und der neu vergebenen `position` |
+| Byte-identische Wiederholung | `200` mit `duplicate: true` und **derselben** `position` wie beim ersten Mal |
+| Gleiche ID, abweichender Inhalt | `409 client_event_id_conflict` |
+
+„Byte-identisch" heißt inhaltsgleich, nicht zeichengleich: Der Payload wird
+kanonisiert (Objektschlüssel rekursiv sortiert, unerhebliche Leerzeichen
+entfernt) und gehasht. Eine andere Schlüsselreihenfolge im JSON ist also
+unschädlich, ein geänderter Wert nicht.
+
+Praktisch: Bei einem Netzwerkfehler ohne Antwort einfach **dasselbe Event noch
+einmal senden**. Es kann nicht doppelt ankommen. Was man nicht tun darf, ist
+den Zeitstempel neu zu berechnen oder ein Feld nachzubessern — dann ist es ein
+anderes Event unter derselben ID und wird zum `409`.
+
+Beispielantworten:
+[`retry-idempotent-response.json`](../api/examples/retry-idempotent-response.json),
+[`conflict-response.json`](../api/examples/conflict-response.json).
+
+## Größenlimit
+
+Ein einzelnes Event darf standardmäßig **2 MiB (2097152 Bytes)** groß sein.
+Darüber antwortet der Server `413` mit dem Code `event_too_large`. Der Wert ist
+serverseitig über die Umgebungsvariable `MAX_EVENT_BYTES` konfigurierbar
+(siehe [Betrieb](./operations.md#konfiguration)) — ein Agent kann ihn nicht
+verhandeln und sollte ihn nicht ausreizen.
+
+Das Limit trifft in der Praxis zwei Dinge: sehr große
+`architecture.snapshot_published` und sehr große `unifiedDiff`. Beides lässt
+sich aufteilen — die Architektur über inkrementelle `change_*`-Events, Diffs
+ohnehin pro Datei.
+
+Ist die Anfrage größer als 8 MiB, lehnt bereits Nginx sie ab, und zwar mit einer
+HTML-Fehlerseite statt einem `application/problem+json`. Ein Client sollte
+`413` deshalb nicht am Antwortkörper erkennen, sondern am Statuscode.
+
+## Fehlerformat
+
+Alle Fehler folgen **RFC 9457** (`application/problem+json`) mit den Feldern
+`type`, `title`, `status`, `detail`, `code` und `instance`. Der `code` ist das
+stabile, maschinenlesbare Feld — auf ihn programmiert man, nicht auf `detail`.
+
+| Status | Wann | Codes |
+| --- | --- | --- |
+| `400` | Der Body ist gültiges JSON, verletzt aber den Vertrag | `invalid_field`, `unsupported_event_type`, `unsupported_schema_version` |
+| `409` | `clientEventId` mit anderem Inhalt wiederverwendet | `client_event_id_conflict` |
+| `413` | Event größer als das Limit | `event_too_large` |
+| `415` | Falscher `Content-Type` | `unsupported_media_type` |
+| `422` | Schema-gültig, aber im Widerspruch zum Projektzustand | siehe die Tabelle unten |
+
+### `400` nennt die Felder einzeln
+
+Ein `400` trägt zusätzlich `errors[]`. Jeder Eintrag hat ein `field` als
+**JSON-Pointer** (RFC 6901) in den gesendeten Body, einen `code` und eine
+Meldung. Ein Tippfehler im Umschlag erzeugt typischerweise zwei Einträge — das
+unbekannte Feld und das fehlende richtige:
+
+```json
+{
+  "type": "https://visualise-ai.local/problems/invalid-field",
+  "title": "Invalid field", "status": 400, "code": "invalid_field",
+  "detail": "the agent.progress_reported event violates the contract in 3 place(s).",
+  "instance": "/api/v1/events",
+  "errors": [
+    { "field": "/occuredAt",       "code": "unknown_property", "message": "property \"occuredAt\" is not declared by the contract" },
+    { "field": "/occurredAt",      "code": "required",         "message": "required property \"occurredAt\" is missing" },
+    { "field": "/payload/percent", "code": "out_of_range",     "message": "maximum: got 140, want 100" }
+  ]
+}
+```
+
+Weil der Server anhand von `type` genau den einen Zweig der Union validiert, den
+der Agent gemeint hat, beziehen sich die Pointer immer auf das gesendete Event —
+nicht auf 19 andere Eventtypen. Ein weiteres Beispiel:
+[`validation-error-response.json`](../api/examples/validation-error-response.json).
+
+### Die `422`-Codes einzeln
+
+| Code | Bedeutung | Behebung |
+| --- | --- | --- |
+| `run_not_started` | Der Run wurde nie eröffnet | Zuerst `agent.started` des Root-Orchestrators mit `role: orchestrator` und `parentAgentId: null` senden |
+| `run_already_started` | Ein zweiter Root-Orchestrator für denselben Run | Pro Run genau einen Root. Für eine neue Sitzung eine neue `runId` |
+| `unknown_agent` | Der meldende Agent hat nie `agent.started` gesendet | Das `agent.started` dieses Agenten vorher senden |
+| `parent_agent_unknown` | Der in `parentAgentId` genannte Agent ist unbekannt | Den Elternagenten zuerst starten, oder die ID korrigieren |
+| `terminal_event_not_allowed` | Ein anderer Agent als der Orchestrator hat `run.finished` gesendet | `run.finished` dem Root-Orchestrator überlassen |
+| `run_already_finished` | Work-Event nach `run.finished` | Neuen Run eröffnen. Korrekturen bleiben über `correction.issued`/`retraction.issued` möglich |
+| `correction_target_unknown` | Das korrigierte oder zurückgezogene Event existiert im Projekt nicht | Die `clientEventId` des Originals prüfen; sie ist projektweit, nicht runweit |
+
+## Eine minimale gültige Sequenz
+
+Fünf Events, von Hand gebaut, mehr braucht es nicht, damit das Cockpit etwas
+Sinnvolles zeigt: ein Root-Orchestrator, ein Subagent, ein Architektur-Snapshot,
+ein Feedback, ein Diff.
+
+```bash
+BASE=http://localhost:8080
+
+post() { curl -sS -X POST "$BASE/api/v1/events" -H 'Content-Type: application/json' -d "$1"; echo; }
+
+# 1 — Root-Orchestrator eröffnet den Run
+post '{
+  "schemaVersion": "1.0",
+  "clientEventId": "11111111-1111-4111-8111-111111111111",
+  "projectId": "docs-proof", "runId": "run-docs-proof-0001",
+  "agentId": "orchestrator-root", "parentAgentId": null,
+  "occurredAt": "2026-08-04T12:00:00Z",
+  "type": "agent.started",
+  "payload": { "role": "orchestrator", "displayName": "Root Orchestrator",
+               "assignedTask": "Checkout-Service umbauen und die Arbeit delegieren." }
+}'
+
+# 2 — Subagent meldet sich selbst an, bevor er irgendetwas anderes meldet
+post '{
+  "schemaVersion": "1.0",
+  "clientEventId": "22222222-2222-4222-8222-222222222222",
+  "projectId": "docs-proof", "runId": "run-docs-proof-0001",
+  "agentId": "subagent-implementer", "parentAgentId": "orchestrator-root",
+  "occurredAt": "2026-08-04T12:00:10Z",
+  "type": "agent.started",
+  "payload": { "role": "subagent", "displayName": "Implementer",
+               "assignedTask": "Preisberechnung aus dem API-Modul herausloesen." }
+}'
+
+# 3 — Architektur. Ersetzt das angewandte Modell vollstaendig.
+post '{
+  "schemaVersion": "1.0",
+  "clientEventId": "33333333-3333-4333-8333-333333333333",
+  "projectId": "docs-proof", "runId": "run-docs-proof-0001",
+  "agentId": "subagent-implementer", "parentAgentId": "orchestrator-root",
+  "occurredAt": "2026-08-04T12:01:00Z",
+  "type": "architecture.snapshot_published",
+  "payload": {
+    "snapshotId": "snapshot-0001",
+    "components": [
+      { "componentId": "checkout",     "name": "Checkout",     "kind": "system",    "parentComponentId": null },
+      { "componentId": "checkout.api", "name": "Checkout API", "kind": "service",   "parentComponentId": "checkout" },
+      { "componentId": "checkout.db",  "name": "Checkout DB",  "kind": "datastore", "parentComponentId": "checkout" }
+    ],
+    "relationships": [
+      { "relationshipId": "rel-0001", "sourceComponentId": "checkout.api",
+        "targetComponentId": "checkout.db", "kind": "data", "protocol": "postgresql" }
+    ]
+  }
+}'
+
+# 4 — Komponentenbezogenes Feedback als Markdown
+post '{
+  "schemaVersion": "1.0",
+  "clientEventId": "44444444-4444-4444-8444-444444444444",
+  "projectId": "docs-proof", "runId": "run-docs-proof-0001",
+  "agentId": "subagent-implementer", "parentAgentId": "orchestrator-root",
+  "occurredAt": "2026-08-04T12:02:00Z",
+  "type": "feedback.published",
+  "payload": {
+    "feedbackId": "feedback-0001", "componentIds": ["checkout.api"],
+    "format": "markdown", "title": "Rundungsregel ist nicht festgelegt",
+    "body": "Die neue Preisberechnung rundet **pro Position**, die alte rundete pro Bestellung."
+  }
+}'
+
+# 5 — Unified Diff fuer genau eine Datei
+post '{
+  "schemaVersion": "1.0",
+  "clientEventId": "55555555-5555-4555-8555-555555555555",
+  "projectId": "docs-proof", "runId": "run-docs-proof-0001",
+  "agentId": "subagent-implementer", "parentAgentId": "orchestrator-root",
+  "occurredAt": "2026-08-04T12:03:00Z",
+  "type": "diff.reported",
+  "payload": {
+    "diffId": "diff-0001", "changeId": "change-0001",
+    "componentIds": ["checkout.api"],
+    "filePath": "internal/checkout/pricing.go",
+    "unifiedDiff": "--- a/internal/checkout/pricing.go\n+++ b/internal/checkout/pricing.go\n@@ -10,3 +10,3 @@ func Total(o Order) Amount {\n-\treturn round(sum(o.Lines))\n+\treturn sum(roundEach(o.Lines))\n }\n"
+  }
+}'
+```
+
+Jeder Aufruf antwortet mit `201` und den Positionen 1 bis 5. Danach zeigt
+`http://localhost:8080/projects/docs-proof` die drei Komponenten; ein Klick auf
+*Checkout API* öffnet den Inspektor mit Feedback und Diff.
+
+`run.finished` fehlt hier bewusst: Es ist optional, und der Run bleibt offen.
+
+## Fertige Beispiel-Payloads
+
+Nicht abtippen — die folgenden Dateien sind die vom Vertrag referenzierten
+Beispiele und werden gegen ihn validiert:
+
+| Datei | Zeigt |
+| --- | --- |
+| [`root-agent-started.json`](../api/examples/root-agent-started.json) | Root-Orchestrator, `parentAgentId: null` |
+| [`subagent-started.json`](../api/examples/subagent-started.json) | Subagent mit Elternagent |
+| [`architecture-snapshot.json`](../api/examples/architecture-snapshot.json) | Vier Hierarchieebenen und jede Beziehungsart, inklusive getrennter NATS-Topic-Kanten |
+| [`component-change-planned.json`](../api/examples/component-change-planned.json) | Geplante Komponentenänderung |
+| [`component-change-applied.json`](../api/examples/component-change-applied.json) | Dieselbe Änderung, angewandt |
+| [`feedback-published.json`](../api/examples/feedback-published.json) | Komponentenbezogenes Markdown-Feedback |
+| [`diff-reported.json`](../api/examples/diff-reported.json) | Unified Diff für genau eine Datei |
+| [`correction-issued.json`](../api/examples/correction-issued.json) | Korrektur eines früheren Events |
+| [`run-finished.json`](../api/examples/run-finished.json) | Optionales Terminalevent |
+
+Die Beispiele sind **einzelne Illustrationen und keine lauffähige Reihenfolge**:
+Wer sie der Reihe nach sendet, läuft in die Lifecycle-Regeln oben. Eine
+lauffähige Reihenfolge steht [weiter oben](#eine-minimale-gültige-sequenz) und
+im Simulator.
+
+Weitere Beispiele — Read Models, Fehlerantworten und die
+Ablehnungs-Fixtures — sind in [`api/README.md`](../api/README.md) katalogisiert.
+
+## SSE: Stream und Reconnect
+
+`GET /api/v1/projects/{projectId}/stream` liefert Server-Sent Events. Jedes
+`data:` trägt einen `StreamedEvent`: dasselbe Event, das der Agent gesendet hat,
+plus `position`, `serverEventId` und `receivedAt`. Das `event:`-Feld trägt den
+`type`, das `id:`-Feld die Position.
+
+**Die SSE-`id` *ist* die serverseitige Projektposition.** Positionen sind pro
+Projekt monoton und lückenlos; sie sind der einzige Cursor. Die Event-UUID ist
+kein Cursor — sie trägt keine Ordnung.
+
+Wiederaufnahme geht auf zwei Wegen:
+
+| Weg | Wer benutzt ihn | Verhalten bei ungültigem Wert |
+| --- | --- | --- |
+| Header `Last-Event-ID` | Browser (`EventSource` setzt ihn automatisch) | Wird ignoriert, der Stream startet live |
+| Query `?lastEventPosition=` | Clients mit eigenem Cursor: Simulator, Tests, CLI | `400` — ein unbrauchbarer Wert ist ein Client-Defekt |
+
+Sind beide gesetzt, gewinnt `lastEventPosition`. **Der Replay beginnt bei
+`position + 1`** und geht danach nahtlos in den Livebetrieb über; es gibt keine
+sichtbare Grenze zwischen beidem, der Client sieht nur steigende Positionen.
+Jedes committete Event wird dabei genau einmal geliefert, in Positionsordnung,
+ohne Lücke und ohne Duplikat.
+
+> **Leicht zu übersehen: Ein Stream *ohne* Cursor startet am Live-Ende und
+> replayt nicht.** Er ist danach vollkommen still, bis das nächste Event
+> eintrifft — was wie ein kaputter Stream aussieht, aber der dokumentierte
+> Anfangszustand ist. **Wer die Historie braucht, muss `lastEventPosition=0`
+> setzen**; Positionen beginnen bei 1, also liefert `0` das Projekt von vorn.
+
+Zwei kleinere Punkte, die beim Selbstbau eines Clients auffallen:
+
+- **Keepalives sind SSE-Kommentarzeilen** (`: keepalive`) und tragen nie ein
+  `id:`. Sie können den Cursor nicht verschieben; ein Client muss sie ignorieren.
+  Die erste Zeile nach dem Verbindungsaufbau ist in der Regel ein Keepalive.
+- **Ein Cursor hinter dem Ende des Logs** wird auf das aktuelle Ende gezogen,
+  nicht wörtlich genommen. Ein wörtlich befolgter Wert ergäbe einen dauerhaft
+  stillen Stream.
+- Ein unbekanntes Projekt antwortet `404 project_not_found`.
+
+Ein durchgespieltes Beispiel mit echten Requests und Antworten:
+[`api/examples/sse-reconnect.md`](../api/examples/sse-reconnect.md).
+
+## Read API
+
+Agents brauchen sie nicht — sie ist die Lesefläche des Cockpits. Wer sie doch
+verwendet (etwa in Tests), sollte zwei Dinge wissen: Jede Antwort trägt
+`projectPosition`, mit dem sich ein HTTP-Schnappschuss gegen den SSE-Cursor
+abgleichen lässt, und die Alias-Run-ID `current` löst auf den Run auf, den
+zuletzt ein Root-Orchestrator eröffnet hat. Der vollständige Überblick steht in
+[`api/README.md`](../api/README.md).
+
+## Was der Agent nicht erwarten darf
+
+Das Cockpit ist beobachtend und read-only: Es gibt keinen Rückkanal, keine
+Steuerbefehle, keine Freigaben und keine Bewertung der gemeldeten Arbeit. Was
+v0 sonst noch ausdrücklich nicht tut — und warum das Feedback eines Agenten als
+nicht vertrauenswürdiger Input behandelt wird — steht in
+[`security-and-boundaries.md`](./security-and-boundaries.md).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,270 @@
+# Betrieb
+
+Wie das Cockpit lokal oder im privaten Netzwerk betrieben wird: Voraussetzungen,
+Start, Konfiguration, Gesundheitsprüfungen, Daten und Demo.
+
+Bevor du das System jemandem zugänglich machst, lies
+[`security-and-boundaries.md`](./security-and-boundaries.md). Es gibt keine
+Authentifizierung.
+
+## Voraussetzungen
+
+| Werkzeug | Wofür | Anmerkung |
+| --- | --- | --- |
+| Docker Engine | Betrieb | Zuletzt geprüft mit 29.5 |
+| Docker Compose | Betrieb | Als Plugin (`docker compose …`), nicht als altes `docker-compose`. Zuletzt geprüft mit 5.1 |
+
+Mehr ist für den Betrieb **nicht** nötig. Backend, Frontend und Simulator werden
+im Container gebaut; Go und Node brauchst du nur, wenn du am Quellcode arbeitest
+oder den Simulator direkt vom Host aus startest (siehe
+[Demo ausführen](#demo-ausfuehren) und den Abschnitt „Lokale Entwicklung" im
+[README](../README.md#lokale-entwicklung)).
+
+Das Cockpit ist Desktop-only. Verbindliche Abnahmeauflösung ist 1920 × 1080 in
+Chromium.
+
+## Start aus einem leeren Checkout
+
+```bash
+git clone <repository-url> visualise-ai
+cd visualise-ai
+cp .env.example .env          # optional, die Defaults funktionieren unverändert
+docker compose up --build
+```
+
+Der erste Build lädt die Basis-Images und kompiliert Go-Backend und
+Vite-Bundle; das dauert einige Minuten. Danach starten die Services in fester
+Reihenfolge: `postgres` muss gesund sein, bevor `backend` startet, und `backend`
+muss gesund sein, bevor `frontend` startet.
+
+Wenn `docker compose up` ohne `-d` läuft, siehst du die Logs aller drei
+Services. Für den Hintergrundbetrieb:
+
+```bash
+docker compose up --build -d
+docker compose ps             # Status aller Services
+docker compose logs -f backend
+docker compose down           # stoppt alles, Daten bleiben erhalten
+```
+
+Sobald `frontend` gesund ist, ist die Oberfläche unter <http://localhost:8080>
+erreichbar.
+
+<a id="demo-ausfuehren"></a>
+
+## Demo ausführen
+
+Eine frische Datenbank ist leer. Das Cockpit erfindet nichts, also gibt es
+nichts zu sehen, bis ein Agent etwas meldet. Der mitgelieferte Simulator meldet
+einen vollständigen, deterministischen Run über dieselbe öffentliche Route, die
+auch ein echter Agent benutzt.
+
+Er läuft auf dem Host und braucht dafür Node (der Container-Build verwendet
+Node 22):
+
+```bash
+cd simulator
+npm install
+npm run simulate
+```
+
+Läuft das Frontend auf einem anderen Port, muss der Simulator die Basis-URL
+kennen:
+
+```bash
+npm run simulate -- --base http://localhost:8101
+```
+
+Danach zeigt <http://localhost:8080/projects/visualise-ai> den Run: die
+Architektur auf dem Canvas, die Agenthierarchie links, der Komponenteninspektor
+rechts nach einem Klick auf eine Komponente.
+
+### Flags
+
+| Flag | Bedeutung | Default |
+| --- | --- | --- |
+| `--base <url>` | Öffentlicher Einstiegspunkt, nur Schema und Host | `http://localhost:8080` |
+| `--project <id>` | Projekt, unter dem gemeldet wird | Projekt des Szenarios |
+| `--run <id>` | Run-ID | Run-ID des Szenarios |
+| `--speed <faktor>` | Pausenmultiplikator: `1` normal, `0` keine Pausen, `2` doppelt so langsam | `1` |
+| `--scenario <name>` | `full`, `retry` oder `conflict` | `full` |
+| `--seed <n>` | Seed der ID-, Pausen- und Uhrenströme | `20260804` |
+| `--finish <bool>` | Ob der `full`-Run `run.finished` sendet | `false` |
+| `--json` | Maschinenlesbare Zusammenfassung auf stdout, Erzählung auf stderr | aus |
+
+### Szenarien
+
+| Szenario | Projekt | Zeigt |
+| --- | --- | --- |
+| `full` | `visualise-ai` | Den repräsentativen Run: 62 Events, jeden Eventtyp außer dem optionalen `run.finished` |
+| `retry` | `visualise-ai-retry` | `201`, danach eine byte-identische Wiederholung mit `200 duplicate: true` und **derselben** Position |
+| `conflict` | `visualise-ai-conflict` | Dieselbe `clientEventId` mit anderem Inhalt: `409 client_event_id_conflict` |
+
+Jedes Szenario schreibt in ein eigenes Projekt mit eigenem Root-Orchestrator, so
+dass keines den aktuellen Run eines anderen überschreibt.
+
+**Alle drei Szenarien setzen eine leere Datenbank voraus.** Gegen eine bereits
+gefüllte Datenbank ist die erste Zustellung berechtigterweise ein Duplikat — das
+ist korrektes Verhalten, aber nicht das, was die Szenarien behaupten. Vor einem
+Wiederholungslauf also:
+
+```bash
+docker compose down -v && docker compose up --build -d
+```
+
+Wiederholte Läufe gegen eine leere Datenbank erzeugen denselben semantischen
+Ablauf: dieselben Events, dieselben Positionen und damit dieselben Read Models.
+Client-Event-IDs, Pausen und Zeitstempel stammen aus getrennten, geseedeten
+Generatoren. Weitere Details in
+[`simulator/README.md`](../simulator/README.md).
+
+## Konfiguration
+
+Alle Einstellungen sind Umgebungsvariablen. `docker compose` liest sie
+automatisch aus einer Datei `.env` im Projektverzeichnis;
+[`.env.example`](../.env.example) ist die kommentierte Vorlage. Jeder Wert ist
+optional — die Defaults lassen `docker compose up --build` in einem leeren
+Checkout funktionieren.
+
+| Variable | Wofür | Default | Wann ändern |
+| --- | --- | --- | --- |
+| `FRONTEND_HTTP_PORT` | Der einzige vom Deployment veröffentlichte Host-Port. Nginx lauscht im Container immer auf 8080; diese Variable bestimmt nur, worauf er auf dem Host abgebildet wird. | `8080` | Bei [Portkonflikten](#portkonflikte) oder wenn mehrere Stacks parallel laufen |
+| `POSTGRES_USER` | Datenbanknutzer. Geht auch in die vom Compose zusammengesetzte `DATABASE_URL` ein. | `visualise` | Praktisch nie — die Datenbank ist nicht von außen erreichbar |
+| `POSTGRES_PASSWORD` | Passwort dieses Nutzers | `visualise` | Praktisch nie, siehe oben |
+| `POSTGRES_DB` | Name der Datenbank | `visualise` | Praktisch nie |
+| `BACKEND_VERSION` | Build-Argument des Backend-Images. Wird von `/healthz` und `/readyz` als `version` zurückgemeldet. | `dev` | Wenn du ein getaggtes Image baust und im Betrieb erkennen willst, welches läuft |
+| `BACKEND_LOG_LEVEL` | zerolog-Level: `trace`, `debug`, `info`, `warn`, `error` | `info` | Zur Fehlersuche auf `debug` |
+| `BACKEND_LOG_FORMAT` | `json` (maschinenlesbar) oder `console` (menschenlesbar) | `json` | Beim lokalen Mitlesen der Logs auf `console`. Ein anderer Wert lässt das Backend beim Start scheitern |
+| `DATABASE_CONNECT_TIMEOUT` | Wie lange das Backend beim Start auf PostgreSQL wartet, bevor es scheitert. Go-Duration (`60s`, `2m`). | `60s` | Auf langsamen Rechnern erhöhen |
+| `MAX_EVENT_BYTES` | Maximale Größe eines einzelnen ingestierten Events in Bytes | `2097152` (2 MiB) | Wenn Agents größere Snapshots oder Diffs melden — siehe die Warnung unten |
+| `SHUTDOWN_TIMEOUT` | Kulanzfrist für laufende Requests beim Herunterfahren. Go-Duration. | `15s` | Selten |
+| `DATABASE_URL` | Vollständiger PostgreSQL-DSN. Wird von `docker-compose.yml` aus den `POSTGRES_*`-Werten zusammengesetzt. | zusammengesetzt | Nur, wenn das Backend auf eine andere Datenbank zeigen soll |
+
+`HTTP_ADDR` (Listen-Adresse des Backends, `:8080`) wird von
+`docker-compose.yml` fest gesetzt und ist bewusst nicht in `.env.example`: der
+Container-Port ist Teil der Topologie, nicht der Konfiguration.
+
+> **`MAX_EVENT_BYTES` über 8 MiB anzuheben, genügt allein nicht.** Nginx
+> begrenzt den Request-Body auf dieser Route mit `client_max_body_size 8m`. Ein
+> größeres Event würde vom Backend akzeptiert, aber schon von Nginx mit `413`
+> abgelehnt. Über 8 MiB hinaus muss auch
+> `frontend/nginx/default.conf` angepasst werden.
+
+Alle Werte werden beim Start geprüft. Ein nicht parsbarer oder nicht positiver
+Wert lässt das Backend scheitern, statt still auf den Default zurückzufallen —
+und ein gescheitertes Backend wird nie als bereit geroutet (siehe unten).
+
+### Nach dem ersten Start wirken die `POSTGRES_*`-Werte nicht mehr
+
+Das offizielle PostgreSQL-Image initialisiert Nutzer und Datenbank nur, wenn das
+Volume `pgdata` leer ist. Änderst du `POSTGRES_USER`, `POSTGRES_PASSWORD` oder
+`POSTGRES_DB` später, ändert sich zwar die vom Compose gebaute `DATABASE_URL`,
+nicht aber die Datenbank — das Backend kann sich dann nicht mehr anmelden und
+wird nie bereit. Wer diese Werte ändern will, muss das Volume neu anlegen
+(`docker compose down -v`) und verliert dabei alle Daten.
+
+## Healthchecks und Readiness
+
+Das Backend trennt zwei verschiedene Fragen:
+
+| Endpunkt | Beantwortet | Antwort |
+| --- | --- | --- |
+| `GET /healthz` | Läuft der Prozess und antwortet er? PostgreSQL wird **nicht** berührt. | Immer `200 {"status":"ok","version":"…"}`, solange der Prozess bedient |
+| `GET /readyz` | Ist die Startarbeit fertig **und** antwortet PostgreSQL gerade? | `200 {"status":"ready","version":"…"}`, sonst `503` |
+
+Zur Startarbeit gehört die Schemamigration (GORM `AutoMigrate`). Sie läuft,
+bevor das Bereitschaftsflag gesetzt wird — eine gescheiterte Migration bedeutet
+also, dass das Backend nie bereit meldet.
+
+Darauf baut die Compose-Topologie auf:
+
+- Der Healthcheck des `backend`-Containers probt `/readyz`, nicht `/healthz`.
+  Er hat ein `start_period` von 60 s, damit das Warten auf PostgreSQL nicht als
+  Fehlschlag zählt.
+- `frontend` deklariert `depends_on: backend: condition: service_healthy`.
+- `backend` deklariert dasselbe für `postgres`, dessen Healthcheck `pg_isready`
+  ausführt.
+
+**Ein Backend, das nicht startet, wird deshalb nie als bereit geroutet.** Es
+wird nicht gesund, also startet das Frontend gar nicht erst. Der sichtbare
+Preis: solange das Backend unten ist, ist die Oberfläche nicht erreichbar,
+statt eine Hülle auszuliefern, die bei jedem Request 502 antwortet. Für ein
+Beobachtungswerkzeug mit genau einer Instanz ist das die gewünschte Variante —
+eine Oberfläche, die nichts weiß, aber so aussieht, als wüsste sie etwas, wäre
+schlimmer als keine.
+
+Beide Probes sind auch über Nginx erreichbar, was für ein Skript, das auf das
+System wartet, praktisch ist:
+
+```bash
+curl -fsS http://localhost:8080/readyz
+```
+
+## Datenpersistenz
+
+PostgreSQL legt seine Daten im Named Volume `pgdata` ab (unter dem
+Compose-Projektnamen, also standardmäßig `visualise-ai_pgdata`).
+
+| Befehl | Wirkung |
+| --- | --- |
+| `docker compose down` | Container und Netzwerk werden entfernt. **Das Volume bleibt** — beim nächsten `up` sind alle Events wieder da. |
+| `docker compose down -v` | Das Volume wird mit gelöscht. Der nächste Start beginnt mit einer leeren Datenbank. |
+
+Der Event Log ist append-only und die Audit-Quelle; es gibt in v0 kein
+Löschen einzelner Events, keinen Export und kein Backup-Kommando. Wer die Daten
+sichern will, sichert das Volume mit Docker-Bordmitteln.
+
+`down -v` ist der reguläre Weg, um Simulator und End-to-End-Test wieder auf
+einen definierten Anfangszustand zu bringen.
+
+## Portkonflikte
+
+Der Default-Host-Port ist **8080**. Ist er belegt, scheitert `docker compose up`
+mit einer Bind-Fehlermeldung. `FRONTEND_HTTP_PORT` überschreibt ihn:
+
+```bash
+FRONTEND_HTTP_PORT=8101 docker compose up --build -d
+# oder dauerhaft in .env: FRONTEND_HTTP_PORT=8101
+```
+
+Innerhalb des Containers lauscht Nginx unverändert auf 8080; nur die Abbildung
+auf den Host ändert sich. Alles, was auf die Basis-URL zeigt, muss mitgezogen
+werden: der Browser, `--base` des Simulators und die Basis-URL des
+End-to-End-Tests.
+
+Sollen mehrere Stacks parallel laufen, braucht jeder zusätzlich einen eigenen
+Compose-Projektnamen, damit sich Container und Volumes nicht überschreiben:
+
+```bash
+FRONTEND_HTTP_PORT=8101 docker compose -p mein-stack up --build -d
+FRONTEND_HTTP_PORT=8101 docker compose -p mein-stack down -v
+```
+
+## End-to-End-Abnahme (Playwright)
+
+Der verpflichtende Abnahmetest läuft in Chromium bei 1920 × 1080 gegen das echte
+Compose-System aus leerer Datenbank:
+
+```bash
+cd e2e
+npm install
+npx playwright install chromium
+npm test
+```
+
+Ein Fehlschlag blockiert die v0-Freigabe. Aufbau, Voraussetzungen und
+Konfiguration des Tests stehen in [`e2e/README.md`](../e2e/README.md); dieser
+Abschnitt beschreibt bewusst nur den Aufruf. Das Verzeichnis `e2e/` wird mit
+Issue #14 geliefert; bis dessen Pull Request gemergt ist, zeigt der Link ins
+Leere.
+
+## Fehlersuche
+
+| Symptom | Wahrscheinliche Ursache |
+| --- | --- |
+| `docker compose up` scheitert mit „port is already allocated" | Port 8080 belegt — siehe [Portkonflikte](#portkonflikte) |
+| `frontend` startet nicht, `backend` bleibt `starting` oder `unhealthy` | Das Backend wird nicht bereit. `docker compose logs backend` zeigt den Grund: ungültige Konfiguration, gescheiterte Migration oder keine Datenbankverbindung |
+| Oberfläche lädt, zeigt aber keine Projekte | Die Datenbank ist leer. Das ist der korrekte Zustand — führe die [Demo](#demo-ausfuehren) aus oder lass einen Agenten melden |
+| Simulator meldet `200 duplicate: true` statt `201` | Die Datenbank ist nicht leer. `docker compose down -v` und neu starten |
+| Ingestion antwortet `422 unknown_agent` | Der meldende Agent hat vorher kein `agent.started` gesendet — siehe [Agent-Integration](./agent-integration.md#lifecycle) |
+| SSE-Stream bleibt still, obwohl Events ankommen | Der Stream wurde ohne Cursor geöffnet und beginnt am Live-Ende. Für Historie `lastEventPosition=0` setzen — siehe [SSE](./agent-integration.md#sse-stream-und-reconnect) |

--- a/docs/security-and-boundaries.md
+++ b/docs/security-and-boundaries.md
@@ -1,0 +1,144 @@
+# Vertrauensgrenze und Produktgrenzen
+
+Was dieses System schützt, was es ausdrücklich nicht schützt, und wo v0 endet.
+Lies diesen Text, bevor du das Cockpit jemand anderem zugänglich machst.
+
+## Nur lokal oder im privaten Netzwerk
+
+**v0 hat keine Authentifizierung, keine Autorisierung und keine Multi-Tenancy.**
+Der OpenAPI-Vertrag sagt das explizit: `security: []` — keine Operation
+verlangt Credentials. Das ist kein Versäumnis, sondern eine bewusste
+v0-Entscheidung.
+
+Daraus folgt unmittelbar:
+
+- **Nicht ins öffentliche Internet stellen.** Kein Port-Forwarding, kein
+  öffentlicher Reverse Proxy, kein Tunnel.
+- Wer den veröffentlichten Port erreicht, hat vollen Lese- **und** Schreibzugriff.
+- Ein privates Netzwerk ist die äußere Grenze. Innerhalb davon gibt es keine
+  weitere.
+
+### Es gibt keine Mandantentrennung
+
+„Projekt" ist eine Gliederung, keine Grenze. `projectId` ist ein vom Agenten
+frei gewähltes Kürzel, und die Ingestion prüft nur seine Form, nicht seine
+Herkunft. **Wer den Ingestion-Endpunkt erreicht, kann in jedes Projekt
+schreiben** — auch in ein bereits bestehendes, dessen ID er kennt oder errät.
+Genauso kann jeder, der die Oberfläche erreicht, jedes Projekt lesen.
+
+Read Models sind zwar strikt projektbezogen — keine Antwort enthält je eine
+Zeile eines anderen Projekts, selbst wenn zwei Projekte dieselbe Run-, Agent-
+oder Komponenten-ID benutzen. Das ist Korrektheit der Auslieferung, keine
+Zugriffskontrolle.
+
+## Nginx ist der einzige Einstiegspunkt
+
+Von den drei Compose-Services veröffentlicht nur `frontend` einen Host-Port.
+`backend` und `postgres` haben bewusst keinen `ports:`-Eintrag und sind
+ausschließlich aus dem Compose-Netzwerk erreichbar.
+
+Das hat zwei Konsequenzen, die zusammengehören:
+
+- Die gesamte Angriffsfläche des Systems ist ein einziger Port. Was Nginx nicht
+  weiterreicht, existiert von außen nicht.
+- PostgreSQL für ein Debugging zugänglich zu machen, verlangt eine ausdrückliche
+  Änderung an `docker-compose.yml`. Das ist Absicht: es soll nicht versehentlich
+  passieren.
+
+Die Routen, die Nginx weiterreicht, stehen im
+[README](../README.md#netzwerktopologie).
+
+## Agent-Feedback ist nicht vertrauenswürdiger Input
+
+`feedback.published` trägt Markdown, das ein Agent geschrieben hat. Dessen
+eigene Eingaben sind Webseiten, Werkzeugausgaben und Dateien — allesamt
+außerhalb der Vertrauensgrenze dieses Systems. Der Vertrag sagt das in
+denselben Worten und verlagert die Verantwortung ausdrücklich zum Client:
+`FeedbackEntry.body` ist „untrusted markdown … handed through verbatim —
+sanitising it before rendering is the client's job".
+
+Das Cockpit rendert diesen Text in denselben Origin, der auch mit der Read API
+spricht. Es sanitisiert ihn deshalb vor dem Rendern mit `rehype-sanitize` gegen
+eine **Allow-List**: Was nicht aufgeführt ist, wird entfernt. Ein nicht
+vorhergesehener Vektor scheitert damit standardmäßig, statt daran zu scheitern,
+dass jemand ihn vorhergesehen hat.
+
+> **`frontend/src/components/workspace/inspector/sanitizeSchema.ts` ist eine
+> Sicherheitskontrolle, keine Formatierungsoption.** Ein zusätzlicher Eintrag in
+> `tagNames` oder in `protocols` erweitert unmittelbar, was ein Agent in den
+> Origin des Cockpits rendern darf. Eine Änderung an dieser Datei verlangt
+> dieselbe Sorgfalt wie eine Änderung an einer Authentifizierungsregel.
+
+Die Begründung der Pipeline im Detail — warum sanitisiert wird und nicht auf
+das Parsen von HTML verzichtet — steht in
+[ADR 0012](./decisions/0012-component-inspector-and-markdown-safety.md).
+
+## Was v0 ausdrücklich nicht kann
+
+Diese Punkte sind keine offenen Aufgaben, sondern gezogene Grenzen. Wenn ein
+Nutzer eines davon erwartet, ist die Erwartung falsch, nicht das System.
+
+| Nicht in v0 | Bedeutung |
+| --- | --- |
+| **Repository-Zugriff** | Das System liest kein Repository. Jeder Diff, jeder Dateipfad und jede Architektur ist das, was ein Agent gemeldet hat — nicht das, was in einem Repository steht. Nichts wird verifiziert. |
+| **GitHub-, GitLab- oder Gitea-Anbindung** | Keine Integration, keine Commits, keine Pull Requests, keine Webhooks. Siehe [`RepositoryProvider`-Grenze](#repositoryprovider-grenze). |
+| **Authentifizierung und Autorisierung** | Siehe oben. |
+| **Multi-Tenancy** | Siehe oben. |
+| **Programmablauf-Visualisierung** | Das Cockpit zeigt die Architektur und die gemeldete Arbeit daran, keine Aufruf- oder Kontrollflüsse. |
+| **Steuerung des Agenten** | Read-only und beobachtend. Es gibt keinen Rückkanal zum Agenten: kein Stoppen, kein Umlenken, kein Genehmigen. |
+| **Prompting aus der Anwendung heraus** | Es gibt kein Eingabefeld, das beim Agenten landet. |
+| **Bewertung, ob die Arbeit richtig ist** | Das System führt keine Qualitäts- oder Driftbewertung durch. `risk.reported` und `problem.reported` sind Aussagen des Agenten über sich selbst. Der Mensch urteilt. |
+
+Ebenfalls nicht abgeleitet, sondern nur gemeldet: der Status. Es gibt keine
+Stall-Erkennung, keine Timeouts und keine Heuristik. Ein Run ohne Terminalevent
+bleibt offen und zeigt seinen letzten gemeldeten Stand. Details im
+[Lifecycle-Abschnitt](./agent-integration.md#lifecycle).
+
+Zwei technische Grenzen desselben Zuschnitts: es gibt genau **eine**
+Backend-Instanz — der SSE-Broker läuft im Prozess, eine zweite Instanz würde die
+Live-Hälfte der Streams brechen — und das Cockpit ist Desktop-only mit
+verbindlicher Abnahme bei 1920 × 1080 in Chromium.
+
+<a id="repositoryprovider-grenze"></a>
+
+## Die `RepositoryProvider`-Grenze
+
+v0 enthält **keinen** Repository-Zugriff und **keine** `RepositoryProvider`-
+Schnittstelle. Es gibt nichts zu implementieren und nichts zu konfigurieren;
+dieser Abschnitt beschreibt ausschließlich, *wo* eine spätere Anbindung an
+GitHub, GitLab oder Gitea andocken würde und welche Annahmen heute schon so
+getroffen wurden, dass sie das nicht verbauen.
+
+**Die Stelle.** Alles, was das Cockpit über den Code weiß, kommt heute als
+gemeldeter Inhalt in einem Event: `diff.reported` trägt den Unified Diff und den
+Dateipfad, `architecture.snapshot_published` trägt das Modell. Eine
+Repository-Anbindung würde genau hier ansetzen — als **Auflöser einer
+Meldung gegen ein Repository**, nicht als zweite Datenquelle neben dem Event
+Log. Der Event Log bliebe die Wahrheit darüber, *was der Agent behauptet hat*;
+ein Provider könnte danebenstellen, *was im Repository tatsächlich steht*.
+
+**Die Annahmen, die das offenhalten:**
+
+- **Diffs sind repository-relativ und unified.** `filePath` ist per Schema
+  repository-relativ; absolute Pfade und `..`-Segmente werden abgelehnt. Ein
+  gemeldeter Pfad ist damit ohne Umrechnung gegen einen Repository-Baum
+  auflösbar. Der Diff selbst ist unified — dasselbe Format, das jeder Forge
+  ausliefert.
+- **Ein Diff-Event trägt genau eine Datei.** Es gibt keine gebündelten
+  Mehrdateien-Diffs, die erst zerlegt werden müssten. Die logische Änderung
+  wird über `changeId` zusammengehalten.
+- **Komponenten tragen keine Repository-Identität.** Eine `componentId` ist ein
+  vom Agenten vergebenes, stabiles Kürzel; das Modell kennt weder Repository-URL
+  noch Branch noch Commit. Die Architektur ist damit nicht an ein Repository
+  gebunden und muss auch nicht daraus abgeleitet werden. Eine spätere Zuordnung
+  wäre eine zusätzliche Beziehung, keine Änderung am Modell.
+- **Der Event Log ist die Audit-Quelle.** Er ist append-only und im Code
+  erzwungen; Korrekturen und Rücknahmen sind neue Events mit Verweis auf das
+  Original, nie Bearbeitungen. Ein späterer Provider kann also nichts
+  überschreiben — er kann nur ergänzen. Das ist die Eigenschaft, die eine
+  Anbindung ungefährlich macht.
+
+Was bewusst **nicht** festgelegt ist: die Signatur einer solchen Schnittstelle,
+ihr Ort im Code, ihr Transport und ihre Authentifizierung gegenüber der Forge.
+Diese Entscheidungen gehören in das Issue, das die Anbindung tatsächlich baut,
+und werden hier nicht vorweggenommen.


### PR DESCRIPTION
## Zusammenfassung

Betriebs- und Agent-Integrationsdokumentation für v0, getrennt nach den beiden
Zielgruppen: technische Nutzer, die das System lokal betreiben, und
Agent-Autoren, die nur mit OpenAPI und dieser Dokumentation eine gültige
Eventsequenz senden wollen.

| Datei | Inhalt |
| --- | --- |
| `README.md` (überarbeitet) | Kurzer Einstieg: Quick Start, Topologie, Dokumentationsübersicht, lokale Entwicklung |
| `docs/operations.md` (neu) | Voraussetzungen, Start aus leerem Checkout, Demo, alle Umgebungsvariablen aus `.env.example`, Healthchecks und Readiness, Datenpersistenz, Portkonflikte, Playwright-Aufruf, Fehlersuche |
| `docs/agent-integration.md` (neu) | Umschlag, Lifecycle, geschlossener Katalog, Idempotenz, Größenlimit, RFC-9457-Fehlerformat mit allen 422-Codes einzeln, minimale gültige Sequenz, SSE-Reconnect |
| `docs/security-and-boundaries.md` (neu) | Vertrauensgrenze, fehlende Mandantentrennung, Nginx als einziger Einstiegspunkt, Agent-Feedback als nicht vertrauenswürdiger Input, v0-Ausschlüsse, `RepositoryProvider`-Grenze |

Keine Änderungen an `backend/`, `frontend/`, `api/`, `simulator/`, `e2e/`,
`.github/` oder `docs/decisions/`. Jede Aussage wurde gegen das laufende
Compose-System geprüft.

## Nachweis 1 — Start aus leerem Checkout und Demo

Ausgeführt wie in der Dokumentation beschrieben, mit `FRONTEND_HTTP_PORT=8101`
und `-p vai-docs` (Ports 8080–8083 sind lokal belegt), nach
`docker compose -p vai-docs down -v`:

```
$ FRONTEND_HTTP_PORT=8101 docker compose -p vai-docs up --build -d
 Container vai-docs-postgres-1 Started
 Container vai-docs-postgres-1 Waiting
 Container vai-docs-postgres-1 Healthy
 Container vai-docs-backend-1 Starting
 Container vai-docs-backend-1 Started
 Container vai-docs-backend-1 Waiting
 Container vai-docs-backend-1 Healthy
 Container vai-docs-frontend-1 Starting
 Container vai-docs-frontend-1 Started

$ docker compose -p vai-docs ps
NAME                  SERVICE    STATUS                    PORTS
vai-docs-backend-1    backend    Up 6 seconds (healthy)    8080/tcp
vai-docs-frontend-1   frontend   Up (health: starting)     0.0.0.0:8101->8080/tcp
vai-docs-postgres-1   postgres   Up 11 seconds (healthy)   5432/tcp

$ curl -sS http://localhost:8101/healthz
{"status":"ok","version":"dev"}
$ curl -sS http://localhost:8101/readyz
{"status":"ready","version":"dev"}
$ curl -sS http://localhost:8101/api/v1/projects
{"projectPosition":0,"projects":[]}
```

Demo, wörtlich nach `docs/operations.md`
(`cd simulator && npm install && npm run simulate -- --base http://localhost:8101`):

```
    62  201  agent.status_reported           orchestrator-root             —

Summary
  scenario        full
  project         visualise-ai
  run             run-2026-08-04-0001
  events sent     62
  created (201)   62
  duplicate (200) 0
  conflict (409)  0
  end position    62
  open            http://localhost:8101/projects/visualise-ai
```

Read Models danach:

```
$ curl -sS http://localhost:8101/api/v1/projects/visualise-ai
{"projectPosition":62,"project":{"projectId":"visualise-ai","firstSeenAt":"2026-08-04T09:00:46Z",
 "lastEventAt":"2026-08-04T09:53:37Z","lastPosition":62,"currentRunId":"run-2026-08-04-0001",
 "counts":{"runs":1,"openRuns":1,"components":17,"relationships":11,"activeChanges":2}}}

$ curl -sS .../runs/current/agents        # gekürzt
orchestrator-root            orchestrator  status idle  finishedOutcome null
subagent-architecture-mapper subagent      status done  finishedOutcome completed
subagent-implementer         subagent      status done  finishedOutcome completed
subagent-reviewer            subagent      status done  finishedOutcome completed
subagent-test-engineer       subagent      status done  finishedOutcome completed
```

Die Oberfläche wurde bei 1920 × 1080 geöffnet und rendert die gemeldeten Daten,
unter anderem die zwei Planrevisionen des Orchestrators:

```
plan-2026-08-04-0001 · 2 Revisionen
Revision 1 (frühere Fassung) — 04.08.2026, 09:12:59 UTC · orchestrator-root — 1 von 4 Schritten abgeschlossen
Revision 2 (aktuell)         — 04.08.2026, 09:44:14 UTC · orchestrator-root — 4 von 5 Schritten abgeschlossen
```

Der Stack lief ausschließlich als eigenes Compose-Projekt und wurde mit
`docker compose -p vai-docs down -v` vollständig abgeräumt.

## Nachweis 2 — Von Hand gebaute, gültige Eventsequenz

Ohne Simulator, nur mit `curl` gegen das laufende System: Root-Agent, ein
Subagent, ein Snapshot, ein Feedback, ein Diff. Die Sequenz steht wörtlich in
`docs/agent-integration.md`.

```
### 1/5 agent.started (Root-Orchestrator)                 HTTP 201
{"projectId":"docs-proof","position":1,"duplicate":false, …}
### 2/5 agent.started (Subagent)                          HTTP 201
{"projectId":"docs-proof","position":2,"duplicate":false, …}
### 3/5 architecture.snapshot_published                   HTTP 201
{"projectId":"docs-proof","position":3,"duplicate":false, …}
### 4/5 feedback.published                                HTTP 201
{"projectId":"docs-proof","position":4,"duplicate":false, …}
### 5/5 diff.reported                                     HTTP 201
{"projectId":"docs-proof","position":5,"duplicate":false, …}
```

Gegenproben zu den dokumentierten Regeln:

```
A) Event eines Agenten ohne vorheriges agent.started      HTTP 422
{"code":"unknown_agent","detail":"agent \"subagent-never-started\" never reported
 agent.started in run \"run-docs-proof-0001\"", …}

B) byte-identische Wiederholung von Event 1               HTTP 200
{"position":1,"serverEventId":"f6ef3c99-…","duplicate":true, …}   # dieselbe Position

C) gleiche clientEventId, anderer Inhalt                  HTTP 409
{"code":"client_event_id_conflict","detail":"… was already accepted at position 1
 of project \"docs-proof\" with different content.", …}
```

Ergebnis im Cockpit:

```
$ curl -sS http://localhost:8101/api/v1/projects/docs-proof
{"projectPosition":5,"project":{…,"currentRunId":"run-docs-proof-0001",
 "counts":{"runs":1,"openRuns":1,"components":3,"relationships":1,"activeChanges":0}}}

$ curl -sS .../components/checkout.api    # gekürzt
component  checkout.api (service, parent checkout, appliedAt 2026-08-04T12:01:00Z)
feedback   feedback-0001 "Rundungsregel ist nicht festgelegt"
diffs      diff-0001  internal/checkout/pricing.go  (changeId change-0001)
```

Zusätzlich wurden **alle sieben 422-Lifecycle-Codes** einzeln provoziert und
gegen die Dokumentation abgeglichen: `run_not_started`, `run_already_started`,
`unknown_agent`, `parent_agent_unknown`, `terminal_event_not_allowed`,
`run_already_finished` (mit `retraction.issued` als weiterhin akzeptiertem
Event) und `correction_target_unknown`. Ebenso `415`, `400` mit
JSON-Pointer-Feldfehlern und `413` an beiden Größengrenzen.

SSE-Verhalten wurde ebenfalls geprüft — insbesondere die dokumentierte
Stolperfalle, dass ein Stream ohne Cursor nicht replayt:

```
$ curl --max-time 3 -H 'Accept: text/event-stream' .../stream
: keepalive                                  # kein Replay, startet am Live-Ende

$ curl --max-time 3 -H 'Accept: text/event-stream' '.../stream?lastEventPosition=0'
: keepalive
id: 1
event: agent.started
data: {…}

$ curl --max-time 3 -H 'Last-Event-ID: 3' -H 'Accept: text/event-stream' .../stream
: keepalive
id: 4
event: feedback.published
data: {…}
```

## Lücken in der eigenen Dokumentation, die der Nachweis aufgedeckt hat

Beim Bau der Sequenz von Hand fehlten sechs Angaben, die inzwischen ergänzt sind:

1. **`parentComponentId` ist ein Pflichtfeld, auch für Wurzelkomponenten.**
   Weglassen ist ein `400`; `null` muss explizit dastehen. Ergänzt unter
   „Regeln, die man beim ersten Mal übersieht".
2. **Zwei verschiedene ID-Formate.** `projectId`/`runId`/`agentId`/`componentId`
   sind Slugs mit strengem Muster (mindestens 3 Zeichen, Kleinbuchstaben),
   während `feedbackId`/`diffId`/`changeId`/… freie `Identifier` sind. Eigener
   Unterabschnitt.
3. **`Content-Type: application/json` ist Pflicht**, sonst `415` — stand vorher
   nirgends in der Nutzerdokumentation.
4. **`parentAgentId` gehört in jedes Event eines Subagenten**, nicht nur in sein
   `agent.started`.
5. **Nginx begrenzt den Body auf 8 MiB** (`client_max_body_size 8m`). Oberhalb
   davon antwortet Nginx mit einer HTML-Fehlerseite statt `problem+json`, und
   `MAX_EVENT_BYTES` allein anzuheben genügt nicht. Ergänzt in `operations.md`
   und `agent-integration.md`.
6. **Die erste Zeile eines SSE-Streams ist in der Regel ein Keepalive** — für
   einen selbstgebauten Client relevant, weil ein Stream ohne Cursor sonst wie
   ein Fehler aussieht.

Zusätzlich beim Schreiben empirisch geprüft und dokumentiert: Werden
`POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB` nach der Erstinitialisierung
des Volumes geändert, scheitert die Anmeldung, das Backend wird nie gesund und
das Frontend startet gar nicht erst (`dependency failed to start: container
vai-docs-backend-1 is unhealthy`). Das ist zugleich der Nachweis für „ein
gescheiterter Backend-Start wird nie als bereit geroutet".

## Gefundene Widersprüche (hier bewusst nicht repariert)

1. **`api/openapi.yaml` behauptet, `/healthz` und `/readyz` seien nicht über
   Nginx erreichbar.** Beide Operationen tragen die Beschreibung „Not routed
   through the Nginx frontend and therefore not reachable from outside the
   Compose network" und einen eigenen `servers`-Eintrag `http://backend:8080`;
   `tags.Operations` sagt dasselbe. `frontend/nginx/default.conf` proxyt beide
   aber ausdrücklich (`location = /healthz`, `location = /readyz`), und der Test
   bestätigt es:

   ```
   $ curl -sS http://localhost:8101/readyz
   {"status":"ready","version":"dev"}
   ```

   Die Dokumentation beschreibt den tatsächlichen Zustand (erreichbar, praktisch
   für Warteskripte). Der Vertragstext in `api/` sollte korrigiert werden — das
   liegt außerhalb des Scopes dieses Issues.

2. **`MAX_EVENT_BYTES` ist oberhalb von 8 MiB wirkungslos**, weil Nginx vorher
   abriegelt und dabei kein `problem+json` liefert. Kein Fehler im engeren Sinn,
   aber eine Konfigurationsoption, deren nutzbarer Wertebereich enger ist als
   dokumentiert. Hier nur beschrieben, nicht geändert.

## Offene Risiken

- `docs/operations.md` verlinkt `e2e/README.md`. Das Verzeichnis entsteht
  parallel in #14; bis dessen Pull Request gemergt ist, zeigt genau dieser eine
  Link ins Leere. Der Abschnitt beschreibt bewusst nur den Aufruf, damit kein
  Widerspruch zu #14 entsteht.
- Simulator-Flags und -Szenarien stehen jetzt sowohl in `simulator/README.md`
  als auch in `docs/operations.md` (vom Issue so gefordert). `simulator/README.md`
  bleibt die Detailquelle und wird von dort verlinkt; bei künftigen
  Flag-Änderungen müssen beide Stellen nachgezogen werden.
- Alle 47 relativen Links und Anker der vier Dateien wurden automatisiert
  geprüft; einzige Fundstelle ist das oben genannte `e2e/README.md`.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
