### PR TITLE
Deutsche Pluralformen korrigieren und die Beziehungslegende an das Modell binden

### DIFF
--- a/frontend/src/canvas/ComponentNode.tsx
+++ b/frontend/src/canvas/ComponentNode.tsx
@@ -2,6 +2,7 @@ import { Handle, Position, type NodeProps } from '@xyflow/react'
 import { memo } from 'react'
 
 import { cn } from '@/lib/utils'
+import { COUNT_LABELS, counted } from '@/lib/plural'
 import { WORK_STATE_BY_ID } from '@/state/workStates'
 
 import { ChangeOverlayMark } from './ChangeOverlayMark'
@@ -224,7 +225,7 @@ export const CompoundNode = memo(function CompoundNode({
         )}
         {overlay && <ChangeOverlayMark overlay={overlay} />}
         <span className="text-muted-foreground shrink-0 text-[10px]">
-          {childCount} Kinder
+          {counted(childCount, COUNT_LABELS.child)}
         </span>
         <KindBadge label={kind.label} />
       </div>

--- a/frontend/src/components/workspace/ArchitecturePane.tsx
+++ b/frontend/src/components/workspace/ArchitecturePane.tsx
@@ -39,6 +39,14 @@ export function ArchitecturePane({
   const componentCount = architecture.data?.components.length ?? 0
   const relationshipCount = architecture.data?.relationships.length ?? 0
 
+  // The legend is a key to what is drawn, so it lists only the kinds actually
+  // reported. Deriving it here keeps the legend and the canvas reading from the
+  // same model instead of from the contract's full catalogue.
+  const presentKinds = useMemo(
+    () => [...new Set((architecture.data?.relationships ?? []).map((r) => r.kind))],
+    [architecture.data?.relationships],
+  )
+
   // Kept stable across refetches: TanStack Query's structural sharing returns
   // the same arrays when nothing changed, so the canvas does not re-layout.
   // The overlay travels alongside the applied model, never inside it — a
@@ -107,7 +115,7 @@ export function ArchitecturePane({
       </div>
 
       <div className="border-border bg-card/80 shrink-0 space-y-1.5 border-t px-3 py-2">
-        <RelationshipLegend />
+        <RelationshipLegend kinds={presentKinds} />
         <StatusLegend />
       </div>
     </section>

--- a/frontend/src/components/workspace/InspectorPane.tsx
+++ b/frontend/src/components/workspace/InspectorPane.tsx
@@ -19,6 +19,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { cn } from '@/lib/utils'
+import { COUNT_LABELS, counted } from '@/lib/plural'
 import type { DeepFocusTarget } from '@/routes/searchParams'
 
 export interface InspectorPaneProps {
@@ -202,16 +203,16 @@ export function InspectorPane({
                   {showSecondary && head && (
                     <div className="flex flex-wrap gap-1">
                       <Badge variant="outline" className="text-2xs font-normal">
-                        {head.feedback.length} Feedback
+                        {counted(head.feedback.length, COUNT_LABELS.feedback)}
                       </Badge>
                       <Badge variant="outline" className="text-2xs font-normal">
-                        {diffs.length} Diffs
+                        {counted(diffs.length, COUNT_LABELS.diff)}
                       </Badge>
                       <Badge variant="outline" className="text-2xs font-normal">
-                        {head.risks.length} Risiken
+                        {counted(head.risks.length, COUNT_LABELS.risk)}
                       </Badge>
                       <Badge variant="outline" className="text-2xs font-normal">
-                        {head.problems.length} Probleme
+                        {counted(head.problems.length, COUNT_LABELS.problem)}
                       </Badge>
                     </div>
                   )}

--- a/frontend/src/components/workspace/RelationshipLegend.test.tsx
+++ b/frontend/src/components/workspace/RelationshipLegend.test.tsx
@@ -1,0 +1,66 @@
+import { render as rtlRender, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import type { RelationshipKind } from '@/api/types'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+import { RelationshipLegend } from './RelationshipLegend'
+
+/** The legend uses tooltips, which Radix only renders inside its provider. */
+const render = (ui: ReactElement) =>
+  rtlRender(<TooltipProvider>{ui}</TooltipProvider>)
+
+const ALL_KINDS: RelationshipKind[] = [
+  'http',
+  'grpc',
+  'data',
+  'async',
+  'nats_topic',
+  'dependency',
+]
+
+function renderedKinds(): string[] {
+  return ALL_KINDS.filter((kind) =>
+    screen.queryByTestId(`relationship-legend-${kind}`) !== null,
+  )
+}
+
+describe('relationship legend', () => {
+  it('lists only the kinds the reported model actually contains', () => {
+    render(<RelationshipLegend kinds={['http', 'dependency', 'data', 'async']} />)
+
+    expect(renderedKinds()).toEqual(['http', 'data', 'async', 'dependency'])
+  })
+
+  it('does not offer NATS or gRPC to a project that reports neither', () => {
+    // The cockpit observes; a legend that advertises a message bus nobody
+    // reported sends the reader looking for something that is not there.
+    render(<RelationshipLegend kinds={['http', 'dependency']} />)
+
+    expect(screen.queryByTestId('relationship-legend-nats_topic')).toBeNull()
+    expect(screen.queryByTestId('relationship-legend-grpc')).toBeNull()
+  })
+
+  it('keeps the catalogue order rather than the order of first appearance', () => {
+    render(<RelationshipLegend kinds={['dependency', 'async', 'http']} />)
+
+    expect(renderedKinds()).toEqual(['http', 'async', 'dependency'])
+  })
+
+  it('falls back to the full catalogue while nothing has been reported', () => {
+    render(<RelationshipLegend kinds={[]} />)
+
+    expect(renderedKinds()).toEqual(ALL_KINDS)
+  })
+
+  it('renders every kind with its colour-independent channels', () => {
+    render(<RelationshipLegend kinds={['http', 'nats_topic']} />)
+
+    for (const kind of ['http', 'nats_topic']) {
+      const entry = screen.getByTestId(`relationship-legend-${kind}`)
+      expect(entry.getAttribute('data-dasharray')).toBeTruthy()
+      expect(entry.getAttribute('data-marker')).toBeTruthy()
+    }
+  })
+})

--- a/frontend/src/components/workspace/RelationshipLegend.tsx
+++ b/frontend/src/components/workspace/RelationshipLegend.tsx
@@ -1,16 +1,39 @@
+import type { RelationshipKind } from '@/api/types'
 import { RELATIONSHIP_KIND_STYLES } from '@/canvas/relationshipKinds'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 /**
- * Legend for the six relationship kinds of the contract.
+ * Legend for the relationship kinds the canvas is currently drawing.
  *
  * The canvas encodes a kind through its stroke pattern, its arrow head and a
  * text badge — never through colour, because the accent hues belong to the work
  * states. This legend shows exactly those three channels, so it stays readable
  * in greyscale and matches what is drawn on the canvas one for one.
+ *
+ * It lists only the kinds actually present in the reported model. A legend is a
+ * key to what is on screen, not a catalogue of what the contract can express:
+ * showing `NATS` and `gRPC` for a project that reports neither invites the
+ * reader to look for something that is not there.
  */
-export function RelationshipLegend({ className }: { className?: string }) {
+export function RelationshipLegend({
+  className,
+  kinds,
+}: {
+  className?: string
+  /**
+   * Kinds present in the current model. Omitted or empty falls back to the full
+   * catalogue, which is the honest answer while nothing has been reported yet.
+   */
+  kinds?: readonly RelationshipKind[]
+}) {
+  const present = kinds && kinds.length > 0 ? new Set(kinds) : null
+  const styles = present
+    ? RELATIONSHIP_KIND_STYLES.filter((style) => present.has(style.id))
+    : RELATIONSHIP_KIND_STYLES
+
+  if (styles.length === 0) return null
+
   return (
     <div className={cn('flex flex-wrap items-center gap-x-4 gap-y-1.5', className)}>
       <span className="pane-heading">Beziehungsarten</span>
@@ -18,7 +41,7 @@ export function RelationshipLegend({ className }: { className?: string }) {
         className="flex flex-wrap items-center gap-x-4 gap-y-1.5"
         data-testid="relationship-legend"
       >
-        {RELATIONSHIP_KIND_STYLES.map((style) => (
+        {styles.map((style) => (
           <li key={style.id}>
             <Tooltip>
               <TooltipTrigger asChild>

--- a/frontend/src/components/workspace/RunAgentPane.tsx
+++ b/frontend/src/components/workspace/RunAgentPane.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/collapsible'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
+import { COUNT_LABELS, counted } from '@/lib/plural'
 
 export interface RunAgentPaneProps {
   projectId: ProjectId
@@ -136,8 +137,9 @@ export function RunAgentPane({ projectId, runId }: RunAgentPaneProps) {
                       </span>
                     </Row>
                     <Row label="Umfang">
-                      {run.data.run.counts.agents} Agents · {run.data.run.counts.plans}{' '}
-                      Pläne · {run.data.run.counts.workSteps} Arbeitsschritte
+                      {counted(run.data.run.counts.agents, COUNT_LABELS.agent)} ·{' '}
+                      {counted(run.data.run.counts.plans, COUNT_LABELS.plan)} ·{' '}
+                      {counted(run.data.run.counts.workSteps, COUNT_LABELS.workStep)}
                     </Row>
                   </dl>
                 )}

--- a/frontend/src/lib/plural.test.ts
+++ b/frontend/src/lib/plural.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { COUNT_LABELS, counted, pluralise } from './plural'
+
+describe('German count labels', () => {
+  it('uses the singular for exactly one', () => {
+    expect(counted(1, COUNT_LABELS.plan)).toBe('1 Plan')
+    expect(counted(1, COUNT_LABELS.risk)).toBe('1 Risiko')
+    expect(counted(1, COUNT_LABELS.child)).toBe('1 Kind')
+    expect(counted(1, COUNT_LABELS.diff)).toBe('1 Diff')
+    expect(counted(1, COUNT_LABELS.agent)).toBe('1 Agent')
+    expect(counted(1, COUNT_LABELS.workStep)).toBe('1 Arbeitsschritt')
+  })
+
+  it('uses the plural for zero, which German treats like many', () => {
+    expect(counted(0, COUNT_LABELS.plan)).toBe('0 Pläne')
+    expect(counted(0, COUNT_LABELS.risk)).toBe('0 Risiken')
+    expect(counted(0, COUNT_LABELS.problem)).toBe('0 Probleme')
+  })
+
+  it('uses the plural for more than one', () => {
+    expect(counted(2, COUNT_LABELS.plan)).toBe('2 Pläne')
+    expect(counted(13, COUNT_LABELS.workStep)).toBe('13 Arbeitsschritte')
+    expect(counted(28, COUNT_LABELS.component)).toBe('28 Komponenten')
+  })
+
+  it('leaves nouns whose German plural equals the singular alone', () => {
+    expect(counted(1, COUNT_LABELS.feedback)).toBe('1 Feedback')
+    expect(counted(7, COUNT_LABELS.feedback)).toBe('7 Feedback')
+  })
+
+  it('pluralise returns the word without the number', () => {
+    expect(pluralise(1, COUNT_LABELS.relationship)).toBe('Beziehung')
+    expect(pluralise(37, COUNT_LABELS.relationship)).toBe('Beziehungen')
+  })
+})

--- a/frontend/src/lib/plural.ts
+++ b/frontend/src/lib/plural.ts
@@ -1,0 +1,42 @@
+/**
+ * German count labels.
+ *
+ * The cockpit renders a lot of counted nouns, and German does not form its
+ * plurals by appending an "s". Interpolating a count in front of a hard-coded
+ * plural produced "1 Pläne", "1 Risiken", "1 Diffs" and "1 Kinder" — small
+ * enough to look like a typo, frequent enough to make the whole surface feel
+ * unfinished.
+ */
+export interface CountLabel {
+  /** Form used for exactly one. */
+  one: string
+  /** Form used for zero and for more than one. */
+  many: string
+}
+
+/** Returns the form that matches `count`, without the number. */
+export function pluralise(count: number, label: CountLabel): string {
+  return Math.abs(count) === 1 ? label.one : label.many
+}
+
+/** Returns `count` followed by the matching form, e.g. `1 Plan` / `2 Pläne`. */
+export function counted(count: number, label: CountLabel): string {
+  return `${count} ${pluralise(count, label)}`
+}
+
+/** The counted nouns the cockpit uses. */
+export const COUNT_LABELS = {
+  agent: { one: 'Agent', many: 'Agents' },
+  plan: { one: 'Plan', many: 'Pläne' },
+  workStep: { one: 'Arbeitsschritt', many: 'Arbeitsschritte' },
+  child: { one: 'Kind', many: 'Kinder' },
+  diff: { one: 'Diff', many: 'Diffs' },
+  risk: { one: 'Risiko', many: 'Risiken' },
+  problem: { one: 'Problem', many: 'Probleme' },
+  feedback: { one: 'Feedback', many: 'Feedback' },
+  component: { one: 'Komponente', many: 'Komponenten' },
+  relationship: { one: 'Beziehung', many: 'Beziehungen' },
+  revision: { one: 'Revision', many: 'Revisionen' },
+  step: { one: 'Schritt', many: 'Schritte' },
+  run: { one: 'Run', many: 'Runs' },
+} as const satisfies Record<string, CountLabel>


### PR DESCRIPTION
## Zusammenfassung

Zwei Befunde, die erst sichtbar wurden, als das Cockpit auf **dieses Repository** statt auf die erfundene Demo-Architektur zeigte. Bei Daten, deren Wahrheit man kennt, fallen falsche Beschriftungen sofort auf.

### 1. Deutsche Pluralformen fehlten

Zählwerte wurden vor fest verdrahtete Pluralformen interpoliert. Im laufenden System stand deshalb:

| Ort | vorher | jetzt |
| --- | --- | --- |
| Runzustand → Umfang | `1 Pläne` | `1 Plan` |
| Inspector-Badges | `1 Risiken`, `1 Diffs` | `1 Risiko`, `1 Diff` |
| Komponentenknoten | `1 Kinder` | `1 Kind` |

Einzeln wirkt jedes wie ein Tippfehler; zusammen lässt es die Oberfläche unfertig aussehen. `src/lib/plural.ts` hält jetzt je Substantiv ein explizites Singular-/Pluralpaar, `counted(n, …)` setzt die passende Form. Auch `Feedback` ist erfasst — dort sind beide Formen gleich, was der Test festhält, damit niemand später ein „s" anhängt.

### 2. Die Beziehungslegende beschrieb den Vertrag statt das Modell

`RelationshipLegend` renderte **alle sechs** Beziehungsarten unabhängig davon, was gemeldet wurde. Dieses Repository benutzt weder NATS noch gRPC — die Legende bot beides trotzdem an und schickte den Leser auf die Suche nach etwas, das es nicht gibt.

Die Legende ist ein Schlüssel zu dem, was auf dem Schirm ist, kein Katalog dessen, was der Vertrag ausdrücken kann. Sie listet jetzt nur die im Modell vorhandenen Arten, in Katalogreihenfolge (damit sie sich beim Eintreffen einer Beziehung nicht umsortiert), und fällt auf den vollen Satz zurück, solange nichts gemeldet wurde.

## Testnachweise

```
npm run lint      -> keine Ausgabe
npm run typecheck -> keine Ausgabe
npm test          -> 28 Dateien / 224 Tests grün   (vorher 214, +10 neue)
```

Neue Tests: `src/lib/plural.test.ts` (6) und `src/components/workspace/RelationshipLegend.test.tsx` (5), darunter explizit:

> `does not offer NATS or gRPC to a project that reports neither`

## Hinweis

Kein `Closes` — kein Issue, sondern Politur an gemergter Arbeit, gefunden über das Self-Szenario aus PR #32.
