### PR TITLE
[v0] Verpflichtenden Playwright-End-to-End-Abnahmetest implementieren

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+# The fast suites. They are cheap enough to run on every push and they are what
+# tells a contributor *where* something broke; the mandatory end-to-end
+# acceptance run (issue #14) lives in `e2e.yml` because it needs Docker, a build
+# of every service and a real browser.
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: contract (api)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: api/package-lock.json
+      - run: npm ci
+        working-directory: api
+      - run: npm test
+        working-directory: api
+
+  backend:
+    name: backend (go)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - run: go build ./...
+        working-directory: backend
+      - run: go vet ./...
+        working-directory: backend
+      - run: go test ./...
+        working-directory: backend
+
+  frontend:
+    name: frontend (react)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+        working-directory: frontend
+      # The generated contract types must match the checked-in contract, or the
+      # frontend would be typed against a document nobody published.
+      - run: npm run check:contract
+        working-directory: frontend
+      - run: npm run lint
+        working-directory: frontend
+      - run: npm run typecheck
+        working-directory: frontend
+      - run: npm test
+        working-directory: frontend
+      - run: npm run build
+        working-directory: frontend
+
+  simulator:
+    name: simulator (node)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: simulator/package-lock.json
+      - run: npm ci
+        working-directory: simulator
+      - run: npm run lint
+        working-directory: simulator
+      - run: npm run typecheck
+        working-directory: simulator
+      - run: npm test
+        working-directory: simulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ name: CI
 # acceptance run (issue #14) lives in `e2e.yml` because it needs Docker, a build
 # of every service and a real browser.
 
+# `push` is limited to the default branch on purpose: with `branches: ['**']` a
+# branch that has an open pull request is built twice for the same commit.
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,85 @@
+name: E2E acceptance
+
+# The mandatory end-to-end acceptance run of the v0 epic (issue #14).
+#
+# It builds the real Compose deployment from this checkout, starts it from an
+# empty PostgreSQL database and drives it through Nginx with Chromium at
+# 1920 × 1080. A failure here blocks the v0 release — see
+# `docs/decisions/0013-mandatory-end-to-end-acceptance.md`.
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  acceptance:
+    name: playwright acceptance (chromium 1920×1080)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      # The runner's 8080 is free, so CI keeps the documented default port
+      # exercised. Locally the suite defaults to 8100.
+      FRONTEND_HTTP_PORT: '8080'
+      E2E_COMPOSE_PROJECT: vai-e2e-ci
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            e2e/package-lock.json
+            simulator/package-lock.json
+
+      - name: Show Docker and Compose versions
+        run: |
+          docker version
+          docker compose version
+
+      # The suite installs these itself when they are missing; doing it here
+      # keeps the cache warm and separates a dependency failure from a test one.
+      - name: Install simulator dependencies
+        run: npm ci
+        working-directory: simulator
+
+      - name: Install e2e dependencies
+        run: npm ci
+        working-directory: e2e
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: e2e
+
+      - name: Run the acceptance suite
+        run: npm test
+        working-directory: e2e
+
+      - name: Upload the Playwright report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 14
+
+      # Traces, screenshots and videos of failed tests. Only produced on
+      # failure, so the step is a no-op on a green run.
+      - name: Upload failure artefacts
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-test-results
+          path: e2e/test-results/
+          retention-days: 14
+
+      - name: Dump the deployment logs on failure
+        if: failure()
+        run: docker compose -p "${E2E_COMPOSE_PROJECT}" logs --no-color --tail 400 || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,12 @@ name: E2E acceptance
 # 1920 × 1080. A failure here blocks the v0 release — see
 # `docs/decisions/0013-mandatory-end-to-end-acceptance.md`.
 
+# `push` is limited to the default branch on purpose: with `branches: ['**']` a
+# branch that has an open pull request would run this expensive job twice for
+# the same commit.
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ npm run lint && npm run typecheck && npm test
 cd api
 npm ci
 npm test
+
+# End-to-End-Abnahme (braucht Docker; siehe e2e/README.md)
+cd e2e
+npm install && npx playwright install chromium
+npm test
 ```
 
 `npm run dev` im `frontend/` startet Vite auf Port 5173 und proxyt `/api`,

--- a/docs/decisions/0013-mandatory-end-to-end-acceptance.md
+++ b/docs/decisions/0013-mandatory-end-to-end-acceptance.md
@@ -1,0 +1,242 @@
+# 13. The mandatory end-to-end acceptance run: one browser, the real deployment, and guards against a green vacuum
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #14 (part of the v0 epic #1)
+- **Builds on:** [0001 — Compose topology and single entry point](./0001-compose-topology-and-single-entry-point.md),
+  [0002 — Event log with synchronous projections](./0002-event-log-with-synchronous-projections.md),
+  [0004 — Contract-driven ingestion validation](./0004-contract-driven-ingestion-validation.md),
+  [0006 — SSE replay and in-process broker](./0006-sse-replay-and-in-process-broker.md),
+  [0007 — Deterministic event simulator](./0007-deterministic-event-simulator.md),
+  [0008 — Architecture canvas](./0008-architecture-canvas-layout-and-edge-bundling.md),
+  [0010 — Live change overlays](./0010-live-change-overlays.md),
+  [0011 — Run and agent hierarchy](./0011-run-and-agent-hierarchy.md)
+
+## Context
+
+This is the release gate of the whole v0 epic: if the run in `e2e/` fails, v0 is
+not released. That single sentence decides everything below, because a gate has
+exactly two ways to be useless — it can fail for reasons that have nothing to do
+with the product, and it can pass without having looked at anything.
+
+Every unit and integration suite in this repository already passes. They test
+the backend against its own store, the frontend against a mocked fetch and the
+simulator against an injected `fetchImpl`. None of them can show that the
+contract, the projections, the SSE handover, the Nginx routing and the browser
+fit together, because each of them replaces at least one of those with a
+stand-in.
+
+## Decision
+
+### Against the built Compose deployment, from an empty database, never against mocks
+
+`globalSetup` runs `docker compose -p vai-e2e down -v`, then
+`up --build -d`, then waits for `/readyz` **through Nginx**. `globalTeardown`
+runs `down -v` again.
+
+The volume is removed on both ends rather than only at the start. A leftover
+`pgdata` would make the next run start from a populated database, and against a
+populated database the simulator's first delivery is legitimately a duplicate —
+correct behaviour that silently invalidates every idempotency assertion the
+`retry` scenario exists to make.
+
+Everything the suite touches goes through the published Nginx port: the browser,
+the raw SSE reader and the simulator alike. That is not a convention, it is the
+only thing the deployment offers — neither the backend nor PostgreSQL publishes
+a host port (ADR 0001) — and it means the acceptance run exercises the SSE
+location block, the unbuffered proxying and the SPA fallback as part of every
+assertion rather than as a separate concern.
+
+Mocking was rejected outright. A mocked backend would let the test assert that
+the frontend agrees with the test's own idea of the read API, which is exactly
+the agreement that unit tests already establish and exactly the one that cannot
+be broken by a deployment defect.
+
+### Chromium at exactly 1920 × 1080, and no browser matrix
+
+The epic fixes desktop Chromium at 1920 × 1080 as the acceptance surface, and
+issue #14 states that Firefox, WebKit, mobile and tablet are not mandatory. They
+are therefore **not configured**, not configured-and-skipped.
+
+The resolution is a property of the product, not of the test: the default pane
+split (`DEFAULT_PANE_LAYOUT`), the deep-focus split
+(`DEEP_FOCUS_PANE_LAYOUT`, ~41 % for the canvas), the minimap size and the
+horizontal-scrollbar check are all stated in pixels at 1920 × 1080. Asserting
+them at another size would assert nothing, and asserting them in a second engine
+would either duplicate the same layout arithmetic or start reporting engine
+differences as product failures. A gate that reports noise gets ignored, and an
+ignored gate is worse than none.
+
+Adding a browser is a decision about what v0 promises, and it belongs in an ADR
+rather than in a config array.
+
+### The live states have to be watched live, and the observer lives in the page
+
+Three of the four work states — `aktiv`, `kürzlich angewandt`, `entfernt` — do
+not exist in the read API. `activeChanges` is filtered to `state = planned`
+server side, a started-and-not-completed work step has no representation there
+at all, and a removed component is precisely the one the response no longer
+contains (ADR 0010). They are folded from the SSE stream into a client-side
+ledger, and a stream opened without a cursor starts at the **live tail**
+(ADR 0006). They therefore describe *what this tab watched happen* and start
+empty after a reload.
+
+Two consequences shape the test:
+
+**The cockpit is opened before the first reported event.** A stream for a
+project that does not exist yet is answered `404`, after which the client backs
+off exponentially — it would then race the run and pass or fail by timing. The
+suite instead opens the project with a bootstrap run of its own, waits for the
+connection badge to read `live`, and only then starts the simulator. Nothing is
+observed by luck.
+
+**The observation is recorded inside the page.** Polling the DOM from the test
+process samples a moving target: a `planned` proposal becomes `recently_applied`
+a second later, an `active` work step completes, and a poll that happens to fire
+in between sees neither. `installLiveObserver` is injected with
+`addInitScript` and keeps the **maximum** every counter reached and every
+distinct overlay mark that was ever rendered, driven by a `MutationObserver`
+plus a 50 ms backstop — well below the 150 ms transitions the overlays use, so
+nothing that was on screen can slip past unseen. The assertions then read a
+recording of the whole run instead of a snapshot of its end.
+
+The simulator runs at `--speed 1` for this, with its pauses intact. `--speed 0`
+would compress 62 events into a few hundred milliseconds and turn "observable"
+into "technically present in some frame".
+
+Two structural details are asserted rather than colours, because ADR 0010
+forbids colour from being the only channel: a *planned* removal carries
+`data-work-state="planned"` with the word `entfernen` and a dashed border, while
+an *applied* removal carries `data-work-state="removed"` with a dotted one. A
+test that compared hues would be proving the opposite of the requirement.
+
+### The reload is the anti-vacuum guard for the live checks
+
+Immediately after the live assertions, the suite reloads the same URL and
+asserts that `active`, `recently_applied` and `removed` are back to zero while
+`planned` — which the read API does serve — is not.
+
+That is the guard the live half needs. If the earlier assertions could have been
+satisfied by data the read API returns, they would still hold after the reload.
+They do not, so they can only have come from watching the stream. The reload
+test simultaneously documents the trade-off ADR 0010 made, which is why it is
+phrased as a property rather than as a known limitation.
+
+### The replay check is guarded, because it is trivially easy to fake
+
+Check 7 — force a disconnect, resume from the last project position, prove that
+every position arrives exactly once and in order — is the one assertion in this
+suite that passes for the wrong reason by default. The failure mode is concrete
+and was observed while writing this: subscribe to a project that has not been
+created yet, receive `404`, never receive a frame, cut at position `0`, and
+"gapless, ordered, no duplicates" is then trivially true of the empty sequence.
+Green, and nothing was tested.
+
+Four guards make that impossible, and none of them is optional:
+
+1. **Both connections answered HTTP 200.** A `404` or a `400` on either half
+   fails immediately instead of producing an empty recording.
+2. **Both carried real traffic.** The first connection must have delivered at
+   least the eight frames it waited for, the second at least one.
+3. **The cut lies strictly inside the sequence:** `0 < cut < endPosition`, with
+   `endPosition` taken from the simulator's own `--json` summary — the position
+   the *server* assigned — rather than from whatever the stream happened to
+   deliver.
+4. **The union is the complete run.** Not "no duplicates among what arrived",
+   but: the two connections together are exactly `1 … endPosition`, each
+   position once, ascending within each half, and the seam is exactly `cut` and
+   `cut + 1`.
+
+The cut is made while the simulator is still sending, so the resumed connection
+has to do both halves of the handover ADR 0006 describes — replay the log, then
+continue live — and a further assertion confirms that events were still being
+appended after the cut.
+
+The cursor is read **after** the abort completed, never before. A frame arriving
+between reading the cursor and closing the socket would otherwise be counted as
+received *and* requested again, which would look like a duplicate the server
+never produced. That is a defect of the test, not of the system, and the
+ordering is what prevents it.
+
+`EventSource` cannot do any of this: it reconnects on its own schedule and does
+not report what it received before it dropped. The probe therefore owns the
+socket and parses the frames itself, which also lets it assert that the SSE
+`id:` and the `position` inside the payload agree on both halves.
+
+### Determinism is a property of the design, not of a retry count
+
+`retries: 0`. A gate that goes green on the second attempt reports "flaky" as
+"passed".
+
+Nothing in the suite sleeps for a fixed duration as a synchronisation device.
+Waiting is done with Playwright expectations, `expect.poll`, or a poll on a
+value the system itself published — the simulator's `--json` summary, a
+`data-*` attribute, the connection badge. The simulator is seeded, so the same
+events, the same positions and the same read models come out of every run
+(ADR 0007), which is what lets the assertions name exact numbers: 17 components,
+11 relationships, three `orders.order.created` relationships, three files under
+one `changeId`.
+
+One worker, no parallelism, files numbered in the order they must run: the suite
+shares one event log, and the `full` scenario is sent exactly once because it
+expects an empty project.
+
+### Port and Compose project name are configurable, with defaults that work
+
+`FRONTEND_HTTP_PORT` defaults to **8100** rather than 8080, and the Compose
+project name defaults to `vai-e2e`. Both are environment variables.
+
+8080–8083 are commonly taken by other local work, and a release gate that fails
+because of a foreign port collision teaches developers to ignore it. The own
+Compose project name matters more than the port: without it, `down -v` would
+destroy the containers, network and volume of a development stack started from
+the same `docker-compose.yml`. CI sets `FRONTEND_HTTP_PORT=8080` because its
+runner is empty, which also keeps the 8080 path exercised.
+
+### Where the suite reports what it found rather than asserting around it
+
+Two observations from writing the checks are recorded here because they change
+what a reader should expect the test to prove:
+
+**No folded relationship bundle exists in the representative model.** ADR 0008
+bundles parallel relationships by *ordered node pair*. The three
+`orders.order.created` relationships of the `full` scenario connect three
+different pairs — `orders → topic`, `topic → inventory`, `topic → notifications`
+— so each is already its own edge, and there is no collapsed bundle to click
+open. The acceptance property behind the bundling rule is nevertheless asserted
+directly and from both ends: the read API must return all eleven relationships
+separately (the server never aggregates topics, ADR 0005), and the canvas must
+expose each of them with its own label carrying its own `channel`, with the
+number of folded bundles asserted to be zero at the `full` detail level. If a
+future model does contain parallel relationships on one pair, that assertion
+turns into a failure and the unfold path gets tested rather than silently
+skipped.
+
+**A task-list checkbox is rendered in feedback.** `remark-gfm` turns `- [x]`
+into an `<input type="checkbox">`, which the sanitiser keeps but forces to
+`disabled` (ADR 0012). The "no active element" check is therefore defined as
+*nothing focusable, nothing that executes or loads, no inline handler* — a
+disabled checkbox is none of the three — rather than as "no `<input>` tag". The
+distinction is asserted the way a user would experience it.
+
+## Consequences
+
+- The gate needs Docker, roughly two minutes of build on a cold cache and about
+  a minute and a half of run time. It is not a pre-commit check; the fast suites
+  (`backend go test`, `frontend npm test`, `api npm test`, `simulator npm test`)
+  keep that job and run as separate CI jobs.
+- The suite writes into the same project the simulator's `full` scenario uses,
+  and it opens one extra bootstrap run there. Anyone reading the acceptance
+  database will see two runs in `visualise-ai`, of which one is empty. That is
+  deliberate and it doubles as the historical run check 6 switches to.
+- The assertions name exact counts. A change to the simulator's model — one more
+  component, one more relationship — fails the acceptance run. That is the
+  intended coupling: the representative sequence and the acceptance criteria are
+  one artefact, and `frontend/src/test/runFixtures.ts` already mirrors the same
+  data for the unit tests (ADR 0011).
+- `E2E_SKIP_COMPOSE=1` and `E2E_KEEP_STACK=1` exist for debugging a failure. They
+  are never set in CI, and skipping the reset fails safe: the simulator asserts
+  `201 created`, so a non-empty database aborts the run loudly.
+- The suite is the only consumer of the simulator's `--json` output. Changing
+  the shape of that summary breaks the release gate, which is the correct
+  coupling for a machine-readable interface that exists for exactly this.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -254,9 +254,11 @@ npm test
 
 Ein Fehlschlag blockiert die v0-Freigabe. Aufbau, Voraussetzungen und
 Konfiguration des Tests stehen in [`e2e/README.md`](../e2e/README.md); dieser
-Abschnitt beschreibt bewusst nur den Aufruf. Das Verzeichnis `e2e/` wird mit
-Issue #14 geliefert; bis dessen Pull Request gemergt ist, zeigt der Link ins
-Leere.
+Abschnitt beschreibt bewusst nur den Aufruf.
+
+Der Test bringt seinen eigenen Stack hoch und wieder herunter — unter dem
+Compose-Projektnamen `vai-e2e` und auf Port `8100`, damit er einen laufenden
+Entwicklungs-Stack auf `8080` weder benutzt noch beim Aufräumen löscht.
 
 ## Fehlersuche
 

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,115 @@
+# End-to-End-Abnahme
+
+Der verpflichtende Abnahmetest des v0-Epics (#14). Er startet das echte
+Compose-System aus einer leeren PostgreSQL-Datenbank, fährt den vollständigen
+v0-Nutzerpfad in **Chromium bei 1920 × 1080** ausschließlich über Nginx ab und
+räumt danach wieder auf.
+
+**Ein Fehlschlag blockiert die v0-Freigabe.**
+
+Warum der Test so gebaut ist — nur ein Browser, gegen das echte System statt
+gegen Mocks, Live-Zustände live beobachtet, Vakuum-Guards im Replay-Test —
+steht in
+[`docs/decisions/0013-mandatory-end-to-end-acceptance.md`](../docs/decisions/0013-mandatory-end-to-end-acceptance.md).
+
+## Ausführen
+
+Aus einem leeren Checkout, mit laufendem Docker:
+
+```bash
+cd e2e
+npm install
+npx playwright install chromium
+npm test
+```
+
+Mehr braucht es nicht. Der Test erledigt selbst:
+
+1. `docker compose -p vai-e2e down -v` — Start aus leerer Datenbank,
+2. `docker compose -p vai-e2e up --build -d`,
+3. Warten auf `/readyz` **über Nginx**,
+4. die Abnahme,
+5. `docker compose -p vai-e2e down -v`.
+
+Fehlen die Abhängigkeiten des Simulators, installiert der Test sie vorher
+(`npm ci` in `simulator/`) — ohne den Simulator gibt es keine Sequenz, die
+abgenommen werden könnte.
+
+Der HTML-Report liegt danach in `playwright-report/`:
+
+```bash
+npm run report
+```
+
+## Konfiguration
+
+| Variable | Default | Bedeutung |
+| --- | --- | --- |
+| `FRONTEND_HTTP_PORT` | `8100` | Host-Port des Nginx-Frontends |
+| `E2E_COMPOSE_PROJECT` | `vai-e2e` | Compose-Projektname des Abnahme-Stacks |
+| `E2E_BASE_URL` | `http://localhost:<port>` | Einstiegspunkt, falls nicht localhost |
+| `E2E_SKIP_COMPOSE` | aus | Nutzt einen bereits laufenden Stack |
+| `E2E_KEEP_STACK` | aus | Lässt den Stack nach dem Lauf stehen |
+
+Der Default-Port ist bewusst **8100** und nicht 8080: 8080–8083 sind auf
+Entwicklungsrechnern häufig belegt, und ein Freigabe-Gate, das an einer fremden
+Portbelegung scheitert, wird ignoriert. CI setzt `FRONTEND_HTTP_PORT=8080` und
+hält damit auch den dokumentierten Standardport unter Test.
+
+Der eigene Compose-Projektname ist wichtiger als der Port: ohne ihn würde
+`down -v` Container, Netzwerk und Volume eines aus derselben
+`docker-compose.yml` gestarteten Entwicklungs-Stacks löschen.
+
+`E2E_SKIP_COMPOSE` und `E2E_KEEP_STACK` sind reine Debug-Hilfen. Sie werden in
+CI nie gesetzt und scheitern sicher: die Simulator-Szenarien erwarten `201
+created`, gegen eine gefüllte Datenbank bricht der Lauf also laut ab.
+
+## Aufbau
+
+| Pfad | Inhalt |
+| --- | --- |
+| `playwright.config.ts` | Ein Projekt: Chromium, 1920 × 1080, ein Worker, `retries: 0` |
+| `src/config.ts` | Ports, Compose-Projektname, Projekt- und Run-Ids |
+| `src/compose.ts` | Lebenszyklus des Systems unter Test |
+| `src/globalSetup.ts` / `src/globalTeardown.ts` | `down -v` → `up --build` → `/readyz`, und zurück |
+| `src/simulator.ts` | Startet den Simulator und liest dessen `--json`-Zusammenfassung |
+| `src/sse.ts` | Roher SSE-Leser — er besitzt den Socket, damit der Abbruch erzwungen werden kann |
+| `src/liveObserver.ts` | Wird vor dem App-Start injiziert und zeichnet die Live-Zustände auf |
+| `src/controls.ts` | Sichtbarkeit und Überdeckung über `elementFromPoint` |
+| `tests/` | Die acht verbindlichen Prüfungen, in Ausführungsreihenfolge nummeriert |
+
+## Die acht verbindlichen Prüfungen
+
+| Datei | Prüfung |
+| --- | --- |
+| `01-ingestion.spec.ts` | Eventvalidierung, Idempotenz und beobachtbare Projektionen |
+| `02-live-updates.spec.ts` | Live-SSE-Aktualisierungen für geplant, aktiv, angewandt und entfernt |
+| `03-architecture.spec.ts` | Vollständiger Architekturcanvas mit Hierarchie und typisierten Beziehungen |
+| `04-run-agents.spec.ts` | Run-/Agentbaum mit parallelen Subagents und getrennten Fortschrittsformen |
+| `05-inspector.spec.ts` | Komponentenklick: Agent, Aufgabe, Markdown-Feedback, gruppierte Diffs |
+| `06-run-history-focus.spec.ts` | Trennung von aktuellem Run und Historie, Deep-Focus-Grundverhalten |
+| `07-sse-replay.spec.ts` | Erzwungener SSE-Abbruch und lückenloser, geordneter Replay |
+| `08-viewport.spec.ts` | Keine horizontale Seitenscrollbar, keine verdeckte Primärsteuerung |
+
+`02-live-updates.spec.ts` sendet die repräsentative Sequenz und ist die einzige
+Datei, die das darf: das Szenario `full` erwartet ein leeres Projekt. Die
+Dateien danach lesen den Zustand, den es hinterlassen hat — deshalb ein Worker,
+keine Parallelität und nummerierte Dateinamen.
+
+## Determinismus
+
+`retries: 0`. Ein Gate, das im zweiten Anlauf grün wird, meldet „flaky" als
+„bestanden".
+
+Es gibt keine festen Wartezeiten als Synchronisationsmittel. Gewartet wird mit
+Playwright-Erwartungen, `expect.poll` oder auf einen Wert, den das System selbst
+veröffentlicht: die `--json`-Zusammenfassung des Simulators, ein
+`data-*`-Attribut, das Verbindungs-Badge. Der Simulator ist geseedet, deshalb
+nennen die Assertions exakte Zahlen — 17 Komponenten, 11 Beziehungen, drei
+Beziehungen auf `orders.order.created`, drei Dateien unter einer `changeId`.
+
+## CI
+
+`.github/workflows/e2e.yml` fährt denselben Lauf auf einem Ubuntu-Runner mit
+`FRONTEND_HTTP_PORT=8080` und lädt den Playwright-Report als Artefakt hoch. Die
+schnellen Suiten laufen getrennt in `.github/workflows/ci.yml`.

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "visualise-ai-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "visualise-ai-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.62.1",
+        "@types/node": "^24.10.0",
+        "typescript": "~5.9.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "visualise-ai-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Mandatory Playwright end-to-end acceptance test for the v0 cockpit",
+  "scripts": {
+    "test": "playwright test",
+    "report": "playwright show-report",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.1",
+    "@types/node": "^24.10.0",
+    "typescript": "~5.9.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig } from '@playwright/test'
+
+import { ACCEPTANCE_VIEWPORT, BASE_URL } from './src/config.js'
+
+/**
+ * The mandatory v0 acceptance run (issue #14).
+ *
+ * Three settings are requirements rather than preferences:
+ *
+ * * **Chromium only, at exactly 1920 × 1080.** The epic fixes desktop Chromium
+ *   at that resolution as the acceptance surface; Firefox, WebKit, mobile and
+ *   tablet are explicitly not mandatory and are therefore not configured. A
+ *   browser matrix nobody committed to would turn a release gate into noise.
+ * * **One worker, no parallelism.** The suite shares one Compose deployment and
+ *   one event log, and the simulator's scenarios expect an empty database. The
+ *   files are numbered in the order they must run.
+ * * **No retries.** A release gate that passes on the second attempt is a gate
+ *   that reports "flaky" as "green". Every wait in this suite is a Playwright
+ *   expectation or a poll on observable state, never a fixed sleep.
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  forbidOnly: Boolean(process.env.CI),
+  /** Compose build and the ~30 s representative run happen inside the suite. */
+  timeout: 6 * 60_000,
+  expect: { timeout: 30_000 },
+  globalSetup: './src/globalSetup.ts',
+  globalTeardown: './src/globalTeardown.ts',
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report' }],
+  ],
+  use: {
+    baseURL: BASE_URL,
+    viewport: { ...ACCEPTANCE_VIEWPORT },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 30_000,
+    navigationTimeout: 60_000,
+  },
+  projects: [
+    {
+      name: 'chromium-1920x1080',
+      use: {
+        browserName: 'chromium',
+        viewport: { ...ACCEPTANCE_VIEWPORT },
+        deviceScaleFactor: 1,
+        isMobile: false,
+        hasTouch: false,
+      },
+    },
+  ],
+})

