### PR TITLE
Vertrag und Einstiegspunkt an das tatsächliche Verhalten angleichen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@
 # The only host port published by the deployment.
 FRONTEND_HTTP_PORT=8080
 
+# Largest request body Nginx forwards, in Nginx size notation (e.g. 4m, 16m).
+# This is the entry point's limit, not the contract's: it must stay ABOVE
+# MAX_EVENT_BYTES below, otherwise Nginx rejects an oversized event before the
+# backend can answer with the contract's problem+json. Raise both together.
+MAX_REQUEST_BODY_SIZE=4m
+
 # ---- PostgreSQL (internal only) ---------------------------------------------
 POSTGRES_USER=visualise
 POSTGRES_PASSWORD=visualise
@@ -24,7 +30,9 @@ BACKEND_LOG_FORMAT=json
 DATABASE_CONNECT_TIMEOUT=60s
 
 # Maximum accepted size of a single ingested agent event, in bytes.
-# 2097152 = 2 MiB, the default of the event contract.
+# 2097152 = 2 MiB, the default of the event contract. Keep it below
+# MAX_REQUEST_BODY_SIZE above; Nginx sits in front and enforces its own limit
+# first, so a value above it would never take effect.
 MAX_EVENT_BYTES=2097152
 
 # Grace period for in-flight requests on shutdown.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16,7 +16,7 @@ info:
     | `POST /api/v1/events` | Single-event ingestion, idempotent per `clientEventId`. |
     | `GET /api/v1/projects/{projectId}/stream` | Server-Sent Events: gap-free replay followed by the live stream. |
     | `GET /api/v1/projects` … `GET /api/v1/projects/{projectId}/components/{componentId}/history` | Project scoped read models: projects, architecture, runs, agents, plans and component evidence. |
-    | `GET /healthz`, `GET /readyz` | Internal container probes, not reachable from outside the Compose network. |
+    | `GET /healthz`, `GET /readyz` | Container probes, proxied by Nginx and therefore reachable from the published port. |
 
     ## The read models
 
@@ -725,12 +725,12 @@ paths:
       operationId: getLiveness
       summary: Liveness probe (internal)
       description: |
-        Internal liveness probe of the Go backend container. It reports only that the process
-        is running and answering; it never touches PostgreSQL. Not routed through the Nginx
-        frontend and therefore not reachable from outside the Compose network.
-      servers:
-        - url: http://backend:8080
-          description: Internal Go backend container — reachable only inside the Compose network
+        Liveness probe of the Go backend container. It reports only that the process is
+        running and answering; it never touches PostgreSQL.
+
+        Nginx proxies this route, so it answers on the published port as well as inside the
+        Compose network. It carries no project data, but like every other route in v0 it is
+        unauthenticated — see the trust boundary in `docs/security-and-boundaries.md`.
       responses:
         '200':
           description: The process is alive.
@@ -746,12 +746,12 @@ paths:
       operationId: getReadiness
       summary: Readiness probe (internal)
       description: |
-        Internal readiness probe of the Go backend container. It reports whether the backend
-        can serve traffic, which includes a reachable PostgreSQL and applied migrations. Not
-        routed through the Nginx frontend.
-      servers:
-        - url: http://backend:8080
-          description: Internal Go backend container — reachable only inside the Compose network
+        Readiness probe of the Go backend container. It reports whether the backend can serve
+        traffic, which includes a reachable PostgreSQL and applied migrations.
+
+        Nginx proxies this route, so it answers on the published port as well as inside the
+        Compose network. The Compose healthcheck probes it, which is why a backend that failed
+        to start is never routed to as ready.
       responses:
         '200':
           description: The backend is ready to serve ingestion and streaming.

--- a/backend/internal/ingest/contract/openapi.yaml
+++ b/backend/internal/ingest/contract/openapi.yaml
@@ -16,7 +16,7 @@ info:
     | `POST /api/v1/events` | Single-event ingestion, idempotent per `clientEventId`. |
     | `GET /api/v1/projects/{projectId}/stream` | Server-Sent Events: gap-free replay followed by the live stream. |
     | `GET /api/v1/projects` … `GET /api/v1/projects/{projectId}/components/{componentId}/history` | Project scoped read models: projects, architecture, runs, agents, plans and component evidence. |
-    | `GET /healthz`, `GET /readyz` | Internal container probes, not reachable from outside the Compose network. |
+    | `GET /healthz`, `GET /readyz` | Container probes, proxied by Nginx and therefore reachable from the published port. |
 
     ## The read models
 
@@ -725,12 +725,12 @@ paths:
       operationId: getLiveness
       summary: Liveness probe (internal)
       description: |