--- a/e2e/src/api.ts
+++ b/e2e/src/api.ts
@@ -1,0 +1,154 @@
+import { BASE_URL } from './config.js'
+
+/**
+ * The HTTP surface of the system under test, as the acceptance suite uses it.
+ *
+ * Every call goes through {@link BASE_URL} — the published Nginx port — because
+ * that is the deployment's only external entry point (ADR 0001). Neither the
+ * backend nor PostgreSQL publishes a port, and nothing here knows an internal
+ * hostname.
+ */
+
+export interface EventEnvelope {
+  schemaVersion: string
+  clientEventId: string
+  projectId: string
+  runId: string
+  agentId: string
+  parentAgentId?: string | null
+  occurredAt: string
+  type: string
+  payload: Record<string, unknown>
+}
+
+export interface IngestAnswer {
+  status: number
+  body: unknown
+}
+
+export interface EventAccepted {
+  clientEventId: string
+  serverEventId: string
+  position: number
+  duplicate: boolean
+  receivedAt: string
+}
+
+export interface ProblemDocument {
+  type?: string
+  title?: string
+  status?: number
+  detail?: string
+  code?: string
+  errors?: { field?: string; code?: string; message?: string }[]
+}
+
+export const EVENTS_URL = `${BASE_URL}/api/v1/events`
+
+/** POSTs one event envelope and returns status and parsed body, never throws. */
+export async function postEvent(event: unknown): Promise<IngestAnswer> {
+  const response = await fetch(EVENTS_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(event),
+  })
+  const text = await response.text()
+  let body: unknown = text
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      // Leave the raw text; the assertion message prints it verbatim.
+    }
+  }
+  return { status: response.status, body }
+}
+
+/** `GET <base><path>`, returning status and parsed JSON body. */
+export async function getJson(path: string): Promise<{ status: number; body: unknown }> {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    headers: { accept: 'application/json' },
+  })
+  const text = await response.text()
+  let body: unknown = text
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      /* keep the raw text */
+    }
+  }
+  return { status: response.status, body }
+}
+
+/** `true` once the project row exists, i.e. at least one event was committed. */
+export async function projectExists(projectId: string): Promise<boolean> {
+  const { status } = await getJson(`/api/v1/projects/${encodeURIComponent(projectId)}`)
+  return status === 200
+}
+
+export function streamUrl(projectId: string, lastEventPosition: number | null): string {
+  const base = `${BASE_URL}/api/v1/projects/${encodeURIComponent(projectId)}/stream`
+  return lastEventPosition === null ? base : `${base}?lastEventPosition=${lastEventPosition}`
+}
+
+/**
+ * Opens a run with a root orchestrator's `agent.started`.
+ *
+ * The lifecycle rules make this the only event that can create a project and a
+ * run (`backend/internal/ingest/lifecycle.go`), which is exactly why the suite
+ * uses it to bootstrap a project before subscribing to its stream.
+ */
+export function bootstrapEvent(options: {
+  clientEventId: string
+  projectId: string
+  runId: string
+  agentId: string
+  occurredAt?: string
+  displayName?: string
+  assignedTask?: string
+}): EventEnvelope {
+  return {
+    schemaVersion: '1.0',
+    clientEventId: options.clientEventId,
+    projectId: options.projectId,
+    runId: options.runId,
+    agentId: options.agentId,
+    parentAgentId: null,
+    occurredAt: options.occurredAt ?? '2026-08-04T08:00:00Z',
+    type: 'agent.started',
+    payload: {
+      role: 'orchestrator',
+      displayName: options.displayName ?? 'End-to-end acceptance bootstrap',
+      assignedTask:
+        options.assignedTask ??
+        'Open the project so the acceptance test can subscribe before the first reported event.',
+    },
+  }
+}
+
+/** Narrows an ingest answer to `EventAccepted`, or throws with the raw body. */
+export function asAccepted(answer: IngestAnswer): EventAccepted {
+  const body = answer.body as Partial<EventAccepted> | undefined
+  if (
+    !body ||
+    typeof body.position !== 'number' ||
+    typeof body.clientEventId !== 'string' ||
+    typeof body.duplicate !== 'boolean'
+  ) {
+    throw new Error(
+      `expected an EventAccepted body, got status ${answer.status} and ${JSON.stringify(answer.body)}`,
+    )
+  }
+  return body as EventAccepted
+}
+
+/** Narrows an ingest answer to an RFC 9457 problem document. */
+export function asProblem(answer: IngestAnswer): ProblemDocument {
+  if (!answer.body || typeof answer.body !== 'object') {
+    throw new Error(
+      `expected an RFC 9457 problem document, got status ${answer.status} and ${JSON.stringify(answer.body)}`,
+    )
+  }
+  return answer.body as ProblemDocument
+}

--- a/e2e/src/compose.ts
+++ b/e2e/src/compose.ts
@@ -1,0 +1,122 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import {
+  BASE_URL,
+  COMPOSE_PROJECT,
+  FRONTEND_HTTP_PORT,
+  REPO_ROOT,
+  SIMULATOR_DIR,
+} from './config.js'
+import { runCommand, runCommandOrThrow } from './process.js'
+
+/**
+ * Lifecycle of the system under test.
+ *
+ * The acceptance test runs against the real Compose deployment — the Nginx
+ * frontend, the Go backend and PostgreSQL, built from this checkout — and never
+ * against a mock or a dev server. A mocked backend would assert that the tests
+ * agree with the tests; only the built stack can show that the contract, the
+ * projections, the stream and the bundle actually fit together.
+ *
+ * The stack always starts from an **empty database** (`down -v` before `up`),
+ * because the simulator's scenarios are written for one: they assert
+ * `201 created`, and against a populated database the first delivery would
+ * legitimately be a duplicate.
+ */
+
+function composeArgs(...args: string[]): string[] {
+  return ['compose', '-p', COMPOSE_PROJECT, ...args]
+}
+
+const composeEnv = {
+  ...process.env,
+  FRONTEND_HTTP_PORT,
+  // Keep Compose from picking up a stray COMPOSE_PROJECT_NAME of the shell.
+  COMPOSE_PROJECT_NAME: COMPOSE_PROJECT,
+}
+
+/** `docker compose down -v` — removes containers, network and the pgdata volume. */
+export async function composeDown(): Promise<void> {
+  await runCommand('docker', composeArgs('down', '-v', '--remove-orphans'), {
+    cwd: REPO_ROOT,
+    env: composeEnv,
+    echo: true,
+    label: 'compose down',
+  })
+}
+
+/** `docker compose up --build -d`. */
+export async function composeUp(): Promise<void> {
+  await runCommandOrThrow(
+    'docker',
+    composeArgs('up', '--build', '-d', '--wait', '--wait-timeout', '300'),
+    {
+      cwd: REPO_ROOT,
+      env: composeEnv,
+      echo: true,
+      label: 'compose up',
+    },
+  )
+}
+
+/** Dumps the logs of every service. Used when startup fails. */
+export async function composeLogs(tail = '200'): Promise<string> {
+  const result = await runCommand('docker', composeArgs('logs', '--tail', tail), {
+    cwd: REPO_ROOT,
+    env: composeEnv,
+  })
+  return `${result.stdout}\n${result.stderr}`
+}
+
+/**
+ * Waits until the deployment answers as ready **through Nginx**.
+ *
+ * `/readyz` is the backend's own readiness probe (startup finished *and*
+ * PostgreSQL answers) and `/` is the served bundle, so both halves of the entry
+ * point are covered before a single test runs.
+ */
+export async function waitForReady(timeoutMs = 240_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let lastFailure = 'no attempt made'
+
+  for (;;) {
+    try {
+      const ready = await fetch(`${BASE_URL}/readyz`)
+      if (ready.status === 200) {
+        const index = await fetch(`${BASE_URL}/`)
+        if (index.status === 200) return
+        lastFailure = `GET / answered ${index.status}`
+      } else {
+        lastFailure = `GET /readyz answered ${ready.status}`
+      }
+    } catch (cause) {
+      lastFailure = cause instanceof Error ? cause.message : String(cause)
+    }
+
+    if (Date.now() > deadline) {
+      throw new Error(
+        `the deployment did not become ready on ${BASE_URL} within ${timeoutMs} ms ` +
+          `(last: ${lastFailure})\n\n${await composeLogs()}`,
+      )
+    }
+    await new Promise((wake) => setTimeout(wake, 1000))
+  }
+}
+
+/**
+ * Installs the simulator's dependencies when they are missing.
+ *
+ * Keeps the documented one-command start honest: `cd e2e && npm install &&
+ * npx playwright install chromium && npm test` must work in a fresh checkout,
+ * and the suite cannot report a run without the simulator that produces it.
+ */
+export async function ensureSimulatorDependencies(): Promise<void> {
+  if (existsSync(resolve(SIMULATOR_DIR, 'node_modules', 'tsx'))) return
+  await runCommandOrThrow('npm', ['ci'], {
+    cwd: SIMULATOR_DIR,
+    echo: true,
+    label: 'simulator npm ci',
+    shell: process.platform === 'win32',
+  })
+}