-        Internal liveness probe of the Go backend container. It reports only that the process
-        is running and answering; it never touches PostgreSQL. Not routed through the Nginx
-        frontend and therefore not reachable from outside the Compose network.
-      servers:
-        - url: http://backend:8080
-          description: Internal Go backend container — reachable only inside the Compose network
+        Liveness probe of the Go backend container. It reports only that the process is
+        running and answering; it never touches PostgreSQL.
+
+        Nginx proxies this route, so it answers on the published port as well as inside the
+        Compose network. It carries no project data, but like every other route in v0 it is
+        unauthenticated — see the trust boundary in `docs/security-and-boundaries.md`.
       responses:
         '200':
           description: The process is alive.
@@ -746,12 +746,12 @@ paths:
       operationId: getReadiness
       summary: Readiness probe (internal)
       description: |
-        Internal readiness probe of the Go backend container. It reports whether the backend
-        can serve traffic, which includes a reachable PostgreSQL and applied migrations. Not
-        routed through the Nginx frontend.
-      servers:
-        - url: http://backend:8080
-          description: Internal Go backend container — reachable only inside the Compose network
+        Readiness probe of the Go backend container. It reports whether the backend can serve
+        traffic, which includes a reachable PostgreSQL and applied migrations.
+
+        Nginx proxies this route, so it answers on the published port as well as inside the
+        Compose network. The Compose healthcheck probes it, which is why a backend that failed
+        to start is never routed to as ready.
       responses:
         '200':
           description: The backend is ready to serve ingestion and streaming.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,10 @@ services:
     restart: unless-stopped
     ports:
       - "${FRONTEND_HTTP_PORT:-8080}:8080"
+    environment:
+      # Must stay above the backend's MAX_EVENT_BYTES, otherwise Nginx rejects an
+      # oversized event before the backend can answer per contract.
+      MAX_REQUEST_BODY_SIZE: ${MAX_REQUEST_BODY_SIZE:-4m}
     depends_on:
       backend:
         condition: service_healthy

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -194,9 +194,11 @@ Das Limit trifft in der Praxis zwei Dinge: sehr große
 sich aufteilen — die Architektur über inkrementelle `change_*`-Events, Diffs
 ohnehin pro Datei.
 