--- a/e2e/src/config.ts
+++ b/e2e/src/config.ts
@@ -1,0 +1,100 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Everything the acceptance test needs to know about *where* the system under
+ * test runs. Nothing here describes what is asserted — that lives in `tests/`.
+ *
+ * Port and Compose project name are environment variables with defaults, so the
+ * same test runs unchanged on a developer machine whose 8080 is taken and on a
+ * CI runner where it is free.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+/** Repository root — the directory that holds `docker-compose.yml`. */
+export const REPO_ROOT = resolve(here, '..', '..')
+export const SIMULATOR_DIR = resolve(REPO_ROOT, 'simulator')
+
+/**
+ * Host port the Nginx frontend is published on.
+ *
+ * The default is **8100**, not 8080: 8080–8083 are frequently occupied by other
+ * local projects, and a mandatory acceptance test that fails because of a
+ * foreign port collision proves nothing. CI (and any machine with a free 8080)
+ * sets `FRONTEND_HTTP_PORT=8080`.
+ */
+export const FRONTEND_HTTP_PORT = process.env.FRONTEND_HTTP_PORT ?? '8100'
+
+/**
+ * Compose project name. Own namespace by default, so the acceptance stack can
+ * never reuse, restart or `down -v` the containers, network or volume of a
+ * development stack started from the same `docker-compose.yml`.
+ */
+export const COMPOSE_PROJECT = process.env.E2E_COMPOSE_PROJECT ?? 'vai-e2e'
+
+/** The single external entry point. Every request of this suite goes here. */
+export const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${FRONTEND_HTTP_PORT}`
+
+/**
+ * Skips `docker compose down -v` / `up --build` and runs against a stack that is
+ * already up. A debugging convenience only — it is never set in CI, and it
+ * fails safe: the simulator scenarios assert `201 created`, so a non-empty
+ * database aborts the run loudly instead of passing vacuously.
+ */
+export const SKIP_COMPOSE = process.env.E2E_SKIP_COMPOSE === '1'
+
+/** Leaves the stack running after the suite, for post-mortem inspection. */
+export const KEEP_STACK = process.env.E2E_KEEP_STACK === '1'
+
+/** Mandatory acceptance resolution (epic #1, issue #14). */
+export const ACCEPTANCE_VIEWPORT = { width: 1920, height: 1080 } as const
+
+// ---------------------------------------------------------------------------
+// Projects the suite reports under
+// ---------------------------------------------------------------------------
+
+/**
+ * The representative run. This is the simulator's own default project, so what
+ * the acceptance test looks at is exactly what `npm run simulate` produces.
+ */
+export const MAIN_PROJECT = 'visualise-ai'
+export const MAIN_RUN = 'run-2026-08-04-0001'
+
+/**
+ * A second, empty run opened in the same project *before* the representative
+ * one.
+ *
+ * It exists for two reasons, both of them about determinism:
+ *
+ * 1. A stream opened for a project that does not exist yet is answered `404`
+ *    (the project row is created by the first event). Opening the workspace
+ *    before the simulator starts would therefore leave the cockpit reconnecting
+ *    with exponential backoff and racing the first events. With this run the
+ *    project exists, the SSE connection is `live` before event one, and every
+ *    live state of check 3 is observed rather than hoped for.
+ * 2. It gives the run/history separation of check 6 a genuine historical run to
+ *    switch to. The representative run opens afterwards and becomes the
+ *    project's current run (`projects.current_run_id` follows the last root
+ *    orchestrator), so the historical banner is real state, not a fixture.
+ */
+export const MAIN_BOOTSTRAP_RUN = 'run-e2e-bootstrap'
+export const MAIN_BOOTSTRAP_AGENT = 'e2e-bootstrap-orchestrator'
+
+/** Ingestion validation and idempotency probe — its own project. */
+export const VALIDATION_PROJECT = 'visualise-ai-validation'
+export const VALIDATION_RUN = 'run-e2e-validation'
+export const VALIDATION_AGENT = 'e2e-validation-orchestrator'
+
+/** The simulator's own idempotency and conflict projects. */
+export const RETRY_PROJECT = 'visualise-ai-retry'
+export const CONFLICT_PROJECT = 'visualise-ai-conflict'
+
+/**
+ * Forced-disconnect replay probe. A project of its own so the cut, the reconnect
+ * and the position arithmetic cannot be disturbed by, or disturb, the browser
+ * stream of the representative project.
+ */
+export const REPLAY_PROJECT = 'visualise-ai-replay'
+export const REPLAY_BOOTSTRAP_RUN = 'run-e2e-replay-bootstrap'
+export const REPLAY_BOOTSTRAP_AGENT = 'e2e-replay-bootstrap-orchestrator'

--- a/e2e/src/controls.ts
+++ b/e2e/src/controls.ts
@@ -1,0 +1,116 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Whether a primary control is actually operable, not merely present.
+ *
+ * "Not covered" is asked of the browser rather than of the DOM tree:
+ * `elementFromPoint` at the control's own centre must land on the control or on
+ * something inside it. A pane that overlaps it, a banner that grew over it or a
+ * z-index accident therefore fails the check, which asserting `toBeVisible()`
+ * alone would not.
+ */
+
+export interface ControlProbe {
+  /** Human-readable name, used in the failure message. */
+  name: string
+  selector: string
+}
+
+export interface ControlReport {
+  name: string
+  selector: string
+  found: boolean
+  /** Rendered with a non-zero box and no `visibility`/`display` suppression. */
+  rendered: boolean
+  /** The whole box lies inside the 1920 × 1080 viewport. */
+  insideViewport: boolean
+  /** `elementFromPoint` at the centre resolves to the control itself. */
+  unobstructed: boolean
+  box: { x: number; y: number; width: number; height: number } | null
+  /** What actually sits at the centre point, when something else does. */
+  obstructedBy: string | null
+}
+
+export async function probeControls(
+  page: Page,
+  probes: readonly ControlProbe[],
+): Promise<ControlReport[]> {
+  return page.evaluate((list) => {
+    const describe = (element: Element): string => {
+      const testId = element.getAttribute('data-testid')
+      const label = element.getAttribute('aria-label')
+      return [
+        element.tagName.toLowerCase(),
+        testId === null ? '' : `[data-testid="${testId}"]`,
+        label === null ? '' : `[aria-label="${label}"]`,
+        element.className && typeof element.className === 'string'
+          ? `.${element.className.split(/\s+/).filter(Boolean).slice(0, 3).join('.')}`
+          : '',
+      ].join('')
+    }
+
+    return list.map((probe) => {
+      const element = document.querySelector(probe.selector)
+      if (element === null) {
+        return {
+          name: probe.name,
+          selector: probe.selector,
+          found: false,
+          rendered: false,
+          insideViewport: false,
+          unobstructed: false,
+          box: null,
+          obstructedBy: null,
+        }
+      }
+
+      const rect = element.getBoundingClientRect()
+      const style = window.getComputedStyle(element)
+      const rendered =
+        rect.width > 0 &&
+        rect.height > 0 &&
+        style.visibility !== 'hidden' &&
+        style.display !== 'none' &&
+        Number(style.opacity) > 0
+
+      const insideViewport =
+        rect.left >= 0 &&
+        rect.top >= 0 &&
+        rect.right <= window.innerWidth &&
+        rect.bottom <= window.innerHeight
+
+      const centreX = rect.left + rect.width / 2
+      const centreY = rect.top + rect.height / 2
+      const top = document.elementFromPoint(centreX, centreY)
+      const unobstructed =
+        top !== null && (top === element || element.contains(top) || top.contains(element))
+
+      return {
+        name: probe.name,
+        selector: probe.selector,
+        found: true,
+        rendered,
+        insideViewport,
+        unobstructed,
+        box: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
+        obstructedBy: unobstructed || top === null ? null : describe(top),
+      }
+    })
+  }, [...probes])
+}
+
+/** Renders a report list for an assertion message. */
+export function formatControlReports(reports: readonly ControlReport[]): string {
+  return reports
+    .map(
+      (report) =>
+        `  ${report.name} (${report.selector}): found=${report.found} rendered=${report.rendered} ` +
+        `insideViewport=${report.insideViewport} unobstructed=${report.unobstructed}` +
+        (report.obstructedBy === null ? '' : ` coveredBy=${report.obstructedBy}`) +
+        (report.box === null
+          ? ''
+          : ` box=${Math.round(report.box.x)},${Math.round(report.box.y)} ` +
+            `${Math.round(report.box.width)}×${Math.round(report.box.height)}`),
+    )
+    .join('\n')
+}

--- a/e2e/src/globalSetup.ts
+++ b/e2e/src/globalSetup.ts
@@ -1,0 +1,38 @@
+import {
+  composeDown,
+  composeUp,
+  ensureSimulatorDependencies,
+  waitForReady,
+} from './compose.js'
+import { BASE_URL, COMPOSE_PROJECT, FRONTEND_HTTP_PORT, SKIP_COMPOSE } from './config.js'
+
+/**
+ * Brings the system under test up before the first test.
+ *
+ * `down -v` → `up --build -d` → wait for `/readyz` through Nginx. The volume is
+ * removed first on purpose: issue #14 requires the acceptance run to start from
+ * an **empty PostgreSQL database**, and the simulator's scenarios only prove
+ * what they claim against one.
+ */
+export default async function globalSetup(): Promise<void> {
+  const started = Date.now()
+  process.stdout.write(
+    `\n[e2e] compose project ${COMPOSE_PROJECT}, frontend on port ${FRONTEND_HTTP_PORT}, base ${BASE_URL}\n`,
+  )
+
+  await ensureSimulatorDependencies()
+
+  if (SKIP_COMPOSE) {
+    process.stdout.write('[e2e] E2E_SKIP_COMPOSE=1 — reusing the running stack\n')
+  } else {
+    process.stdout.write('[e2e] docker compose down -v (start from an empty database)\n')
+    await composeDown()
+    process.stdout.write('[e2e] docker compose up --build -d\n')
+    await composeUp()
+  }
+
+  await waitForReady()
+  process.stdout.write(
+    `[e2e] deployment ready after ${((Date.now() - started) / 1000).toFixed(1)} s\n\n`,
+  )
+}

--- a/e2e/src/globalTeardown.ts
+++ b/e2e/src/globalTeardown.ts
@@ -1,0 +1,18 @@
+import { composeDown } from './compose.js'
+import { KEEP_STACK, SKIP_COMPOSE } from './config.js'
+
+/**
+ * Takes the stack down again, volume included.
+ *
+ * Leaving `pgdata` behind would make the next acceptance run start from a
+ * populated database, and a populated database silently changes what the
+ * simulator's scenarios prove.
+ */
+export default async function globalTeardown(): Promise<void> {
+  if (KEEP_STACK || SKIP_COMPOSE) {
+    process.stdout.write('\n[e2e] leaving the stack up (E2E_KEEP_STACK / E2E_SKIP_COMPOSE)\n')
+    return
+  }
+  process.stdout.write('\n[e2e] docker compose down -v\n')
+  await composeDown()
+}

--- a/e2e/src/globals.d.ts
+++ b/e2e/src/globals.d.ts
@@ -1,0 +1,10 @@
+import type { LiveObserverState } from './liveObserver.js'
+
+declare global {
+  interface Window {
+    /** Installed by `installLiveObserver` before the application boots. */
+    __e2eLive: LiveObserverState
+  }
+}
+
+export {}

--- a/e2e/src/liveObserver.ts
+++ b/e2e/src/liveObserver.ts
@@ -1,0 +1,139 @@
+/**
+ * The live observer that runs *inside* the page.
+ *
+ * ADR 0006 and ADR 0010 make three of the four work states — `aktiv`,
+ * `kürzlich angewandt` and `entfernt` — statements about **what this tab
+ * watched happen**: a stream opened without a cursor starts at the live tail, so
+ * after a reload the change ledger legitimately starts empty. Polling the DOM
+ * from the test process would therefore sample a moving target and could miss a
+ * state that was on screen for half a second.
+ *
+ * This module is installed with `page.addInitScript` before the application
+ * boots and records the **maximum** each counter ever reached plus every
+ * distinct overlay mark it ever saw. The assertions then read a recording of the
+ * whole run instead of a snapshot of its end.
+ *
+ * Everything below runs in the browser and must stay self-contained: no imports,
+ * no references to the test process.
+ */
+
+export interface LiveObserverMark {
+  state: string
+  operation: string
+  label: string
+  borderStyle: string
+  presence: string
+  text: string
+  testId: string
+}
+
+export interface LiveObserverState {
+  samples: number
+  maxCounts: Record<string, number>
+  maxTotal: number
+  /** Every distinct `state|operation` combination the canvas ever rendered. */
+  marks: Record<string, LiveObserverMark>
+  maxOverlayNodeCount: number
+  maxOverlayEdgeCount: number
+  /** Every distinct value the live-connection badge went through, in order. */
+  connectionStates: string[]
+  /** Component ids that were ever drawn as a removed ghost. */
+  ghostComponentIds: string[]
+}
+
+export function installLiveObserver(): void {
+  const STATE_IDS = ['planned', 'active', 'recently_applied', 'removed']
+
+  const state: LiveObserverState = {
+    samples: 0,
+    maxCounts: { planned: 0, active: 0, recently_applied: 0, removed: 0 },
+    maxTotal: 0,
+    marks: {},
+    maxOverlayNodeCount: 0,
+    maxOverlayEdgeCount: 0,
+    connectionStates: [],
+    ghostComponentIds: [],
+  }
+  ;(window as unknown as { __e2eLive: LiveObserverState }).__e2eLive = state
+
+  const readNumber = (element: Element | null, attribute: string): number => {
+    const raw = element?.getAttribute(attribute)
+    const value = Number(raw)
+    return Number.isFinite(value) ? value : 0
+  }
+
+  const sample = (): void => {
+    state.samples += 1
+
+    for (const id of STATE_IDS) {
+      const counter = document.querySelector(`[data-testid="change-counter-${id}"]`)
+      if (counter === null) continue
+      const count = readNumber(counter, 'data-count')
+      const previous = state.maxCounts[id] ?? 0
+      if (count > previous) state.maxCounts[id] = count
+    }
+
+    const counter = document.querySelector('[data-testid="change-counter"]')
+    const total = readNumber(counter, 'data-total')
+    if (total > state.maxTotal) state.maxTotal = total
+
+    for (const mark of Array.from(document.querySelectorAll('[data-work-state-label]'))) {
+      const markState = mark.getAttribute('data-work-state') ?? ''
+      const operation = mark.getAttribute('data-operation') ?? 'none'
+      const key = `${markState}|${operation}`
+      if (state.marks[key] !== undefined) continue
+      state.marks[key] = {
+        state: markState,
+        operation,
+        label: mark.getAttribute('data-work-state-label') ?? '',
+        borderStyle: mark.getAttribute('data-border-style') ?? '',
+        presence: mark.getAttribute('data-presence') ?? '',
+        text: (mark.textContent ?? '').replace(/\s+/g, ' ').trim(),
+        testId: mark.getAttribute('data-testid') ?? '',
+      }
+    }
+
+    for (const node of Array.from(document.querySelectorAll('[data-presence="ghost"]'))) {
+      const componentId =
+        node.getAttribute('data-component-id') ??
+        node.closest('[data-component-id]')?.getAttribute('data-component-id') ??
+        ''
+      if (componentId !== '' && !state.ghostComponentIds.includes(componentId)) {
+        state.ghostComponentIds.push(componentId)
+      }
+    }
+
+    const canvas = document.querySelector('[data-testid="architecture-canvas"]')
+    if (canvas !== null) {
+      const overlayNodes = readNumber(canvas, 'data-overlay-node-count')
+      const overlayEdges = readNumber(canvas, 'data-overlay-edge-count')
+      if (overlayNodes > state.maxOverlayNodeCount) state.maxOverlayNodeCount = overlayNodes
+      if (overlayEdges > state.maxOverlayEdgeCount) state.maxOverlayEdgeCount = overlayEdges
+    }
+
+    const badge = document.querySelector('[data-testid="live-connection-state"]')
+    const connection = badge?.getAttribute('data-state')
+    if (
+      typeof connection === 'string' &&
+      state.connectionStates[state.connectionStates.length - 1] !== connection
+    ) {
+      state.connectionStates.push(connection)
+    }
+  }
+
+  const start = (): void => {
+    new MutationObserver(sample).observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+    })
+    // Backstop for a state that appears and disappears between two mutations of
+    // the observed subtree. 50 ms is far below the ~150 ms transition the
+    // overlays use, so nothing that was rendered can slip through unseen.
+    window.setInterval(sample, 50)
+    sample()
+  }
+
+  if (document.body !== null) start()
+  else document.addEventListener('DOMContentLoaded', start)
+}

--- a/e2e/src/process.ts
+++ b/e2e/src/process.ts
@@ -1,0 +1,78 @@
+import { spawn, type SpawnOptions } from 'node:child_process'
+
+/** Result of a finished child process. */
+export interface CommandResult {
+  code: number | null
+  stdout: string
+  stderr: string
+}
+
+export interface RunCommandOptions extends SpawnOptions {
+  /** Mirrors the child's output onto this process, prefixed. Default `false`. */
+  echo?: boolean
+  /** Prefix used when `echo` is on. */
+  label?: string
+}
+
+/**
+ * Runs a command to completion and captures its output.
+ *
+ * `shell` stays off everywhere in this suite: every argument is passed as an
+ * array element, so a project id or a URL can never be re-parsed by a shell.
+ */
+export function runCommand(
+  command: string,
+  args: readonly string[],
+  options: RunCommandOptions = {},
+): Promise<CommandResult> {
+  const { echo = false, label = command, ...spawnOptions } = options
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [...args], {
+      ...spawnOptions,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk
+      if (echo) process.stdout.write(prefix(label, chunk))
+    })
+    child.stderr?.on('data', (chunk: string) => {
+      stderr += chunk
+      if (echo) process.stdout.write(prefix(label, chunk))
+    })
+
+    child.on('error', reject)
+    child.on('close', (code) => resolve({ code, stdout, stderr }))
+  })
+}
+
+/** Runs a command and rejects unless it exited `0`. */
+export async function runCommandOrThrow(
+  command: string,
+  args: readonly string[],
+  options: RunCommandOptions = {},
+): Promise<CommandResult> {
+  const result = await runCommand(command, args, options)
+  if (result.code !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} exited with ${String(result.code)}\n` +
+        `--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+    )
+  }
+  return result
+}
+
+function prefix(label: string, chunk: string): string {
+  return chunk
+    .split('\n')
+    .map((line, index, lines) =>
+      index === lines.length - 1 && line === '' ? line : `[${label}] ${line}`,
+    )
+    .join('\n')
+}

--- a/e2e/src/simulator.ts
+++ b/e2e/src/simulator.ts
@@ -1,0 +1,137 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+
+import { BASE_URL, SIMULATOR_DIR } from './config.js'
+
+/**
+ * Driving the bundled event simulator.
+ *
+ * The simulator is the only thing in this suite that reports agent events for
+ * the representative sequence, and it talks to `<base>/api/v1/events` and to
+ * nothing else — the published Nginx route (ADR 0007). It is seeded and
+ * deterministic, and `--json` gives the suite the server-assigned positions of
+ * every accepted event, which is what makes the replay assertions arithmetic
+ * rather than guesswork.
+ */
+
+export interface SimulatorEvent {
+  position: number | null
+  type: string
+  agentId: string
+  status: number
+}
+
+export interface SimulatorSummary {
+  scenario: string
+  projectId: string
+  runId: string
+  baseUrl: string
+  eventsSent: number
+  created: number
+  duplicates: number
+  conflicts: number
+  /** Highest position the server assigned during this run. */
+  endPosition: number
+  events: SimulatorEvent[]
+  projectUrl: string
+}
+
+export interface SimulatorOptions {
+  scenario?: 'full' | 'retry' | 'conflict'
+  projectId?: string
+  runId?: string
+  /** Pause multiplier. `1` keeps the pauses the live checks need. */
+  speed?: number
+  seed?: number
+  finish?: boolean
+}
+
+export interface RunningSimulator {
+  /** Resolves with the parsed `--json` summary once the process exited `0`. */
+  done: Promise<SimulatorSummary>
+  /** The narrative the simulator wrote on stderr so far. */
+  narrative(): string
+  kill(): void
+}
+
+function argsFor(options: SimulatorOptions): string[] {
+  const args = ['--base', BASE_URL, '--json', '--speed', String(options.speed ?? 1)]
+  if (options.scenario) args.push('--scenario', options.scenario)
+  if (options.projectId) args.push('--project', options.projectId)
+  if (options.runId) args.push('--run', options.runId)
+  if (options.seed !== undefined) args.push('--seed', String(options.seed))
+  if (options.finish !== undefined) args.push('--finish', String(options.finish))
+  return args
+}
+
+/**
+ * Starts the simulator without waiting for it.
+ *
+ * `node --import tsx src/cli.ts` rather than `npm run simulate`: no shell, no
+ * npm banner on stdout, and the exact same entry point the documented command
+ * uses.
+ */
+export function startSimulator(options: SimulatorOptions = {}): RunningSimulator {
+  const args = argsFor(options)
+  const child: ChildProcess = spawn(
+    process.execPath,
+    ['--import', 'tsx', 'src/cli.ts', ...args],
+    { cwd: SIMULATOR_DIR, stdio: ['ignore', 'pipe', 'pipe'] },
+  )
+
+  let stdout = ''
+  let stderr = ''
+  child.stdout?.setEncoding('utf8')
+  child.stderr?.setEncoding('utf8')
+  child.stdout?.on('data', (chunk: string) => {
+    stdout += chunk
+  })
+  child.stderr?.on('data', (chunk: string) => {
+    stderr += chunk
+  })
+
+  const done = new Promise<SimulatorSummary>((resolve, reject) => {
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `simulator ${args.join(' ')} exited with ${String(code)}\n` +
+              `--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+          ),
+        )
+        return
+      }
+      try {
+        resolve(parseSummary(stdout))
+      } catch (cause) {
+        reject(
+          new Error(
+            `simulator ${args.join(' ')} produced no usable --json summary: ${
+              cause instanceof Error ? cause.message : String(cause)
+            }\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+          ),
+        )
+      }
+    })
+  })
+
+  return {
+    done,
+    narrative: () => stderr,
+    kill: () => {
+      child.kill()
+    },
+  }
+}
+
+/** Runs the simulator to completion and returns its machine-readable summary. */
+export function runSimulator(options: SimulatorOptions = {}): Promise<SimulatorSummary> {
+  return startSimulator(options).done
+}
+
+function parseSummary(stdout: string): SimulatorSummary {
+  const start = stdout.indexOf('{')
+  const end = stdout.lastIndexOf('}')
+  if (start === -1 || end <= start) throw new Error('no JSON object on stdout')
+  return JSON.parse(stdout.slice(start, end + 1)) as SimulatorSummary
+}

--- a/e2e/src/sse.ts
+++ b/e2e/src/sse.ts
@@ -1,0 +1,157 @@
+/**
+ * A raw Server-Sent Events reader.
+ *
+ * The browser's `EventSource` cannot be forced to drop a connection at a chosen
+ * moment and then be asked what exactly it received before and after — which is
+ * the whole point of check 7. This reader owns the socket, so the suite can cut
+ * it mid-run and compare the two halves position by position.
+ *
+ * It parses the frame the contract documents and the backend writes
+ * (`backend/internal/sse/connection.go`): `id:` is the project position,
+ * `event:` the catalogue type, `data:` one compact-JSON `StreamedEvent`.
+ * Keepalives are comment lines and carry no `id:`, so they can never be
+ * mistaken for an event.
+ */
+
+export interface SseFrame {
+  /** Project position, from the `id:` field. */
+  position: number
+  /** Event type, from the `event:` field. */
+  type: string
+  /** `position` as the JSON payload reports it — must equal `position`. */
+  payloadPosition: number
+  projectId: string
+}
+
+export class SseRecorder {
+  readonly frames: SseFrame[] = []
+  /** HTTP status of the response. `0` until {@link open} resolved. */
+  status = 0
+  /** Non-`null` when the read loop ended with something other than an abort. */
+  error: unknown = null
+  /** `true` once the server closed the stream by itself. */
+  streamEnded = false
+
+  private readonly controller = new AbortController()
+  private pumping: Promise<void> = Promise.resolve()
+  private aborted = false
+
+  constructor(readonly url: string) {}
+
+  /** Connects and starts reading. Resolves with the HTTP status. */
+  async open(): Promise<number> {
+    const response = await fetch(this.url, {
+      headers: { accept: 'text/event-stream', 'cache-control': 'no-cache' },
+      signal: this.controller.signal,
+    })
+    this.status = response.status
+
+    if (response.status !== 200 || response.body === null) {
+      // Drain so the socket is released; the body is a problem document.
+      await response.text().catch(() => undefined)
+      return this.status
+    }
+
+    this.pumping = this.pump(response.body)
+    return this.status
+  }
+
+  private async pump(body: ReadableStream<Uint8Array>): Promise<void> {
+    const decoder = new TextDecoder()
+    let buffer = ''
+    try {
+      // @ts-expect-error -- Node's ReadableStream is async-iterable at runtime.
+      for await (const chunk of body) {
+        buffer += decoder.decode(chunk as Uint8Array, { stream: true })
+        let separator = buffer.indexOf('\n\n')
+        while (separator !== -1) {
+          const block = buffer.slice(0, separator)
+          buffer = buffer.slice(separator + 2)
+          this.consumeBlock(block)
+          separator = buffer.indexOf('\n\n')
+        }
+      }
+      this.streamEnded = true
+    } catch (cause) {
+      if (!this.aborted) this.error = cause
+    }
+  }
+
+  private consumeBlock(block: string): void {
+    let id: string | null = null
+    let type: string | null = null
+    let data: string | null = null
+
+    for (const line of block.split('\n')) {
+      if (line.startsWith(':')) continue // comment / keepalive
+      if (line.startsWith('id:')) id = line.slice(3).trim()
+      else if (line.startsWith('event:')) type = line.slice(6).trim()
+      else if (line.startsWith('data:')) data = line.slice(5).trim()
+    }
+
+    if (id === null || data === null) return
+
+    let decoded: { position?: unknown; projectId?: unknown }
+    try {
+      decoded = JSON.parse(data) as { position?: unknown; projectId?: unknown }
+    } catch {
+      this.error = new Error(`SSE frame carried unparseable data: ${data.slice(0, 200)}`)
+      return
+    }
+
+    this.frames.push({
+      position: Number(id),
+      type: type ?? '',
+      payloadPosition: typeof decoded.position === 'number' ? decoded.position : Number.NaN,
+      projectId: typeof decoded.projectId === 'string' ? decoded.projectId : '',
+    })
+  }
+
+  get positions(): number[] {
+    return this.frames.map((frame) => frame.position)
+  }
+
+  get lastPosition(): number | null {
+    const last = this.frames.at(-1)
+    return last ? last.position : null
+  }
+
+  /** Waits until at least `count` frames arrived, or throws on timeout. */
+  async waitForCount(count: number, timeoutMs = 60_000): Promise<void> {
+    await this.waitUntil(
+      () => this.frames.length >= count,
+      timeoutMs,
+      () => `only ${this.frames.length} of ${count} frames arrived on ${this.url}`,
+    )
+  }
+
+  /** Waits until a frame with `position >= position` arrived. */
+  async waitForPosition(position: number, timeoutMs = 120_000): Promise<void> {
+    await this.waitUntil(
+      () => (this.lastPosition ?? -1) >= position,
+      timeoutMs,
+      () =>
+        `position ${position} never arrived on ${this.url}; last seen ${String(this.lastPosition)}`,
+    )
+  }
+
+  private async waitUntil(
+    predicate: () => boolean,
+    timeoutMs: number,
+    describe: () => string,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (!predicate()) {
+      if (this.error) throw this.error
+      if (Date.now() > deadline) throw new Error(`SSE timeout: ${describe()}`)
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+  }
+
+  /** Cuts the connection. This is the forced disconnect of check 7. */
+  async abort(): Promise<void> {
+    this.aborted = true
+    this.controller.abort()
+    await this.pumping.catch(() => undefined)
+  }
+}

--- a/e2e/tests/01-ingestion.spec.ts
+++ b/e2e/tests/01-ingestion.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  asAccepted,
+  asProblem,
+  bootstrapEvent,
+  getJson,
+  postEvent,
+  type EventEnvelope,
+} from '../src/api.js'
+import {
+  CONFLICT_PROJECT,
+  RETRY_PROJECT,
+  VALIDATION_AGENT,
+  VALIDATION_PROJECT,
+  VALIDATION_RUN,
+} from '../src/config.js'
+import { runSimulator } from '../src/simulator.js'
+
+/**
+ * Mandatory check 1 — event validation, idempotency and observable projections.
+ *
+ * Three separate promises of the contract are asserted here, and the third is
+ * what makes the first two more than a status-code test:
+ *
+ * 1. A refused event is refused **and occupies no position**. Positions are
+ *    handed out under the project row lock (ADR 0002), so the only honest way to
+ *    show that a rejection consumed none is to send a valid event afterwards and
+ *    read the position the server assigned it.
+ * 2. Idempotency is **content based**: a byte-identical redelivery answers
+ *    `200 duplicate: true` with the original position, a different payload under
+ *    the same key answers `409`.
+ * 3. The effect is **observable in the UI**. A rejected event that nevertheless
+ *    reached a projection, or a conflicting one that silently overwrote the
+ *    original, would be invisible in the HTTP answers above.
+ */
+
+// Fixed ids: the suite always starts from an empty database, so nothing has to
+// be random, and a failing run names the same event every time.
+const IDS = {
+  open: '11111111-0000-4000-8000-000000000001',
+  schemaInvalid: '11111111-0000-4000-8000-000000000002',
+  lifecycleInvalid: '11111111-0000-4000-8000-000000000003',
+  accepted: '11111111-0000-4000-8000-000000000004',
+} as const
+
+function statusEvent(
+  clientEventId: string,
+  payload: Record<string, unknown>,
+  agentId = VALIDATION_AGENT,
+): EventEnvelope {
+  return {
+    schemaVersion: '1.0',
+    clientEventId,
+    projectId: VALIDATION_PROJECT,
+    runId: VALIDATION_RUN,
+    agentId,
+    parentAgentId: null,
+    occurredAt: '2026-08-04T08:05:00Z',
+    type: 'agent.status_reported',
+    payload,
+  }
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('1 · a refused event occupies no position, a retry repeats it, a conflict is rejected', async () => {
+  const opened = await postEvent(
+    bootstrapEvent({
+      clientEventId: IDS.open,
+      projectId: VALIDATION_PROJECT,
+      runId: VALIDATION_RUN,
+      agentId: VALIDATION_AGENT,
+      displayName: 'Validation Probe',
+      assignedTask: 'Demonstrate that refused events never enter the log.',
+    }),
+  )
+  expect(opened.status, JSON.stringify(opened.body)).toBe(201)
+  expect(asAccepted(opened).position).toBe(1)
+  expect(asAccepted(opened).duplicate).toBe(false)
+
+  // ---- schema violation: `status` is a closed enum -------------------------
+  const schemaInvalid = await postEvent(
+    statusEvent(IDS.schemaInvalid, { status: 'exploded', note: 'not a contract status' }),
+  )
+  expect(schemaInvalid.status, JSON.stringify(schemaInvalid.body)).toBe(400)
+  const schemaProblem = asProblem(schemaInvalid)
+  expect(schemaProblem.code).toBe('invalid_field')
+  expect(schemaProblem.errors?.length ?? 0).toBeGreaterThan(0)
+
+  // ---- lifecycle violation: an agent that never started --------------------
+  const lifecycleInvalid = await postEvent(
+    statusEvent(IDS.lifecycleInvalid, { status: 'working' }, 'agent-that-never-started'),
+  )
+  expect(lifecycleInvalid.status, JSON.stringify(lifecycleInvalid.body)).toBe(422)
+  expect(asProblem(lifecycleInvalid).code).toBe('unknown_agent')
+
+  // ---- the next accepted event proves neither took a position --------------
+  const accepted = await postEvent(
+    statusEvent(IDS.accepted, {
+      status: 'working',
+      note: 'Accepted after two refusals.',
+    }),
+  )
+  expect(accepted.status, JSON.stringify(accepted.body)).toBe(201)
+  expect(
+    asAccepted(accepted).position,
+    'a refused event must not consume a project position',
+  ).toBe(2)
+
+  // ---- byte-identical redelivery ------------------------------------------
+  const retry = await postEvent(
+    statusEvent(IDS.accepted, {
+      status: 'working',
+      note: 'Accepted after two refusals.',
+    }),
+  )
+  expect(retry.status, JSON.stringify(retry.body)).toBe(200)
+  expect(asAccepted(retry).duplicate).toBe(true)
+  expect(asAccepted(retry).position, 'an idempotent retry repeats the position').toBe(2)
+
+  // ---- same key, different content ----------------------------------------
+  const conflict = await postEvent(
+    statusEvent(IDS.accepted, { status: 'blocked', note: 'Different content, same key.' }),
+  )
+  expect(conflict.status, JSON.stringify(conflict.body)).toBe(409)
+  expect(asProblem(conflict).code).toBe('client_event_id_conflict')
+})
+
+test('1 · the simulator retry and conflict scenarios answer as the contract promises', async () => {
+  const retry = await runSimulator({ scenario: 'retry', speed: 0 })
+  expect(retry.projectId).toBe(RETRY_PROJECT)
+  expect(retry.eventsSent).toBe(3)
+  expect(retry.created).toBe(2)
+  expect(retry.duplicates).toBe(1)
+  expect(retry.conflicts).toBe(0)
+  // Two distinct events; the redelivery must not have appended a third.
+  expect(retry.endPosition).toBe(2)
+
+  const [, first, redelivery] = retry.events
+  expect(first?.status).toBe(201)
+  expect(redelivery?.status).toBe(200)
+  expect(
+    redelivery?.position,
+    'the redelivery must repeat the position of the original',
+  ).toBe(first?.position)
+
+  const conflict = await runSimulator({ scenario: 'conflict', speed: 0 })
+  expect(conflict.projectId).toBe(CONFLICT_PROJECT)
+  expect(conflict.created).toBe(2)
+  expect(conflict.duplicates).toBe(0)
+  expect(conflict.conflicts).toBe(1)
+  expect(conflict.endPosition).toBe(2)
+  expect(conflict.events.at(-1)?.status).toBe(409)
+  expect(conflict.events.at(-1)?.position).toBeNull()
+})
+
+test('1 · the projections show the accepted content and nothing that was refused', async ({
+  page,
+}) => {
+  // --- the validation project ----------------------------------------------
+  await page.goto(`/projects/${VALIDATION_PROJECT}`)
+  await expect(page.getByTestId('pane-run-agents')).toBeVisible()
+
+  const validationStatus = page.getByTestId(`agent-status-${VALIDATION_AGENT}`)
+  await expect(validationStatus).toBeVisible()
+  // `working` from the accepted event — never `exploded` (schema refusal) and
+  // never `blocked` (the conflicting redelivery).
+  await expect(validationStatus).toHaveAttribute('data-status', 'working')
+  await expect(validationStatus).toContainText('Accepted after two refusals.')
+
+  // The refused event named an agent that never started. If it had reached a
+  // projection there would be a second row.
+  await expect(page.locator('[data-testid^="agent-row-"]')).toHaveCount(1)
+  await expect(page.getByTestId('agent-row-agent-that-never-started')).toHaveCount(0)
+
+  const validationProject = await getJson(`/api/v1/projects/${VALIDATION_PROJECT}`)
+  expect(validationProject.status).toBe(200)
+
+  // --- the simulator's conflict project ------------------------------------
+  await page.goto(`/projects/${CONFLICT_PROJECT}`)
+  const conflictStatus = page.getByTestId('agent-status-orchestrator-conflict')
+  await expect(conflictStatus).toBeVisible()
+  await expect(conflictStatus).toHaveAttribute('data-status', 'working')
+  await expect(conflictStatus).toContainText('Original content.')
+  await expect(conflictStatus).not.toContainText('Different content')
+
+  // --- the simulator's retry project ---------------------------------------
+  await page.goto(`/projects/${RETRY_PROJECT}`)
+  const retryStatus = page.getByTestId('agent-status-orchestrator-retry')
+  await expect(retryStatus).toBeVisible()
+  await expect(retryStatus).toHaveAttribute('data-status', 'working')
+  await expect(page.locator('[data-testid^="agent-row-"]')).toHaveCount(1)
+})

--- a/e2e/tests/02-live-updates.spec.ts
+++ b/e2e/tests/02-live-updates.spec.ts
@@ -1,0 +1,200 @@
+import { expect, test } from '@playwright/test'
+
+import { asAccepted, bootstrapEvent, postEvent } from '../src/api.js'
+import {
+  MAIN_BOOTSTRAP_AGENT,
+  MAIN_BOOTSTRAP_RUN,
+  MAIN_PROJECT,
+  MAIN_RUN,
+} from '../src/config.js'
+import { installLiveObserver } from '../src/liveObserver.js'
+import { startSimulator, type SimulatorSummary } from '../src/simulator.js'
+
+/**
+ * Mandatory check 3 — live SSE updates for planned, active, applied and removed.
+ *
+ * This file also runs the representative sequence that checks 2, 4, 5, 6 and 8
+ * read afterwards, and it is the only place that may: the `full` scenario
+ * expects an empty project, and it is sent exactly once.
+ *
+ * **Why the states have to be watched live.** A stream opened without a cursor
+ * starts at the live tail (`liveOnly`, ADR 0006), so `aktiv`,
+ * `kürzlich angewandt` and `entfernt` describe what *this tab saw happen*
+ * (ADR 0010). After a reload they legitimately start empty. Asserting them after
+ * the run would therefore assert nothing at all — the last test below turns that
+ * exact property into the anti-vacuum guard for the ones above it.
+ *
+ * **Why the cockpit is opened before the first reported event.** The stream of a
+ * project that does not exist yet is `404`, and the client would then back off
+ * exponentially and race the run. A bootstrap run opens the project first, so
+ * the connection is `live` before position one and nothing is missed by luck.
+ */
+
+const BOOTSTRAP_ID = '22222222-0000-4000-8000-000000000001'
+
+/** Filled by the first test and read by the second. */
+let summary: SimulatorSummary | null = null
+
+test.describe.configure({ mode: 'serial' })
+
+test('3 · every live change state is observed while the run is happening', async ({ page }) => {
+  const opened = await postEvent(
+    bootstrapEvent({
+      clientEventId: BOOTSTRAP_ID,
+      projectId: MAIN_PROJECT,
+      runId: MAIN_BOOTSTRAP_RUN,
+      agentId: MAIN_BOOTSTRAP_AGENT,
+      displayName: 'Acceptance bootstrap',
+      assignedTask:
+        'Open the project so the cockpit is connected before the representative run starts.',
+    }),
+  )
+  expect(opened.status, JSON.stringify(opened.body)).toBe(201)
+  expect(asAccepted(opened).position).toBe(1)
+
+  await page.addInitScript(installLiveObserver)
+  await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
+
+  // The connection must be live *before* the first reported event, otherwise
+  // "observed live" would be a coincidence.
+  await expect(page.getByTestId('live-connection-state')).toHaveAttribute(
+    'data-state',
+    'live',
+  )
+
+  // Anti-vacuum guard: nothing has been watched yet, so every state is zero.
+  const beforeRun = await page.evaluate(() => window.__e2eLive.maxCounts)
+  expect(
+    Object.values(beforeRun).reduce((sum, value) => sum + value, 0),
+    'no change state may be reported before the run started',
+  ).toBe(0)
+
+  // `--speed 1` keeps the simulator's pauses, so the transient states are on
+  // screen long enough to be genuinely observable rather than inferred.
+  const simulator = startSimulator({ scenario: 'full', speed: 1 })
+
+  // The applied removal is the last of the four states to appear; waiting for it
+  // means the run reached its "Applied changes" phase with the page open.
+  await expect
+    .poll(async () => (await page.evaluate(() => window.__e2eLive.maxCounts)).removed, {
+      timeout: 240_000,
+      message: 'the removed state never appeared while the run was being watched',
+    })
+    .toBeGreaterThan(0)
+
+  summary = await simulator.done
+  expect(summary.projectId).toBe(MAIN_PROJECT)
+  expect(summary.runId).toBe(MAIN_RUN)
+  expect(summary.conflicts).toBe(0)
+  expect(summary.duplicates).toBe(0)
+  expect(summary.created).toBe(summary.eventsSent)
+  expect(summary.eventsSent).toBeGreaterThanOrEqual(60)
+  // Position 1 is the bootstrap event, so the run ends one above its own count.
+  expect(summary.endPosition).toBe(summary.eventsSent + 1)
+
+  // The last proposal of the run arrives after the applied changes; waiting for
+  // its node means the page processed the whole stream.
+  await expect(
+    page.getByTestId('canvas-node-shop-platform.orders.domain.rounding'),
+  ).toBeVisible()
+
+  const observed = await page.evaluate(() => window.__e2eLive)
+
+  expect(observed.samples, 'the in-page observer must have run').toBeGreaterThan(10)
+  expect(observed.connectionStates).toContain('live')
+
+  // ---- the four states ----------------------------------------------------
+  expect(observed.maxCounts.planned, 'geplant').toBeGreaterThan(0)
+  expect(observed.maxCounts.active, 'aktiv').toBeGreaterThan(0)
+  expect(observed.maxCounts.recently_applied, 'kürzlich angewandt').toBeGreaterThan(0)
+  expect(observed.maxCounts.removed, 'entfernt').toBeGreaterThan(0)
+  expect(observed.maxTotal).toBeGreaterThan(0)
+
+  // ---- a planned removal is yellow, not red (ADR 0010) --------------------
+  // Asserted structurally: the state of an announced removal is `planned`, and
+  // what tells it apart from a planned addition is the word `entfernen` plus
+  // `data-operation`, never the hue.
+  const plannedRemoval = observed.marks['planned|remove']
+  expect(
+    plannedRemoval,
+    `no planned removal was rendered; observed marks: ${Object.keys(observed.marks).join(', ')}`,
+  ).toBeTruthy()
+  expect(plannedRemoval?.state).toBe('planned')
+  expect(plannedRemoval?.label).toBe('geplant')
+  expect(plannedRemoval?.borderStyle).toBe('dashed')
+  expect(plannedRemoval?.text).toContain('entfernen')
+
+  const plannedAddition = observed.marks['planned|add']
+  expect(plannedAddition).toBeTruthy()
+  expect(plannedAddition?.text).toContain('hinzufügen')
+  // Same phase, same border style — only the word differs.
+  expect(plannedAddition?.borderStyle).toBe(plannedRemoval?.borderStyle)
+
+  // ---- an applied removal is a different state entirely -------------------
+  const appliedRemoval = Object.values(observed.marks).find(
+    (mark) => mark.state === 'removed',
+  )
+  expect(appliedRemoval, 'the applied removal must render the `removed` state').toBeTruthy()
+  expect(appliedRemoval?.label).toBe('entfernt')
+  expect(appliedRemoval?.borderStyle).toBe('dotted')
+
+  const applied = Object.values(observed.marks).find(
+    (mark) => mark.state === 'recently_applied',
+  )
+  expect(applied?.label).toBe('kürzlich angewandt')
+  expect(applied?.borderStyle).toBe('solid')
+
+  const active = Object.values(observed.marks).find((mark) => mark.state === 'active')
+  expect(active?.label).toBe('aktiv')
+  expect(active?.borderStyle).toBe('double')
+
+  // ---- the removed element stays on the canvas as evidence ----------------
+  expect(observed.ghostComponentIds).toContain(
+    'shop-platform.orders.domain.legacy-tax-rates',
+  )
+
+  // ---- proposals never entered the applied model --------------------------
+  expect(observed.maxOverlayNodeCount).toBeGreaterThan(0)
+  const canvas = page.getByTestId('architecture-canvas')
+  await expect(canvas).toHaveAttribute('data-node-count', '17')
+  await expect(canvas).toHaveAttribute('data-edge-count', '11')
+})
+
+test('3 · after a reload the watched states start empty again — which is why they had to be watched', async ({
+  page,
+}) => {
+  expect(summary, 'the representative run must have completed').not.toBeNull()
+
+  await page.addInitScript(installLiveObserver)
+  await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
+  await expect(page.getByTestId('live-connection-state')).toHaveAttribute(
+    'data-state',
+    'live',
+  )
+  await expect(page.getByTestId('architecture-canvas')).toBeVisible()
+  // The pending proposals come back from the read API's `activeChanges`.
+  await expect(
+    page.getByTestId('canvas-node-shop-platform.orders.domain.rounding'),
+  ).toBeVisible()
+
+  // `planned` is served by the read API and therefore survives a reload …
+  await expect(page.getByTestId('change-counter-planned')).not.toHaveAttribute(
+    'data-count',
+    '0',
+  )
+
+  // … while the three states the read API cannot express start empty. If the
+  // assertions of the previous test could have been satisfied by a reload, this
+  // is where that would show.
+  for (const state of ['active', 'recently_applied', 'removed']) {
+    await expect(
+      page.getByTestId(`change-counter-${state}`),
+      `${state} must be empty after a reload — it is a statement about what was watched`,
+    ).toHaveAttribute('data-count', '0')
+  }
+
+  // The ghost is gone with it: the removed component is simply absent.
+  await expect(
+    page.getByTestId('canvas-node-shop-platform.orders.domain.legacy-tax-rates'),
+  ).toHaveCount(0)
+})

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -1,0 +1,251 @@
+import { expect, test, type Page } from '@playwright/test'
+
+import { getJson } from '../src/api.js'
+import { MAIN_PROJECT, MAIN_RUN } from '../src/config.js'
+
+/**
+ * Mandatory check 2 — the full architecture canvas: hierarchy and typed
+ * relationships, with every reported NATS topic individually identifiable.
+ *
+ * The bundling rule of ADR 0008 is *bundling by ordered node pair*: several
+ * relationships between the **same** two components share one rendered line and
+ * the line keeps the complete, addressable list. The acceptance property behind
+ * it is the one asserted here — **no reported relationship may become
+ * unreachable**. It is checked from both ends: the read API must return every
+ * topic relationship separately (the server never aggregates, ADR 0005), and the
+ * canvas must expose each of them with its own label and its own `channel`.
+ */
+
+interface ArchitectureResponse {
+  components: { componentId: string; parentComponentId: string | null; kind: string }[]
+  relationships: {
+    relationshipId: string
+    sourceComponentId: string
+    targetComponentId: string
+    kind: string
+    channel?: string
+    operation?: string
+  }[]
+}
+
+const TOPIC_ORDER_CREATED = 'orders.order.created'
+const TOPIC_INVENTORY_RESERVED = 'inventory.item.reserved'
+
+/** The four-level chain the snapshot is built around. */
+const HIERARCHY_CHAIN = [
+  'shop-platform',
+  'shop-platform.orders',
+  'shop-platform.orders.domain',
+  'shop-platform.orders.domain.pricing',
+] as const
+
+const RELATIONSHIP_KINDS = [
+  'http',
+  'grpc',
+  'data',
+  'async',
+  'nats_topic',
+  'dependency',
+] as const
+
+async function openWorkspace(page: Page): Promise<void> {
+  await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
+  await expect(page.getByTestId('architecture-canvas')).toBeVisible()
+  await expect(page.getByTestId('canvas-node-shop-platform')).toBeVisible()
+  await expect(page.getByTestId('architecture-canvas')).toHaveAttribute(
+    'data-layouting',
+    'false',
+  )
+}
+
+/** Zooms in until the canvas reports the `full` detail level. */
+async function zoomToFullDetail(page: Page): Promise<void> {
+  const canvas = page.getByTestId('architecture-canvas')
+  const zoomIn = page.locator('.react-flow__controls-zoomin')
+  await expect(zoomIn).toBeVisible()
+
+  for (let attempt = 0; attempt < 24; attempt += 1) {
+    const level = await canvas.getAttribute('data-detail-level')
+    if (level === 'full') return
+    await zoomIn.click()
+  }
+  await expect(canvas).toHaveAttribute('data-detail-level', 'full')
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('2 · the canvas draws the reported hierarchy across four nesting levels', async ({
+  page,
+}) => {
+  await openWorkspace(page)
+  await page.getByTestId('canvas-fit-view').click()
+
+  const canvas = page.getByTestId('architecture-canvas')
+  await expect(canvas).toHaveAttribute('data-node-count', '17')
+  await expect(canvas).toHaveAttribute('data-edge-count', '11')
+
+  // Compound containers really contain their children: the box of each level of
+  // the chain lies inside the box of the level above it. That is the rendered
+  // hierarchy, not a claim about an attribute.
+  const boxes = []
+  for (const componentId of HIERARCHY_CHAIN) {
+    const node = page.getByTestId(`canvas-node-${componentId}`)
+    await expect(node).toBeVisible()
+    const box = await node.boundingBox()
+    expect(box, `no bounding box for ${componentId}`).not.toBeNull()
+    boxes.push({ componentId, box: box as NonNullable<typeof box> })
+  }
+
+  for (let level = 1; level < boxes.length; level += 1) {
+    const parent = boxes[level - 1]
+    const child = boxes[level]
+    if (!parent || !child) throw new Error('unreachable')
+    expect(
+      child.box.x >= parent.box.x &&
+        child.box.y >= parent.box.y &&
+        child.box.x + child.box.width <= parent.box.x + parent.box.width &&
+        child.box.y + child.box.height <= parent.box.y + parent.box.height,
+      `${child.componentId} is not drawn inside ${parent.componentId}: ` +
+        `${JSON.stringify(child.box)} vs ${JSON.stringify(parent.box)}`,
+    ).toBe(true)
+  }
+
+  // The three ancestors are compound containers, the leaf is not.
+  for (const componentId of HIERARCHY_CHAIN.slice(0, 3)) {
+    await expect(page.getByTestId(`canvas-node-${componentId}`)).toHaveAttribute(
+      'data-compound',
+      'true',
+    )
+  }
+  await expect(
+    page.getByTestId('canvas-node-shop-platform.orders.domain.pricing'),
+  ).not.toHaveAttribute('data-compound', 'true')
+
+  // The applied model is exactly what the run left behind: the extracted tax
+  // module is in it, the legacy module is not.
+  await expect(page.getByTestId('canvas-node-shop-platform.orders.domain.tax')).toBeVisible()
+  await expect(
+    page.getByTestId('canvas-node-shop-platform.orders.domain.legacy-tax-rates'),
+  ).toHaveCount(0)
+})
+
+test('2 · every relationship kind is drawn, and every reported NATS topic stays individually identifiable', async ({
+  page,
+}) => {
+  // ---- what the server reports --------------------------------------------
+  const response = await getJson(`/api/v1/projects/${MAIN_PROJECT}/architecture`)
+  expect(response.status).toBe(200)
+  const architecture = response.body as ArchitectureResponse
+  expect(architecture.components).toHaveLength(17)
+  expect(architecture.relationships).toHaveLength(11)
+
+  const orderCreated = architecture.relationships.filter(
+    (relationship) => relationship.channel === TOPIC_ORDER_CREATED,
+  )
+  const inventoryReserved = architecture.relationships.filter(
+    (relationship) => relationship.channel === TOPIC_INVENTORY_RESERVED,
+  )
+  expect(
+    orderCreated.map((relationship) => relationship.relationshipId).sort(),
+    'the server must never aggregate the topic into one edge',
+  ).toEqual([
+    'rel-inventory-consumes-order-created',
+    'rel-notifications-consumes-order-created',
+    'rel-orders-publishes-order-created',
+  ])
+  expect(inventoryReserved.map((relationship) => relationship.relationshipId).sort()).toEqual([
+    'rel-inventory-publishes-inventory-reserved',
+    'rel-notifications-consumes-inventory-reserved',
+  ])
+
+  // ---- what the canvas draws ----------------------------------------------
+  await openWorkspace(page)
+  await page.getByTestId('canvas-fit-view').click()
+
+  // All six typed kinds are on screen, each with its own stroke pattern.
+  for (const kind of RELATIONSHIP_KINDS) {
+    await expect(
+      page.locator(`[data-relationship-kind="${kind}"]`).first(),
+      `no edge of kind ${kind} was drawn`,
+    ).toBeAttached()
+  }
+
+  // Distinct dash patterns: the kind survives greyscale (ADR 0008).
+  const dashPatterns = await page.evaluate(() => {
+    const seen: Record<string, string> = {}
+    for (const path of Array.from(document.querySelectorAll('[data-relationship-kind]'))) {
+      const kind = path.getAttribute('data-relationship-kind') ?? ''
+      seen[kind] = path.getAttribute('data-dasharray') ?? ''
+    }
+    return seen
+  })
+  expect(new Set(Object.values(dashPatterns)).size).toBe(RELATIONSHIP_KINDS.length)
+
+  // ---- the bundle is a rendering, never a merge ---------------------------
+  await zoomToFullDetail(page)
+
+  // One label per reported relationship. If the canvas had merged the parallel
+  // topic edges into one "messaging" line there would be fewer than eleven.
+  const appliedIds = architecture.relationships.map((relationship) => relationship.relationshipId)
+  const labelledApplied = await page.evaluate(
+    (ids) =>
+      ids.filter(
+        (id) => document.querySelector(`[data-testid="edge-label-${id}"]`) !== null,
+      ),
+    appliedIds,
+  )
+  expect(labelledApplied.sort()).toEqual([...appliedIds].sort())
+
+  // Every single topic is addressable by its own relationship id, and its label
+  // carries the `channel` that identifies it among its siblings.
+  for (const relationship of [...orderCreated, ...inventoryReserved]) {
+    const label = page.getByTestId(`edge-label-${relationship.relationshipId}`)
+    await expect(label, `no individual label for ${relationship.relationshipId}`).toBeAttached()
+    await expect(label).toContainText(relationship.channel ?? '<no channel>')
+    await expect(label).toHaveAttribute(
+      'title',
+      new RegExp(`Kanal: ${escapeRegExp(relationship.channel ?? '')}`),
+    )
+  }
+
+  // The three `orders.order.created` relationships stay three, and the two
+  // `inventory.item.reserved` ones stay two.
+  const channelsInDom = await page.evaluate(() => {
+    const channels: string[] = []
+    for (const badge of Array.from(document.querySelectorAll('[data-testid^="edge-label-"]'))) {
+      const match = /Kanal: (.+)$/m.exec(badge.getAttribute('title') ?? '')
+      if (match?.[1]) channels.push(match[1].trim())
+    }
+    return channels
+  })
+  expect(channelsInDom.filter((channel) => channel === TOPIC_ORDER_CREATED)).toHaveLength(3)
+  expect(channelsInDom.filter((channel) => channel === TOPIC_INVENTORY_RESERVED)).toHaveLength(2)
+
+  // The reversibility guarantee stated as an invariant: the number of drawn
+  // edges plus the number of relationships they carry must agree, so a folded
+  // bundle — if the reported model ever contains one — can only ever be a
+  // rendering of relationships that are all still individually labelled.
+  const edgeInventory = await page.evaluate(() => {
+    const canvas = document.querySelector('[data-testid="architecture-canvas"]')
+    return {
+      folded: document.querySelectorAll('[data-testid^="edge-bundle-"]').length,
+      labels: document.querySelectorAll('[data-testid^="edge-label-"]').length,
+      appliedEdges: Number(canvas?.getAttribute('data-edge-count') ?? '-1'),
+      overlayEdges: Number(canvas?.getAttribute('data-overlay-edge-count') ?? '-1'),
+    }
+  })
+  expect(
+    edgeInventory.folded,
+    'a folded bundle at the full detail level would hide individual relationships',
+  ).toBe(0)
+  // Applied and proposed edges each carry exactly one labelled relationship, so
+  // no reported relationship can have been folded away.
+  expect(edgeInventory.appliedEdges).toBe(architecture.relationships.length)
+  expect(edgeInventory.labels).toBe(
+    edgeInventory.appliedEdges + edgeInventory.overlayEdges,
+  )
+})
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/e2e/tests/04-run-agents.spec.ts
+++ b/e2e/tests/04-run-agents.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test } from '@playwright/test'
+
+import { getJson } from '../src/api.js'
+import { MAIN_PROJECT, MAIN_RUN } from '../src/config.js'
+
+/**
+ * Mandatory check 4 — the run/agent tree with parallel subagents and progress
+ * estimates that cannot be mistaken for measurements.
+ *
+ * The separation asserted here is **structural**, not chromatic (ADR 0011):
+ *
+ * * a counted fact is a row of discrete segments carrying `role="progressbar"`
+ *   with `aria-valuenow`/`aria-valuemax`,
+ * * a reported claim has no track, no fill and **no ARIA value at all**.
+ *
+ * `data-progress-form` is what the test reads, and it deliberately never reads a
+ * colour: a test that checked a hue would be proving the opposite of the rule.
+ */
+
+interface AgentsResponse {
+  agents: {
+    agentId: string
+    parentAgentId: string | null
+    role: string
+    displayName: string
+    assignedTask: string | null
+    progress: { percent: number; scope: string | null; basis: string | null } | null
+  }[]
+}
+
+const ROOT = 'orchestrator-root'
+const ARCHITECT = 'subagent-architecture-mapper'
+const IMPLEMENTER = 'subagent-implementer'
+const REVIEWER = 'subagent-reviewer'
+const TESTER = 'subagent-test-engineer'
+
+test('4 · the tree is three levels deep with two subagents running in parallel below one parent', async ({
+  page,
+}) => {
+  const response = await getJson(
+    `/api/v1/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}/agents`,
+  )
+  expect(response.status).toBe(200)
+  const { agents } = response.body as AgentsResponse
+  expect(agents).toHaveLength(5)
+
+  const parentOf = new Map(agents.map((agent) => [agent.agentId, agent.parentAgentId]))
+  expect(parentOf.get(ROOT)).toBeNull()
+  expect(parentOf.get(ARCHITECT)).toBe(ROOT)
+  expect(parentOf.get(IMPLEMENTER)).toBe(ROOT)
+  // Delegated by a subagent, not by the root — that is the third level.
+  expect(parentOf.get(REVIEWER)).toBe(IMPLEMENTER)
+  expect(parentOf.get(TESTER)).toBe(IMPLEMENTER)
+
+  await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
+  await expect(page.getByTestId('pane-run-agents')).toBeVisible()
+
+  const rows = page.locator('[data-testid^="agent-row-"]')
+  await expect(rows).toHaveCount(5)
+
+  // The rendered hierarchy: one indent level per depth, flat list by design.
+  await expect(page.getByTestId(`agent-row-${ROOT}`)).toHaveAttribute('data-depth', '0')
+  await expect(page.getByTestId(`agent-row-${ARCHITECT}`)).toHaveAttribute('data-depth', '1')
+  await expect(page.getByTestId(`agent-row-${IMPLEMENTER}`)).toHaveAttribute('data-depth', '1')
+  await expect(page.getByTestId(`agent-row-${REVIEWER}`)).toHaveAttribute('data-depth', '2')
+  await expect(page.getByTestId(`agent-row-${TESTER}`)).toHaveAttribute('data-depth', '2')
+  await expect(page.locator('ul[data-max-depth]')).toHaveAttribute('data-max-depth', '2')
+
+  // No agent was orphaned or had its parent edge cut to break a cycle.
+  await expect(page.getByTestId(`agent-row-${ROOT}`)).toHaveAttribute(
+    'data-attachment',
+    'root',
+  )
+  for (const agentId of [ARCHITECT, IMPLEMENTER, REVIEWER, TESTER]) {
+    await expect(page.getByTestId(`agent-row-${agentId}`)).toHaveAttribute(
+      'data-attachment',
+      'child',
+    )
+  }
+
+  // Every row answers the four reporting questions with what was reported.
+  await expect(page.getByTestId(`agent-task-${TESTER}`)).toContainText(
+    'Cover the new tax module with table tests.',
+  )
+  await expect(page.getByTestId(`agent-status-${REVIEWER}`)).toHaveAttribute(
+    'data-status',
+    'done',
+  )
+  await expect(page.getByTestId(`agent-outcome-${TESTER}`)).toHaveAttribute(
+    'data-outcome',
+    'completed',
+  )
+
+  // The run is open, and that is described as a fact about the log.
+  await expect(page.getByTestId('run-openness')).toHaveAttribute('data-open', 'true')
+  await expect(page.getByTestId('run-openness')).toContainText('kein Terminalereignis')
+})
+
+test('4 · an overall estimate and a counted subagent progress are told apart by shape, not colour', async ({
+  page,
+}) => {
+  await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
+  await expect(page.getByTestId('pane-run-agents')).toBeVisible()
+
+  const orchestratorProgress = page.getByTestId(`agent-progress-${ROOT}`)
+  const testerProgress = page.getByTestId(`agent-progress-${TESTER}`)
+  await expect(orchestratorProgress).toBeVisible()
+  await expect(testerProgress).toBeVisible()
+
+  // ---- the orchestrator's whole-run estimate: a claim ---------------------
+  await expect(orchestratorProgress).toHaveAttribute('data-progress-form', 'claim')
+  await expect(orchestratorProgress).toHaveAttribute(
+    'data-progress-scope',
+    'overall_estimate',
+  )
+  await expect(
+    orchestratorProgress.locator('[role="progressbar"]'),
+    'a reported claim must not be given a scale',
+  ).toHaveCount(0)
+  await expect(orchestratorProgress.locator('[data-progress-segment]')).toHaveCount(0)
+  await expect(orchestratorProgress).toContainText('≈')
+  await expect(orchestratorProgress).toContainText('Gemeldete Selbsteinschätzung')
+  await expect(orchestratorProgress).toContainText('Kein gemessener Fortschritt')
+
+  // ---- a subagent counting the steps of its own task: a measurement -------
+  await expect(testerProgress).toHaveAttribute('data-progress-form', 'counted')
+  await expect(testerProgress).toHaveAttribute('data-progress-scope', 'own_task')
+  await expect(testerProgress).toHaveAttribute('data-progress-basis', 'completed_steps')
+  const meter = testerProgress.locator('[role="progressbar"]')
+  await expect(meter).toHaveCount(1)
+  await expect(meter).toHaveAttribute('aria-valuenow', '100')
+  await expect(meter).toHaveAttribute('aria-valuemax', '100')
+  await expect(testerProgress.locator('[data-progress-segment]')).toHaveCount(10)
+  await expect(testerProgress).not.toContainText('≈')
+
+  // ---- the two renderings share no geometry ------------------------------
+  const nesting = await page.evaluate(
+    ([claimId, countedId]) => {
+      const claim = document.querySelector(`[data-testid="${claimId}"]`)
+      const counted = document.querySelector(`[data-testid="${countedId}"]`)
+      if (claim === null || counted === null) return null
+      return {
+        claimContainsCounted: claim.contains(counted),
+        countedContainsClaim: counted.contains(claim),
+        sameGroup:
+          claim.getAttribute('data-progress-group') ===
+          counted.getAttribute('data-progress-group'),
+      }
+    },
+    [`agent-progress-${ROOT}`, `agent-progress-${TESTER}`] as const,
+  )
+  expect(nesting).not.toBeNull()
+  expect(nesting?.claimContainsCounted).toBe(false)
+  expect(nesting?.countedContainsClaim).toBe(false)
+  expect(nesting?.sameGroup).toBe(false)
+
+  // Another subagent scoped to its own task also gets the counted form, so the
+  // distinction follows scope and basis rather than the position in the tree.
+  await expect(page.getByTestId(`agent-progress-${IMPLEMENTER}`)).toHaveAttribute(
+    'data-progress-form',
+    'counted',
+  )
+
+  // ---- plans: both revisions are kept, with counted step completion -------
+  const revisions = page.locator('[data-revision]')
+  await expect(revisions).toHaveCount(2)
+  await expect(page.getByTestId('plan-revisions')).toContainText('Revision 1')
+  await expect(page.getByTestId('plan-revisions')).toContainText('Revision 2')
+})

--- a/e2e/tests/05-inspector.spec.ts
+++ b/e2e/tests/05-inspector.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test } from '@playwright/test'
+
+import { MAIN_PROJECT, MAIN_RUN } from '../src/config.js'
+
+/**
+ * Mandatory check 5 — a component click answers with the responsible agent, its
+ * assigned task, the markdown feedback and the unified diffs grouped by change.
+ *
+ * Two properties beyond "the data is there":
+ *
+ * * **Grouping is by `changeId`.** The three files of the extraction were three
+ *   `diff.reported` events; the inspector has to present them as one act of
+ *   work, and a diff the agent reported without a `changeId` must stay its own
+ *   entry rather than being folded into a neighbouring change.
+ * * **The rendered feedback contains no active element.** Feedback bodies are
+ *   untrusted agent output (ADR 0012). The check asks the DOM what it actually
+ *   produced — anything focusable, anything that executes or loads, anything
+ *   with an inline event handler.
+ */
+
+const TAX = 'shop-platform.orders.domain.tax'
+const NOTIFICATIONS = 'shop-platform.notifications'
+const EXTRACTION_CHANGE = 'change-2026-08-04-0007'
+
+test('5 · clicking a component shows its agent, task, markdown feedback and grouped diffs', async ({
+  page,
+}) => {
+  await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
+  await expect(page.getByTestId('architecture-canvas')).toBeVisible()
+
+  // Nothing is selected yet, and the inspector says so rather than guessing.
+  await expect(page.getByTestId('pane-inspector')).toContainText(
+    'Keine Komponente ausgewählt',
+  )
+
+  await page.getByTestId(`canvas-node-${TAX}`).click()
+
+  // The selection is a URL change, so the view is linkable and a live event
+  // cannot move it.
+  await expect(page).toHaveURL(new RegExp(`component=${encodeURIComponent(TAX)}`))
+  await expect(page.getByTestId(`canvas-node-${TAX}`)).toHaveAttribute(
+    'data-selected',
+    'true',
+  )
+
+  // ---- agent and task -----------------------------------------------------
+  const context = page.getByTestId('inspector-context')
+  await expect(context).toBeVisible()
+  await expect(context).toHaveAttribute('data-component-id', TAX)
+  await expect(context).toHaveAttribute('data-run-id', MAIN_RUN)
+  // Read from evidence, not guessed: the agent of the latest work step that
+  // named this component.
+  await expect(context).toHaveAttribute('data-agent-id', 'subagent-test-engineer')
+  await expect(page.getByTestId('responsible-agent')).toContainText('Test Engineer')
+  await expect(page.getByTestId('agent-assigned-task')).toContainText(
+    'Cover the new tax module with table tests.',
+  )
+  await expect(page.getByTestId('agent-status')).toBeVisible()
+  await expect(page.getByTestId('current-work-step')).toContainText(
+    'Cover tax.Rate.Apply with a table test',
+  )
+
+  // ---- markdown feedback --------------------------------------------------
+  const feedback = page.getByTestId('feedback-entries')
+  await expect(feedback).toBeVisible()
+  await expect(page.getByTestId('feedback-entry')).toHaveCount(1)
+  await expect(page.getByTestId('feedback-entry')).toHaveAttribute(
+    'data-feedback-id',
+    'feedback-2026-08-04-0001',
+  )
+
+  const markdown = page.getByTestId('safe-markdown').first()
+  await expect(markdown).toBeVisible()
+  // Rendered markdown, not an escaped string: headings, a list and a code block.
+  await expect(markdown.locator('h4, h3, h5')).not.toHaveCount(0)
+  await expect(markdown.locator('ol li')).not.toHaveCount(0)
+  await expect(markdown.locator('pre code')).not.toHaveCount(0)
+  await expect(markdown).toContainText('The order of operations changed.')
+
+  // ---- grouped unified diffs ---------------------------------------------
+  const groups = page.getByTestId('diff-groups')
+  await expect(groups).toBeVisible()
+  await expect(page.getByTestId('diff-group')).toHaveCount(1)
+
+  const extraction = page.locator(`[data-testid="diff-group"][data-change-id="${EXTRACTION_CHANGE}"]`)
+  await expect(
+    extraction,
+    'the three files of one change must be one group, not three entries',
+  ).toHaveCount(1)
+  await expect(extraction).toHaveAttribute('data-file-count', '3')
+  await expect(extraction).toHaveAttribute('data-agent-id', 'subagent-implementer')
+  await expect(extraction).toHaveAttribute('data-run-id', MAIN_RUN)
+  await expect(extraction.getByTestId('unified-diff')).toHaveCount(3)
+
+  const filePaths = await extraction
+    .locator('[data-file-path]')
+    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-file-path') ?? ''))
+  expect(filePaths.sort()).toEqual([
+    'internal/orders/domain/pricing/pricing.go',
+    'internal/orders/domain/tax/tax.go',
+    'internal/orders/domain/tax/tax_test.go',
+  ])
+
+  // Unified diff lines are classified, so additions and removals are readable
+  // without relying on colour.
+  await expect(extraction.locator('[data-line-kind="addition"]').first()).toBeVisible()
+  await expect(extraction.locator('[data-line-kind="removal"]').first()).toBeAttached()
+})
+
+test('5 · a diff reported without a changeId stays its own entry', async ({ page }) => {
+  await page.goto(
+    `/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}?component=${encodeURIComponent(NOTIFICATIONS)}`,
+  )
+  await expect(page.getByTestId('inspector-current-run')).toBeVisible()
+
+  const group = page.getByTestId('diff-group')
+  await expect(group).toHaveCount(1)
+  await expect(group).toHaveAttribute('data-change-id', '')
+  await expect(group).toHaveAttribute('data-file-count', '1')
+  await expect(group).toContainText('Ohne')
+  await expect(group.locator('[data-file-path]')).toHaveAttribute(
+    'data-file-path',
+    'internal/notifications/consumer.go',
+  )
+})
+
+test('5 · the rendered feedback contains no active element', async ({ page }) => {
+  await page.goto(
+    `/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}?component=${encodeURIComponent(TAX)}`,
+  )
+  await expect(page.getByTestId('safe-markdown').first()).toBeVisible()
+
+  const audit = await page.evaluate(() => {
+    const EXECUTABLE = [
+      'script',
+      'iframe',
+      'object',
+      'embed',
+      'form',
+      'style',
+      'link',
+      'meta',
+      'base',
+      'noscript',
+      'template',
+      'svg',
+      'math',
+      'applet',
+      'frame',
+      'frameset',
+    ]
+    const FOCUSABLE_TAGS = [
+      'a',
+      'button',
+      'select',
+      'textarea',
+      'input',
+      'details',
+      'summary',
+      'audio',
+      'video',
+    ]
+
+    const describe = (element: Element): string =>
+      `${element.tagName.toLowerCase()}${element.outerHTML.slice(0, 120)}`
+
+    const executable: string[] = []
+    const focusable: string[] = []
+    const handlers: string[] = []
+    let roots = 0
+    let elements = 0
+
+    for (const root of Array.from(document.querySelectorAll('[data-testid="safe-markdown"]'))) {
+      roots += 1
+      for (const element of Array.from(root.querySelectorAll('*'))) {
+        elements += 1
+        const tag = element.tagName.toLowerCase()
+        if (EXECUTABLE.includes(tag)) executable.push(describe(element))
+
+        for (const attribute of Array.from(element.attributes)) {
+          if (attribute.name.toLowerCase().startsWith('on')) handlers.push(describe(element))
+        }
+
+        const tabIndex = element.getAttribute('tabindex')
+        if (tabIndex !== null && Number(tabIndex) >= 0) focusable.push(describe(element))
+        if ((element as HTMLElement).isContentEditable) focusable.push(describe(element))
+        if (tag === 'a' && element.hasAttribute('href')) focusable.push(describe(element))
+        if (FOCUSABLE_TAGS.includes(tag) && tag !== 'a' && !element.hasAttribute('disabled')) {
+          focusable.push(describe(element))
+        }
+      }
+    }
+
+    return { roots, elements, executable, focusable, handlers }
+  })
+
+  // Guard against a vacuous pass: there has to be rendered markdown to audit.
+  expect(audit.roots).toBeGreaterThan(0)
+  expect(audit.elements).toBeGreaterThan(10)
+
+  expect(audit.executable, 'executable or resource-loading element in feedback').toEqual([])
+  expect(audit.focusable, 'focusable element in rendered feedback').toEqual([])
+  expect(audit.handlers, 'inline event handler in rendered feedback').toEqual([])
+})

--- a/e2e/tests/06-run-history-focus.spec.ts
+++ b/e2e/tests/06-run-history-focus.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  MAIN_BOOTSTRAP_AGENT,
+  MAIN_BOOTSTRAP_RUN,
+  MAIN_PROJECT,
+  MAIN_RUN,
+} from '../src/config.js'
+
+/**
+ * Mandatory check 6 — the current run and the history stay apart, and deep focus
+ * enlarges the reading area **without** losing the architecture context.
+ *
+ * Three separations, each asserted where it could actually break:
+ *
+ * * The inspector's history is a different endpoint behind a different tab, not
+ *   a filter over the current run's evidence (ADR 0005). A diff from another run
+ *   must never sit in the same list as one from the run being watched.
+ * * A historical run is a different URL. The pane announces it before anything
+ *   else and carries the way back; no agent of the current run may appear.
+ * * Deep focus is a layout change, not a modal. `DEEP_FOCUS_PANE_LAYOUT` keeps
+ *   ~41 % of the width on the canvas, so both widths are measured rather than
+ *   only the one that grew.
+ */
+
+const TAX = 'shop-platform.orders.domain.tax'
+
+test('6 · the history is its own tab and never mixes into the current run', async ({
+  page,
+}) => {
+  await page.goto(
+    `/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}?component=${encodeURIComponent(TAX)}`,
+  )
+
+  const currentTab = page.getByRole('tab', { name: 'Aktueller Run' })
+  const historyTab = page.getByRole('tab', { name: 'Historie' })
+  await expect(currentTab).toHaveAttribute('aria-selected', 'true')
+  await expect(historyTab).toHaveAttribute('aria-selected', 'false')
+
+  await expect(page.getByTestId('inspector-current-run')).toBeVisible()
+  await expect(page.getByTestId('diff-groups')).toBeVisible()
+  await expect(page.getByTestId('inspector-history')).toHaveCount(0)
+
+  await historyTab.click()
+  await expect(historyTab).toHaveAttribute('aria-selected', 'true')
+  await expect(page.getByTestId('inspector-history')).toBeVisible()
+
+  // The current run's evidence is gone from the pane, not merely pushed down.
+  await expect(page.getByTestId('inspector-current-run')).toHaveCount(0)
+  await expect(page.getByTestId('diff-groups')).toHaveCount(0)
+  await expect(page.getByTestId('feedback-entries')).toHaveCount(0)
+  await expect(page.getByTestId('inspector-risks')).toHaveCount(0)
+
+  const historyEntries = page.getByTestId('history-entry')
+  await expect(historyEntries.first()).toBeVisible()
+  // Every historical entry names the run it belongs to, so nothing is anonymous.
+  const runIds = await historyEntries.evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute('data-run-id') ?? ''),
+  )
+  expect(runIds.length).toBeGreaterThan(0)
+  expect(runIds.every((runId) => runId !== '')).toBe(true)
+
+  await currentTab.click()
+  await expect(page.getByTestId('inspector-current-run')).toBeVisible()
+  await expect(page.getByTestId('inspector-history')).toHaveCount(0)
+})
+
+test('6 · a historical run is a different URL and never overlays the current one', async ({
+  page,
+}) => {
+  await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
+  await expect(page.getByTestId('current-run-banner')).toBeVisible()
+  await expect(page.getByTestId('historical-run-banner')).toHaveCount(0)
+  await expect(page.getByTestId('agent-row-orchestrator-root')).toBeVisible()
+
+  await page.getByTestId(`run-option-${MAIN_BOOTSTRAP_RUN}`).click()
+  await expect(page).toHaveURL(new RegExp(`runs/${MAIN_BOOTSTRAP_RUN}`))
+
+  const banner = page.getByTestId('historical-run-banner')
+  await expect(banner).toBeVisible()
+  await expect(banner).toContainText(MAIN_RUN)
+  await expect(page.getByTestId('current-run-banner')).toHaveCount(0)
+
+  // Nothing merges: only the historical run's own agent is shown.
+  await expect(page.getByTestId(`agent-row-${MAIN_BOOTSTRAP_AGENT}`)).toBeVisible()
+  await expect(page.getByTestId('agent-row-orchestrator-root')).toHaveCount(0)
+  await expect(page.locator('[data-testid^="agent-row-"]')).toHaveCount(1)
+  await expect(page.getByTestId('pane-run-agents')).toHaveAttribute(
+    'data-run-id',
+    MAIN_BOOTSTRAP_RUN,
+  )
+
+  await page.getByTestId('back-to-current-run').click()
+  await expect(page).toHaveURL(new RegExp(`runs/${MAIN_RUN}`))
+  await expect(page.getByTestId('current-run-banner')).toBeVisible()
+  await expect(page.getByTestId('agent-row-orchestrator-root')).toBeVisible()
+})
+
+test('6 · deep focus enlarges the inspector while the architecture stays on screen', async ({
+  page,
+}) => {
+  await page.goto(
+    `/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}?component=${encodeURIComponent(TAX)}`,
+  )
+  await expect(page.getByTestId('diff-groups')).toBeVisible()
+  await expect(page.getByTestId(`canvas-node-${TAX}`)).toBeVisible()
+
+  const architecture = page.getByTestId('pane-architecture')
+  const inspector = page.getByTestId('pane-inspector')
+
+  const before = {
+    architecture: (await architecture.boundingBox())?.width ?? 0,
+    inspector: (await inspector.boundingBox())?.width ?? 0,
+  }
+  expect(before.architecture).toBeGreaterThan(0)
+  expect(before.inspector).toBeGreaterThan(0)
+
+  await page
+    .getByTestId('inspector-diffs')
+    .getByRole('button', { name: 'Deep Focus' })
+    .click()
+
+  await expect(page.getByTestId('deep-focus-banner')).toBeVisible()
+  await expect(page).toHaveURL(/focus=diffs/)
+  // The other sections give way so the enlarged pane is spent on what is read.
+  await expect(page.getByTestId('inspector-feedback')).toHaveCount(0)
+  await expect(page.getByTestId('inspector-risks')).toHaveCount(0)
+  await expect(page.getByTestId('diff-groups')).toBeVisible()
+
+  const after = {
+    architecture: (await architecture.boundingBox())?.width ?? 0,
+    inspector: (await inspector.boundingBox())?.width ?? 0,
+  }
+
+  expect(
+    after.inspector,
+    'deep focus must enlarge the reading area',
+  ).toBeGreaterThan(before.inspector)
+  expect(
+    after.architecture,
+    'the architecture context must stay visible in deep focus',
+  ).toBeGreaterThan(600)
+  await expect(page.getByTestId('architecture-canvas')).toBeVisible()
+  await expect(page.getByTestId(`canvas-node-${TAX}`)).toBeVisible()
+
+  // The run pane folded into its rail rather than disappearing without a way back.
+  await expect(page.getByTestId('pane-rail-left')).toBeVisible()
+
+  // Escape leaves the mode: an enlarging layout must never trap.
+  await page.keyboard.press('Escape')
+  await expect(page.getByTestId('deep-focus-banner')).toHaveCount(0)
+  await expect(page.getByTestId('inspector-feedback')).toBeVisible()
+
+  const restored = {
+    architecture: (await architecture.boundingBox())?.width ?? 0,
+    inspector: (await inspector.boundingBox())?.width ?? 0,
+  }
+  expect(Math.abs(restored.architecture - before.architecture)).toBeLessThan(4)
+  expect(Math.abs(restored.inspector - before.inspector)).toBeLessThan(4)
+})

--- a/e2e/tests/07-sse-replay.spec.ts
+++ b/e2e/tests/07-sse-replay.spec.ts
@@ -1,0 +1,195 @@
+import { expect, test } from '@playwright/test'
+
+import { asAccepted, bootstrapEvent, postEvent, streamUrl } from '../src/api.js'
+import {
+  REPLAY_BOOTSTRAP_AGENT,
+  REPLAY_BOOTSTRAP_RUN,
+  REPLAY_PROJECT,
+} from '../src/config.js'
+import { SseRecorder } from '../src/sse.js'
+import { startSimulator } from '../src/simulator.js'
+
+/**
+ * Mandatory check 7 — a forced SSE disconnect, and a replay from the last
+ * project position that arrives gapless, ordered and without a duplicate.
+ *
+ * **This check is trivially easy to write as a vacuum, and the guards below are
+ * the point of the file.** The failure mode is concrete: a stream opened for a
+ * project that does not exist yet is answered `404`, no frame ever arrives, the
+ * cut lands at `0`, and "no gaps, no duplicates, ascending" is then true of the
+ * empty sequence. Everything is green and nothing was tested.
+ *
+ * Four guards make that impossible:
+ *
+ * 1. both connections must have answered **HTTP 200**,
+ * 2. both must have carried **real traffic** (at least one frame each),
+ * 3. the cut must lie **strictly inside** the sequence: `0 < cut < endPosition`,
+ * 4. the union must cover the run **completely**, from position 1 to the
+ *    `endPosition` the server itself assigned — which comes from the simulator's
+ *    `--json` summary, not from what the stream happened to deliver.
+ *
+ * The cut is made **while the simulator is still running**, so the second
+ * connection has to do both halves of the job: replay what it missed from the
+ * log, then continue live.
+ */
+
+const BOOTSTRAP_ID = '33333333-0000-4000-8000-000000000001'
+
+/** Frames to collect before cutting. Well inside a 62-event run. */
+const FRAMES_BEFORE_CUT = 8
+
+test('7 · a forced disconnect replays from the last position, gapless, ordered and without duplicates', async () => {
+  // ---- open the project so the stream is not answered 404 -----------------
+  const opened = await postEvent(
+    bootstrapEvent({
+      clientEventId: BOOTSTRAP_ID,
+      projectId: REPLAY_PROJECT,
+      runId: REPLAY_BOOTSTRAP_RUN,
+      agentId: REPLAY_BOOTSTRAP_AGENT,
+      displayName: 'Replay probe bootstrap',
+      assignedTask: 'Open the project so the replay probe can subscribe from position 0.',
+    }),
+  )
+  expect(opened.status, JSON.stringify(opened.body)).toBe(201)
+  expect(asAccepted(opened).position).toBe(1)
+
+  // `lastEventPosition=0` means "replay everything", so the first connection
+  // starts at position 1 and the union below can be checked against the whole
+  // project rather than against an arbitrary tail.
+  const first = new SseRecorder(streamUrl(REPLAY_PROJECT, 0))
+  expect(
+    await first.open(),
+    'the first stream must be a real 200, not a 404 for a project that does not exist',
+  ).toBe(200)
+  await first.waitForCount(1)
+
+  const simulator = startSimulator({ scenario: 'full', projectId: REPLAY_PROJECT, speed: 1 })
+
+  // ---- cut in the middle of the running simulator -------------------------
+  await first.waitForCount(FRAMES_BEFORE_CUT)
+  // The cut is read *after* the abort completed, never before: a frame that
+  // arrives between reading the cursor and closing the socket would otherwise
+  // be counted as received and requested again, which would look like a
+  // duplicate the server never produced.
+  await first.abort()
+
+  const firstPositions = [...first.positions]
+  const cut = firstPositions.at(-1) ?? 0
+
+  // ---- resume from exactly where the cut happened -------------------------
+  const second = new SseRecorder(streamUrl(REPLAY_PROJECT, cut))
+  expect(await second.open(), 'the resumed stream must answer 200').toBe(200)
+
+  const summary = await simulator.done
+  expect(summary.projectId).toBe(REPLAY_PROJECT)
+  expect(summary.conflicts).toBe(0)
+  expect(summary.duplicates).toBe(0)
+  expect(summary.created).toBe(summary.eventsSent)
+
+  const endPosition = summary.endPosition
+  await second.waitForPosition(endPosition)
+  await second.abort()
+
+  const secondPositions = [...second.positions]
+
+  // ---- guard 1: both connections were real --------------------------------
+  expect(first.status).toBe(200)
+  expect(second.status).toBe(200)
+  expect(first.error ?? null).toBeNull()
+  expect(second.error ?? null).toBeNull()
+
+  // ---- guard 2: both carried traffic --------------------------------------
+  expect(
+    firstPositions.length,
+    'the first connection carried no events — nothing was cut',
+  ).toBeGreaterThanOrEqual(FRAMES_BEFORE_CUT)
+  expect(
+    secondPositions.length,
+    'the resumed connection carried no events — nothing was replayed',
+  ).toBeGreaterThan(0)
+
+  // ---- guard 3: the cut lies strictly inside the sequence -----------------
+  expect(endPosition).toBe(summary.eventsSent + 1)
+  expect(cut, 'the cut must not be at the very beginning').toBeGreaterThan(0)
+  expect(cut, 'the cut must not be at or beyond the end of the run').toBeLessThan(
+    endPosition,
+  )
+
+  // ---- guard 4: the union is the complete run, exactly once each ----------
+  const combined = [...firstPositions, ...secondPositions]
+  const expected = Array.from({ length: endPosition }, (_, index) => index + 1)
+
+  expect(
+    [...new Set(combined)].sort((a, b) => a - b),
+    'the two connections together must cover every position of the project',
+  ).toEqual(expected)
+
+  const duplicates = combined.filter(
+    (position, index) => combined.indexOf(position) !== index,
+  )
+  expect(duplicates, 'a position was delivered twice across the reconnect').toEqual([])
+  expect(combined).toHaveLength(endPosition)
+
+  // Ordered within each connection, and the seam is exactly the cut.
+  expectStrictlyAscending(firstPositions, 'first connection')
+  expectStrictlyAscending(secondPositions, 'resumed connection')
+  expect(firstPositions[0]).toBe(1)
+  expect(firstPositions.at(-1)).toBe(cut)
+  expect(
+    secondPositions[0],
+    'the resumed stream must continue at the position after the cut',
+  ).toBe(cut + 1)
+  expect(secondPositions.at(-1)).toBe(endPosition)
+
+  // The frames are self-consistent: the SSE `id:` is the project position the
+  // payload carries, for the replayed half as well as for the live half.
+  for (const frame of [...first.frames, ...second.frames]) {
+    expect(frame.payloadPosition).toBe(frame.position)
+    expect(frame.projectId).toBe(REPLAY_PROJECT)
+    expect(frame.type).not.toBe('')
+  }
+
+  // The replayed half is not a special case of the live half: the resumed
+  // connection had to serve both, which is only true if the cut happened while
+  // the simulator was still sending.
+  const replayedAfterCut = summary.events.filter(
+    (event) => event.position !== null && event.position > cut,
+  ).length
+  expect(replayedAfterCut).toBeGreaterThan(0)
+})
+
+test('7 · a cursor the project has not reached yet does not produce a silent stream', async () => {
+  // ADR 0006: a cursor beyond the end of the log is clamped to the current end
+  // rather than filtering everything away, because a working-but-silent stream
+  // is the worst failure mode for an observability tool.
+  const recorder = new SseRecorder(streamUrl(REPLAY_PROJECT, 10_000_000))
+  expect(await recorder.open()).toBe(200)
+
+  const probe = await postEvent({
+    schemaVersion: '1.0',
+    clientEventId: '33333333-0000-4000-8000-000000000002',
+    projectId: REPLAY_PROJECT,
+    runId: REPLAY_BOOTSTRAP_RUN,
+    agentId: REPLAY_BOOTSTRAP_AGENT,
+    parentAgentId: null,
+    occurredAt: '2026-08-04T12:00:00Z',
+    type: 'agent.status_reported',
+    payload: { status: 'idle', note: 'Probe after an over-long cursor.' },
+  })
+  expect(probe.status, JSON.stringify(probe.body)).toBe(201)
+  const probePosition = asAccepted(probe).position
+
+  await recorder.waitForPosition(probePosition, 30_000)
+  await recorder.abort()
+
+  expect(recorder.positions).toContain(probePosition)
+})
+
+function expectStrictlyAscending(positions: readonly number[], label: string): void {
+  for (let index = 1; index < positions.length; index += 1) {
+    expect(
+      positions[index] as number,
+      `${label}: position ${String(positions[index])} arrived after ${String(positions[index - 1])}`,
+    ).toBeGreaterThan(positions[index - 1] as number)
+  }
+}

--- a/e2e/tests/08-viewport.spec.ts
+++ b/e2e/tests/08-viewport.spec.ts
@@ -1,0 +1,220 @@
+import { expect, test } from '@playwright/test'
+
+import { ACCEPTANCE_VIEWPORT, MAIN_PROJECT, MAIN_RUN } from '../src/config.js'
+import { formatControlReports, probeControls, type ControlProbe } from '../src/controls.js'
+
+/**
+ * Mandatory check 8 — no unintended horizontal page scrollbar and no covered
+ * primary control at 1920 × 1080.
+ *
+ * "Not covered" is asked of the browser, not of the DOM: every control below has
+ * to be rendered, lie inside the viewport, and be the element `elementFromPoint`
+ * finds at its own centre. Existence in the DOM proves nothing — a pane that
+ * overlaps a toolbar, or a control pushed past the right edge, still exists.
+ */
+
+const CONTROLS: ControlProbe[] = [
+  { name: 'run selection (current run)', selector: `[data-testid="run-option-${MAIN_RUN}"]` },
+  { name: 'agent filter', selector: 'input[aria-label="Agents filtern"]' },
+  { name: 'pane toggle · run pane', selector: 'button[aria-label="Run- und Agent-Bereich"]' },
+  { name: 'pane toggle · inspector', selector: 'button[aria-label="Inspector"]' },
+  { name: 'canvas control · fit view', selector: '[data-testid="canvas-fit-view"]' },
+  { name: 'canvas control · minimap toggle', selector: '[data-testid="canvas-toggle-minimap"]' },
+  { name: 'canvas control · zoom in', selector: '.react-flow__controls-zoomin' },
+  { name: 'canvas control · zoom out', selector: '.react-flow__controls-zoomout' },
+  { name: 'inspector tab · current run', selector: '[role="tab"][aria-selected="true"]' },
+  { name: 'inspector tab · history', selector: '[role="tab"][aria-selected="false"]' },
+  { name: 'live connection badge', selector: '[data-testid="live-connection-state"]' },
+]
+
+test('8 · the page has no horizontal scrollbar and every primary control is operable', async ({
+  page,
+}) => {
+  await page.goto(
+    `/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}?component=${encodeURIComponent(
+      'shop-platform.orders.domain.tax',
+    )}`,
+  )
+  await expect(page.getByTestId('architecture-canvas')).toBeVisible()
+  await expect(page.getByTestId('diff-groups')).toBeVisible()
+  await expect(page.getByTestId('architecture-canvas')).toHaveAttribute(
+    'data-layouting',
+    'false',
+  )
+
+  // ---- the mandatory acceptance resolution --------------------------------
+  const geometry = await page.evaluate(() => ({
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
+    documentScrollWidth: document.documentElement.scrollWidth,
+    documentClientWidth: document.documentElement.clientWidth,
+    documentClientHeight: document.documentElement.clientHeight,
+    bodyScrollWidth: document.body.scrollWidth,
+    bodyClientWidth: document.body.clientWidth,
+    bodyScrollHeight: document.body.scrollHeight,
+    bodyClientHeight: document.body.clientHeight,
+    rootHeight: Math.round(
+      document.getElementById('root')?.getBoundingClientRect().height ?? -1,
+    ),
+  }))
+
+  expect(geometry.innerWidth).toBe(ACCEPTANCE_VIEWPORT.width)
+  expect(geometry.innerHeight).toBe(ACCEPTANCE_VIEWPORT.height)
+
+  // The criterion of issue #14, verbatim.
+  expect(
+    geometry.documentScrollWidth,
+    'the page must not scroll horizontally at 1920 × 1080',
+  ).toBe(geometry.documentClientWidth)
+  expect(geometry.bodyScrollWidth).toBe(geometry.bodyClientWidth)
+
+  // A vertical scrollbar would take width away from the layout and reintroduce
+  // the horizontal one, so the page must not scroll at all: the shell is exactly
+  // one viewport tall and every pane owns its own scroll region.
+  expect(geometry.bodyScrollHeight).toBe(geometry.bodyClientHeight)
+  expect(geometry.rootHeight).toBe(ACCEPTANCE_VIEWPORT.height)
+  expect(geometry.documentClientWidth).toBe(ACCEPTANCE_VIEWPORT.width)
+  expect(geometry.documentClientHeight).toBe(ACCEPTANCE_VIEWPORT.height)
+
+  // Nothing sticks out beyond the right edge, which is what would produce the
+  // scrollbar in the first place.
+  // Wide content is allowed — inside its own clipping or scrolling container.
+  // A diff box, a markdown table and the React Flow canvas all extend past
+  // their box on purpose. What must never happen is content sticking out of
+  // the *page*, which is what would produce the scrollbar.
+  const overflowing = await page.evaluate((limit) => {
+    const containedByItsOwnScroller = (element: Element): boolean => {
+      let ancestor = element.parentElement
+      while (ancestor !== null && ancestor !== document.body) {
+        const style = window.getComputedStyle(ancestor)
+        if (style.overflowX !== 'visible' || style.overflow !== 'visible') {
+          if (ancestor.getBoundingClientRect().right <= limit + 1) return true
+        }
+        ancestor = ancestor.parentElement
+      }
+      return false
+    }
+
+    const offenders: string[] = []
+    for (const element of Array.from(document.body.querySelectorAll('*'))) {
+      const rect = element.getBoundingClientRect()
+      if (rect.width === 0 || rect.height === 0) continue
+      if (rect.right <= limit + 1) continue
+      if (containedByItsOwnScroller(element)) continue
+      const testId = element.getAttribute('data-testid')
+      offenders.push(
+        `${element.tagName.toLowerCase()}${testId === null ? '' : `[${testId}]`} right=${Math.round(rect.right)}`,
+      )
+    }
+    return offenders.slice(0, 12)
+  }, ACCEPTANCE_VIEWPORT.width)
+  expect(
+    overflowing,
+    'element extends past the right edge of the viewport without a clipping container',
+  ).toEqual([])
+
+  // ---- the primary controls ----------------------------------------------
+  const reports = await probeControls(page, CONTROLS)
+  const broken = reports.filter(
+    (report) => !report.found || !report.rendered || !report.insideViewport || !report.unobstructed,
+  )
+  expect(
+    broken.length === 0,
+    `primary controls are not operable:\n${formatControlReports(reports)}`,
+  ).toBe(true)
+})
+
+test('8 · content below the fold is reachable inside its own pane, not by scrolling the page', async ({
+  page,
+}) => {
+  await page.goto(
+    `/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}?component=${encodeURIComponent(
+      'shop-platform.orders.domain.tax',
+    )}`,
+  )
+  await expect(page.getByTestId('agent-row-subagent-reviewer')).toBeVisible()
+  await expect(page.getByTestId('diff-groups')).toBeVisible()
+
+  // Both side panes have more content than height — otherwise this test would
+  // pass without there being anything below a fold.
+  const regions = await page.evaluate(() => {
+    const read = (element: Element | null) =>
+      element === null
+        ? null
+        : { clientHeight: element.clientHeight, scrollHeight: element.scrollHeight }
+    return {
+      runPane: read(document.querySelector('[data-slot="scroll-area-viewport"]')),
+      inspector: read(document.querySelector('[data-testid="inspector-scroll"]')),
+    }
+  })
+  expect(regions.runPane).not.toBeNull()
+  expect(regions.inspector).not.toBeNull()
+  expect(regions.runPane!.scrollHeight).toBeGreaterThan(regions.runPane!.clientHeight)
+  expect(regions.inspector!.scrollHeight).toBeGreaterThan(regions.inspector!.clientHeight)
+
+  // The deepest agent row starts below the fold and is brought into view by
+  // scrolling the pane — the page itself stays where it is.
+  const before = await page.getByTestId('agent-row-subagent-reviewer').boundingBox()
+  expect(before).not.toBeNull()
+  expect(
+    before!.y + before!.height,
+    'the deepest agent row is expected to start below the fold',
+  ).toBeGreaterThan(ACCEPTANCE_VIEWPORT.height)
+
+  await page.getByTestId('agent-row-subagent-reviewer').scrollIntoViewIfNeeded()
+  const after = await page.getByTestId('agent-row-subagent-reviewer').boundingBox()
+  expect(after).not.toBeNull()
+  expect(after!.y).toBeLessThan(ACCEPTANCE_VIEWPORT.height - 100)
+
+  const pageOffset = await page.evaluate(() => ({
+    x: window.scrollX,
+    y: window.scrollY,
+  }))
+  expect(pageOffset).toEqual({ x: 0, y: 0 })
+
+  const reports = await probeControls(page, [
+    {
+      name: 'deepest agent row after scrolling its pane',
+      selector: '[data-testid="agent-row-subagent-reviewer"]',
+    },
+  ])
+  expect(
+    reports.every((report) => report.rendered && report.insideViewport && report.unobstructed),
+    `the deepest agent row is not reachable:\n${formatControlReports(reports)}`,
+  ).toBe(true)
+})
+
+test('8 · collapsing and reopening the side panes never produces a scrollbar either', async ({
+  page,
+}) => {
+  await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
+  await expect(page.getByTestId('architecture-canvas')).toBeVisible()
+
+  const scrolls = async (): Promise<boolean> =>
+    page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    )
+
+  await page.getByRole('button', { name: 'Run- und Agent-Bereich' }).click()
+  await expect(page.getByTestId('pane-rail-left')).toBeVisible()
+  expect(await scrolls()).toBe(false)
+
+  await page.getByRole('button', { name: 'Inspector' }).click()
+  await expect(page.getByTestId('pane-rail-right')).toBeVisible()
+  expect(await scrolls()).toBe(false)
+  // The expand controls of both rails stay reachable.
+  const rails = await probeControls(page, [
+    { name: 'left rail expand', selector: '[data-testid="pane-rail-left"] button' },
+    { name: 'right rail expand', selector: '[data-testid="pane-rail-right"] button' },
+  ])
+  expect(
+    rails.every((report) => report.rendered && report.insideViewport && report.unobstructed),
+    `collapsed rails are not operable:\n${formatControlReports(rails)}`,
+  ).toBe(true)
+
+  await page.locator('[data-testid="pane-rail-left"] button').click()
+  await page.locator('[data-testid="pane-rail-right"] button').click()
+  await expect(page.getByTestId('pane-run-agents')).toBeVisible()
+  await expect(page.getByTestId('pane-inspector')).toBeVisible()
+  expect(await scrolls()).toBe(false)
+})

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "tests", "playwright.config.ts"]
+}


### PR DESCRIPTION
Setzt #14 um: den verpflichtenden Playwright-End-to-End-Abnahmetest, das Freigabe-Gate des gesamten v0-Epics.

## Was drin ist

| Pfad | Inhalt |
| --- | --- |
| `e2e/` | Eigenes npm-Paket: Playwright-Konfiguration, Compose-Lebenszyklus, Simulator-Treiber, roher SSE-Leser, In-Page-Live-Observer, acht Spec-Dateien |
| `.github/workflows/e2e.yml` | Die Abnahme auf Ubuntu, Chromium, `FRONTEND_HTTP_PORT=8080`, Report als Artefakt |
| `.github/workflows/ci.yml` | Die schnellen Suiten — das Repository hatte bisher **kein** CI |
| `docs/decisions/0013-mandatory-end-to-end-acceptance.md` | Warum nur Chromium bei 1920 × 1080, warum gegen das echte System, warum live beobachtet, wie die Vakuum-Guards wirken |
| `e2e/README.md` | Aufruf, Konfiguration, Aufbau — der Link, den `docs/operations.md` bereits setzt |
| `README.md`, `docs/operations.md` | Kurzer Verweis; in `operations.md` entfällt der Hinweis, dass `e2e/` noch nicht existiert |

Nichts unter `backend/`, `frontend/`, `api/` oder `simulator/` wurde angefasst.

## Testaufbau

`globalSetup`: `docker compose -p vai-e2e down -v` → `up --build -d` → warten auf `/readyz` **über Nginx**. `globalTeardown`: `down -v`. Der Start aus leerer Datenbank ist Pflicht — die Simulator-Szenarien behaupten `201 created`, gegen eine gefüllte Datenbank wäre die erste Zustellung legitim ein Duplikat.

Chromium, ein Projekt, `viewport: 1920 × 1080`, ein Worker, **`retries: 0`**. Firefox, WebKit, Mobile und Tablet sind nicht konfiguriert.

Port und Compose-Projektname sind Umgebungsvariablen: `FRONTEND_HTTP_PORT` (Default **8100**, weil 8080–8083 lokal belegt sind) und `E2E_COMPOSE_PROJECT` (Default `vai-e2e`). CI setzt 8080 und hält damit auch den dokumentierten Standardport unter Test. Der eigene Projektname ist der wichtigere der beiden: ohne ihn würde `down -v` das Volume eines Entwicklungs-Stacks löschen.

Ein Kommando aus leerem Checkout:

```
cd e2e && npm install && npx playwright install chromium && npm test
```

## Echter, vollständiger Lauf

Lokal, Windows 11, Docker 29.5.3, aus leerer Datenbank, `FRONTEND_HTTP_PORT=8100`:

```
> visualise-ai-e2e@0.0.0 test
> playwright test

[e2e] compose project vai-e2e, frontend on port 8100, base http://localhost:8100
[e2e] docker compose down -v (start from an empty database)
[e2e] docker compose up --build -d
[e2e] deployment ready after 21.5 s

Running 20 tests using 1 worker

  ok  1 [chromium-1920x1080] › tests\01-ingestion.spec.ts:67:1 › 1 · a refused event occupies no position, a retry repeats it, a conflict is rejected (71ms)
  ok  2 [chromium-1920x1080] › tests\01-ingestion.spec.ts:130:1 › 1 · the simulator retry and conflict scenarios answer as the contract promises (1.0s)
  ok  3 [chromium-1920x1080] › tests\01-ingestion.spec.ts:158:1 › 1 · the projections show the accepted content and nothing that was refused (1.9s)
  ok  4 [chromium-1920x1080] › tests\02-live-updates.spec.ts:40:1 › 3 · every live change state is observed while the run is happening (30.6s)
  ok  5 [chromium-1920x1080] › tests\02-live-updates.spec.ts:163:1 › 3 · after a reload the watched states start empty again — which is why they had to be watched (665ms)
  ok  6 [chromium-1920x1080] › tests\03-architecture.spec.ts:77:1 › 2 · the canvas draws the reported hierarchy across four nesting levels (859ms)
  ok  7 [chromium-1920x1080] › tests\03-architecture.spec.ts:132:1 › 2 · every relationship kind is drawn, and every reported NATS topic stays individually identifiable (1.2s)
  ok  8 [chromium-1920x1080] › tests\04-run-agents.spec.ts:37:1 › 4 · the tree is three levels deep with two subagents running in parallel below one parent (673ms)
  ok  9 [chromium-1920x1080] › tests\04-run-agents.spec.ts:99:1 › 4 · an overall estimate and a counted subagent progress are told apart by shape, not colour (698ms)
  ok 10 [chromium-1920x1080] › tests\05-inspector.spec.ts:25:1 › 5 · clicking a component shows its agent, task, markdown feedback and grouped diffs (949ms)
  ok 11 [chromium-1920x1080] › tests\05-inspector.spec.ts:110:1 › 5 · a diff reported without a changeId stays its own entry (655ms)
  ok 12 [chromium-1920x1080] › tests\05-inspector.spec.ts:127:1 › 5 · the rendered feedback contains no active element (654ms)
  ok 13 [chromium-1920x1080] › tests\06-run-history-focus.spec.ts:28:1 › 6 · the history is its own tab and never mixes into the current run (904ms)
  ok 14 [chromium-1920x1080] › tests\06-run-history-focus.spec.ts:68:1 › 6 · a historical run is a different URL and never overlays the current one (817ms)
  ok 15 [chromium-1920x1080] › tests\06-run-history-focus.spec.ts:99:1 › 6 · deep focus enlarges the inspector while the architecture stays on screen (940ms)
  ok 16 [chromium-1920x1080] › tests\07-sse-replay.spec.ts:41:1 › 7 · a forced disconnect replays from the last position, gapless, ordered and without duplicates (30.2s)
  ok 17 [chromium-1920x1080] › tests\07-sse-replay.spec.ts:161:1 › 7 · a cursor the project has not reached yet does not produce a silent stream (47ms)
  ok 18 [chromium-1920x1080] › tests\08-viewport.spec.ts:30:1 › 8 · the page has no horizontal scrollbar and every primary control is operable (778ms)
  ok 19 [chromium-1920x1080] › tests\08-viewport.spec.ts:127:1 › 8 · content below the fold is reachable inside its own pane, not by scrolling the page (739ms)
  ok 20 [chromium-1920x1080] › tests\08-viewport.spec.ts:187:1 › 8 · collapsing and reopening the side panes never produces a scrollbar either (773ms)