-Ist die Anfrage größer als 8 MiB, lehnt bereits Nginx sie ab, und zwar mit einer
-HTML-Fehlerseite statt einem `application/problem+json`. Ein Client sollte
-`413` deshalb nicht am Antwortkörper erkennen, sondern am Statuscode.
+Überschreitet die Anfrage zusätzlich das Limit des Einstiegspunkts
+(`MAX_REQUEST_BODY_SIZE`, Default `4m`), lehnt bereits Nginx sie ab. Auch diese
+Ablehnung kommt als `application/problem+json` mit `code: event_too_large`, ist
+für einen Client also nicht von der des Backends zu unterscheiden — genau das
+ist beabsichtigt.
 
 ## Fehlerformat
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -129,6 +129,7 @@ Checkout funktionieren.
 | Variable | Wofür | Default | Wann ändern |
 | --- | --- | --- | --- |
 | `FRONTEND_HTTP_PORT` | Der einzige vom Deployment veröffentlichte Host-Port. Nginx lauscht im Container immer auf 8080; diese Variable bestimmt nur, worauf er auf dem Host abgebildet wird. | `8080` | Bei [Portkonflikten](#portkonflikte) oder wenn mehrere Stacks parallel laufen |
+| `MAX_REQUEST_BODY_SIZE` | Größter Request-Body, den Nginx durchlässt, in Nginx-Notation (`4m`, `16m`). Das ist das Limit des Einstiegspunkts, nicht das des Vertrags. Muss über `MAX_EVENT_BYTES` bleiben. | `4m` | Gemeinsam mit `MAX_EVENT_BYTES` — siehe die Warnung unten |
 | `POSTGRES_USER` | Datenbanknutzer. Geht auch in die vom Compose zusammengesetzte `DATABASE_URL` ein. | `visualise` | Praktisch nie — die Datenbank ist nicht von außen erreichbar |
 | `POSTGRES_PASSWORD` | Passwort dieses Nutzers | `visualise` | Praktisch nie, siehe oben |
 | `POSTGRES_DB` | Name der Datenbank | `visualise` | Praktisch nie |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -144,11 +144,15 @@ Checkout funktionieren.
 `docker-compose.yml` fest gesetzt und ist bewusst nicht in `.env.example`: der
 Container-Port ist Teil der Topologie, nicht der Konfiguration.
 
-> **`MAX_EVENT_BYTES` über 8 MiB anzuheben, genügt allein nicht.** Nginx
-> begrenzt den Request-Body auf dieser Route mit `client_max_body_size 8m`. Ein
-> größeres Event würde vom Backend akzeptiert, aber schon von Nginx mit `413`
-> abgelehnt. Über 8 MiB hinaus muss auch
-> `frontend/nginx/default.conf` angepasst werden.
+> **`MAX_EVENT_BYTES` anzuheben genügt allein nicht.** Nginx steht davor und
+> begrenzt den Request-Body auf `MAX_REQUEST_BODY_SIZE` (Default `4m`). Ein
+> Event darüber wird schon am Einstiegspunkt abgelehnt und erreicht das Backend
+> nie. Hebe beide Werte gemeinsam an und halte `MAX_REQUEST_BODY_SIZE`
+> oberhalb von `MAX_EVENT_BYTES`.
+>
+> Nginx antwortet in diesem Fall ebenfalls mit `application/problem+json` und
+> `code: event_too_large`, damit ein Agent die Ablehnung genauso auswerten kann
+> wie die des Backends.
 
 Alle Werte werden beim Start geprüft. Ein nicht parsbarer oder nicht positiver
 Wert lässt das Backend scheitern, statt still auf den Default zurückzufallen —

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,8 +14,16 @@ RUN npm run build
 # ---- runtime --------------------------------------------------------------
 FROM nginx:1.29-alpine AS runtime
 
-COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+# The site config is a template so the request size limit can follow the
+# backend's MAX_EVENT_BYTES. The image entrypoint renders /etc/nginx/templates
+# into /etc/nginx/conf.d on start.
+COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
+
+# NGINX_ENVSUBST_FILTER restricts substitution to this one variable, so Nginx's
+# own $host, $uri, $backend and friends survive template rendering untouched.
+ENV MAX_REQUEST_BODY_SIZE=4m \
+    NGINX_ENVSUBST_FILTER=MAX_REQUEST_BODY_SIZE
 
 # The only port published to the host by Compose.
 EXPOSE 8080

--- a/frontend/nginx/default.conf.template
+++ b/frontend/nginx/default.conf.template
@@ -13,7 +13,20 @@ server {
     resolver 127.0.0.11 valid=10s ipv6=off;
     set $backend http://backend:8080;
 
-    client_max_body_size 8m;
+    # Must stay above the backend's MAX_EVENT_BYTES (2 MiB by default), otherwise
+    # Nginx rejects an oversized event before the backend can answer with the
+    # contract's problem+json. Raising MAX_EVENT_BYTES means raising this too;
+    # both are documented together in .env.example.
+    client_max_body_size ${MAX_REQUEST_BODY_SIZE};
+
+    # An event over the limit is still a contract violation, so answer it the way
+    # the contract says instead of with Nginx's HTML error page.
+    error_page 413 = @too_large;
+
+    location @too_large {
+        default_type application/problem+json;
+        return 413 '{"type":"https://visualise-ai.local/problems/event-too-large","title":"Content Too Large","status":413,"detail":"The request body exceeds the size the entry point accepts. See MAX_EVENT_BYTES and MAX_REQUEST_BODY_SIZE.","code":"event_too_large"}';
+    }
 
     # ---- Server-Sent Events -------------------------------------------------
     # Must be declared before the generic /api/ prefix: regex locations win.

--- a/frontend/src/api/generated/contract.ts
+++ b/frontend/src/api/generated/contract.ts
@@ -5,7 +5,7 @@
  * (openapi-typescript). Edit the contract, then regenerate.
  *
  * authority: api/openapi.yaml
- * sha256:    dc6b2426da195c0b6f220a3226c8229f2f575142f5ff5315222e68fd670ce0ee
+ * sha256:    7e96a6f09ee1c901eeeb02dedaa7c0fe1edd94173046ebaf51e286f75684e618
  *
  * `npm run check:contract` — also run by the Vitest suite — fails when this
  * file no longer matches the authority above.
@@ -364,9 +364,12 @@ export interface paths {
         };
         /**
          * Liveness probe (internal)
-         * @description Internal liveness probe of the Go backend container. It reports only that the process
-         *     is running and answering; it never touches PostgreSQL. Not routed through the Nginx
-         *     frontend and therefore not reachable from outside the Compose network.
+         * @description Liveness probe of the Go backend container. It reports only that the process is
+         *     running and answering; it never touches PostgreSQL.
+         *
+         *     Nginx proxies this route, so it answers on the published port as well as inside the
+         *     Compose network. It carries no project data, but like every other route in v0 it is
+         *     unauthenticated — see the trust boundary in `docs/security-and-boundaries.md`.
          */
         get: operations["getLiveness"];
         put?: never;
@@ -386,9 +389,12 @@ export interface paths {
         };
         /**
          * Readiness probe (internal)
-         * @description Internal readiness probe of the Go backend container. It reports whether the backend
-         *     can serve traffic, which includes a reachable PostgreSQL and applied migrations. Not
-         *     routed through the Nginx frontend.
+         * @description Readiness probe of the Go backend container. It reports whether the backend can serve
+         *     traffic, which includes a reachable PostgreSQL and applied migrations.
+         *
+         *     Nginx proxies this route, so it answers on the published port as well as inside the
+         *     Compose network. The Compose healthcheck probes it, which is why a backend that failed
+         *     to start is never routed to as ready.
          */
         get: operations["getReadiness"];
         put?: never;


### PR DESCRIPTION
## Zusammenfassung

Zwei Widersprüche, die der Dokumentations-Agent in [#29](https://github.com/risqyy/visualise-ai/pull/29) gefunden hat — **nicht** durch Lesen der Spec, sondern indem er das System wirklich bedient hat. Beide lagen außerhalb seines Scopes, er hat sie korrekt gemeldet statt still repariert.

### 1. Der Vertrag behauptete das Gegenteil der Realität

`api/openapi.yaml` beschrieb `/healthz` und `/readyz` als

> Not routed through the Nginx frontend and therefore not reachable from outside the Compose network.

mit eigenem `servers`-Eintrag `http://backend:8080`. Tatsächlich proxyt `frontend/nginx/default.conf` beide Routen:

```
location = /healthz { proxy_pass $backend; … }
location = /readyz  { proxy_pass $backend; … }
```

Ein Agent-Autor, der nur den Vertrag liest, hätte daraus die **falsche Vertrauensgrenze** abgeleitet. Die Beschreibung sagt jetzt, was zutrifft, und verweist auf `docs/security-and-boundaries.md`.

### 2. `MAX_EVENT_BYTES` war oberhalb 8 MiB wirkungslos

Die Einstellung ist als serverseitig konfigurierbar dokumentiert, aber Nginx riegelte mit einem fest verdrahteten `client_max_body_size 8m` vorher ab — und antwortete dort mit einer **HTML-Fehlerseite** statt `application/problem+json`. Oberhalb dieser Grenze tat die Einstellung stillschweigend nichts.

Jetzt:
- Die Site-Konfiguration ist ein Template, das der Image-Entrypoint rendert. Das Limit des Einstiegspunkts heißt `MAX_REQUEST_BODY_SIZE` (Default `4m`) und steht in `.env.example` direkt neben `MAX_EVENT_BYTES`, mit der Regel, dass es darüber bleiben muss.
- `NGINX_ENVSUBST_FILTER=MAX_REQUEST_BODY_SIZE` beschränkt die Substitution auf genau diese Variable, damit Nginx-eigene `$host`, `$uri` und `$backend` das Rendern unversehrt überstehen.
- Nginx antwortet auf einen zu großen Body jetzt mit `application/problem+json` und `code: event_too_large`. Ein Client kann die Ablehnung des Einstiegspunkts damit nicht mehr von der des Backends unterscheiden — genau das ist beabsichtigt.

## Testnachweise

**Template-Rendering** (`MAX_REQUEST_BODY_SIZE=1m`), im laufenden Container geprüft:
```
/etc/nginx/conf.d/default.conf:20    client_max_body_size 1m;

nginx-eigene Variablen unversehrt:
  set $backend http://backend:8080;      -> 1 Vorkommen
  proxy_set_header Host $host;           -> 4 Vorkommen
```

**413 als problem+json**, 2 MiB gegen ein 1m-Limit:
```
Body-Größe     2.00 MiB  (Limit 1m)
Status         413
Content-Type   application/problem+json
Antwort        {"type":"https://visualise-ai.local/problems/event-too-large",
                "title":"Content Too Large","status":413,…,"code":"event_too_large"}
```

**Probes durch Nginx erreichbar** — die Vertragskorrektur:
```
GET /healthz -> 200  {"status":"ok","version":"dev"}
GET /readyz  -> 200  {"status":"ready","version":"dev"}
```

**Normalbetrieb unverändert:**
```
GET /api/v1/projects -> 200  {"projectPosition":0,"projects":[]}
GET /                -> 200
```

**Suiten:**
```
api      npm test  -> lint valid, bundle ok, 14 Beispiele, 5 Rejection-Fixtures
frontend npm test  -> 26 Dateien / 214 Tests grün   (Typen neu generiert)
backend  go test ./internal/ingest/ -> ok  (Vertrags-Drift-Guard grün)
```

Die eingebettete Vertragskopie und die generierten Frontend-Typen sind nachgezogen; beide Drift-Guards greifen sonst.

## Hinweis

Kein `Closes` — das ist kein Issue, sondern eine Korrektur an bereits gemergter Arbeit. Betrifft #2 (Compose/Nginx), #3 (Vertrag) und #15 (Dokumentation).