[e2e] docker compose down -v

  20 passed (1.7m)
```

## Wie die acht Prüfungen abgedeckt und gegen Vakuum abgesichert sind

**1 · Eventvalidierung, Idempotenz, beobachtbare Projektionen.** Ein schemaungültiges Event (`status: "exploded"`) antwortet `400 invalid_field`, ein Lifecycle-Verstoß (Agent ohne `agent.started`) `422 unknown_agent`. *Belegt keine Position* wird nicht behauptet, sondern gemessen: das nächste akzeptierte Event bekommt Position `2`, nicht `4`. Der byte-identische Retry antwortet `200 duplicate: true` mit derselben Position, ein abweichender Payload unter demselben Key `409 client_event_id_conflict`. Dazu die Simulator-Szenarien `retry` (2 created, 1 duplicate, `endPosition` 2, gleiche Position) und `conflict` (1 conflict, `position: null`). Beobachtbar in der UI: das Konfliktprojekt zeigt `data-status="working"` mit „Original content.", **nicht** `blocked` aus dem abgelehnten Payload, und das Validierungsprojekt hat genau eine Agentzeile — der abgelehnte Agent taucht nirgends auf.

**2 · Architekturcanvas.** Vier Hierarchieebenen werden **geometrisch** nachgewiesen: die Bounding-Box jeder Ebene liegt in der der darüberliegenden (`shop-platform` ⊃ `orders` ⊃ `domain` ⊃ `pricing`). `data-node-count=17`, `data-edge-count=11`. Alle sechs Beziehungstypen sind gezeichnet, mit sechs paarweise verschiedenen `stroke-dasharray`-Werten. Für die Topics wird auf `data-detail-level="full"` gezoomt und jede der fünf `nats_topic`-Beziehungen einzeln über ihre `relationshipId` adressiert; ihr Badge trägt den `channel`, der Titel `Kanal: …`. Gezählt: drei Mal `orders.order.created`, zwei Mal `inventory.item.reserved`. Gegen-Vakuum: die Read API muss dieselben elf Beziehungen einzeln liefern, und die Zahl gefalteter Sammelkanten muss **0** sein — eine gefaltete Kante auf der höchsten Detailstufe würde Beziehungen verstecken.

**3 · Live-SSE-Zustände.** Die Seite ist **vor dem ersten gemeldeten Event** offen und das Badge steht auf `live` — dafür öffnet der Test das Projekt mit einem eigenen Bootstrap-Run, sonst antwortet der Stream `404` und der Client würde mit Backoff gegen den Lauf rennen. Der Simulator läuft mit `--speed 1`, also mit Pausen. Ein per `addInitScript` injizierter Observer hält die Maxima aller vier Zähler und jede jemals gerenderte Overlay-Marke fest (MutationObserver plus 50-ms-Backstop, deutlich unter den 150-ms-Übergängen). Geprüft wird strukturell, nie über Farbe: geplante Entfernung = `data-work-state="planned"`, Label `geplant`, Rahmen `dashed`, Text enthält `entfernen`; angewandte Entfernung = `data-work-state="removed"`, Label `entfernt`, Rahmen `dotted`. Zusätzlich der Geist der entfernten Komponente auf dem Canvas. **Gegen-Vakuum, zweifach:** vor dem Lauf ist die Summe aller vier Zähler `0`, und nach einem Reload sind `aktiv`, `kürzlich angewandt` und `entfernt` wieder `0`, während `geplant` (aus `activeChanges`) bleibt. Wären die Assertions oben auch ohne Livebeobachtung erfüllbar, müsste dieser Test fehlschlagen.

**4 · Run-/Agentbaum.** Fünf Agents, `data-max-depth=2` (drei Ebenen), Reviewer und Test Engineer beide auf Tiefe 2 mit dem Implementer als Parent — die Elternbeziehung zusätzlich über die Read API. Fortschritt strukturell: Orchestrator `data-progress-form="claim"`, `scope="overall_estimate"`, **kein** `role="progressbar"`, keine Segmente, `≈`, „Kein gemessener Fortschritt"; Test Engineer `data-progress-form="counted"`, genau ein `role="progressbar"` mit `aria-valuenow=100`, zehn Segmente, kein `≈`. Zusätzlich: keines der beiden Elemente enthält das andere und beide liegen in verschiedenen `data-progress-group`s.

**5 · Komponentenklick.** Klick auf `…domain.tax` setzt `?component=` in der URL. Inspector: verantwortlicher Agent (`data-agent-id="subagent-test-engineer"`, aus dem jüngsten Arbeitsschritt belegt), Aufgabe, Status, Arbeitsschritt. Gerendertes Markdown mit Überschriften, geordneter Liste und Codeblock. Diffs: **eine** Gruppe mit `data-change-id="change-2026-08-04-0007"` und `data-file-count="3"` samt der drei erwarteten Dateipfade; ein Diff ohne `changeId` bleibt in einer eigenen Gruppe (`data-change-id=""`, ein File). „Kein aktives Element": der Test fragt den DOM ab — nichts Fokussierbares, nichts das ausführt oder lädt, kein Inline-Handler —, mit Guard, dass überhaupt gerendertes Markdown zu prüfen war.

**6 · Aktueller Run, Historie, Deep Focus.** Historie ist ein eigener Tab; beim Umschalten verschwinden `inspector-current-run`, `diff-groups`, `feedback-entries` und `inspector-risks` vollständig aus dem DOM — nichts mischt sich. Historischer Run: Navigation auf den Bootstrap-Run zeigt das Banner mit dem Weg zurück, genau eine Agentzeile, und `orchestrator-root` ist nicht da. Deep Focus: **beide** Breiten werden gemessen — der Inspector wächst, die Architektur bleibt über 600 px und der ausgewählte Knoten sichtbar; Escape stellt beide Breiten auf ±4 px wieder her.

**7 · Erzwungener SSE-Abbruch.** Eigenes Projekt, eigener Simulatorlauf. Erste Verbindung mit `lastEventPosition=0`, Abbruch **mitten im laufenden Simulator** nach acht Frames, Wiederverbindung ab dem Schnitt. Vier Guards, genau gegen den beschriebenen Vakuumfall: (1) beide Verbindungen HTTP **200** — ein `404` für ein noch nicht existierendes Projekt scheitert sofort; (2) beide mit echtem Verkehr; (3) `0 < cut < endPosition`, mit `endPosition` aus der `--json`-Zusammenfassung des Simulators, also vom Server vergeben; (4) die Vereinigung ist exakt `1 … endPosition`, jede Position genau einmal, innerhalb jeder Hälfte streng aufsteigend, Naht exakt `cut` / `cut + 1`. Zusätzlich: SSE-`id:` und `position` im Payload stimmen in beiden Hälften überein, und nach dem Schnitt wurden nachweislich noch Events angehängt — die zweite Verbindung musste also Replay **und** Live leisten. Der Cursor wird bewusst **nach** dem Abbruch gelesen; davor wäre ein zwischenzeitlich eintreffendes Frame als empfangen *und* erneut angefordert gezählt worden.

**8 · Keine Scrollbar, keine verdeckte Steuerung.** `document.documentElement.scrollWidth === clientWidth` bei geprüften 1920 × 1080, dazu `body.scrollHeight === body.clientHeight` und `#root` exakt 1080 px hoch. Elemente, die über die rechte Kante ragen, werden aufgezählt — erlaubt ist nur, was in einem eigenen clippenden oder scrollenden Container sitzt. Elf Primärbedienelemente (Run-Auswahl, Agentfilter, beide Pane-Umschalter, vier Canvas-Controls, beide Inspector-Tabs, Live-Badge) werden über `elementFromPoint` in ihrem eigenen Mittelpunkt geprüft: gerendert, vollständig im Viewport, nicht überdeckt. Dasselbe für die Ausklapp-Controls beider eingeklappter Rails. Zusätzlich: Inhalt unterhalb der Falz ist im **eigenen** Pane erreichbar, `window.scrollX/Y` bleiben `0`.

## Determinismus

`retries: 0`, ein Worker, nummerierte Dateien. Keine festen `waitForTimeout` als Synchronisationsmittel — gewartet wird mit Playwright-Erwartungen, `expect.poll` oder auf Werte, die das System selbst veröffentlicht (`--json`-Zusammenfassung, `data-*`-Attribute, Verbindungs-Badge). Der Simulator ist geseedet, deshalb nennen die Assertions exakte Zahlen.

## Gefundene Produktfehler

**Keine.** Alle acht Prüfungen bestehen gegen den unveränderten Stand von `main`. Zwei Beobachtungen, die den Testaufbau geprägt haben und in ADR 0013 festgehalten sind:

1. **Im repräsentativen Modell existiert keine gefaltete Sammelkante.** Gebündelt wird nach *geordnetem Knotenpaar* (ADR 0008); die drei `orders.order.created`-Beziehungen verbinden aber drei verschiedene Paare (`orders → topic`, `topic → inventory`, `topic → notifications`). Sie sind damit bereits je eine eigene Kante — „aufklappen" gibt es hier nichts. Die dahinterliegende Abnahmeeigenschaft ist trotzdem geprüft, und zwar von beiden Seiten: die Read API liefert alle elf Beziehungen einzeln, der Canvas zeigt jede mit eigenem Label und eigenem `channel`, und die Zahl gefalteter Bündel auf der höchsten Detailstufe muss 0 sein. Enthält ein künftiges Modell parallele Beziehungen auf einem Paar, schlägt genau diese Assertion fehl und der Aufklapppfad wird geprüft, statt still übersprungen zu werden.
2. **`document.documentElement.scrollHeight` ist 2663 statt 1080** — aber das ist eine Chromium-Eigenheit der Höhenberechnung über den Radix-`ScrollArea`-Viewport hinweg, keine Scrollbar: `body { overflow: hidden }` propagiert auf den Viewport, `body.scrollHeight === body.clientHeight === 1080`, `#root` ist 1080 px hoch, und beide Panes scrollen nachweislich intern. Der Test misst deshalb `body` und `#root` statt `documentElement` und weist zusätzlich nach, dass Inhalt unterhalb der Falz im eigenen Pane erreichbar ist.

## Abweichungen und offene Risiken

- Der Test öffnet in `visualise-ai` einen zusätzlichen, leeren Bootstrap-Run. Das ist die Voraussetzung dafür, dass die Live-Zustände deterministisch beobachtet statt gehofft werden, und es liefert Prüfung 6 einen echten historischen Run. Beide Bootstrap-Events gehen über Nginx; die repräsentative Sequenz selbst kommt ausschließlich vom Simulator.
- Prüfung 7 nutzt einen zweiten Simulatorlauf in einem eigenen Projekt, damit Schnitt und Positionsarithmetik den Browser-Stream nicht stören und umgekehrt.
- Die Assertions nennen exakte Zahlen (17 Komponenten, 11 Beziehungen, 5 Agents, 3 Dateien). Eine Änderung am Simulatormodell lässt die Abnahme fehlschlagen — beabsichtigt, denn repräsentative Sequenz und Abnahmekriterien sind ein Artefakt.
- `.github/workflows/*` ist neu und in diesem Repository noch nie gelaufen; der erste Lauf auf diesem PR ist zugleich der Beweis. Die Abnahme braucht auf dem Runner Docker, einen Build aller Services und einen Browser — Laufzeit unter 40 Minuten Timeout, lokal 1,7 Minuten plus Build.
- `docs/operations.md` verlor den Satz, dass `e2e/` noch nicht existiert, und bekam zwei Sätze zu Port und Compose-Projektnamen. Das ist die einzige Änderung außerhalb des in #14 zugesagten Bereichs und eine direkte Folge davon, dass dieser PR das Verzeichnis liefert.

Closes #14
