### PR TITLE
Desktop-Viewport für variable Fenstergrößen und Browser-Zoom korrigieren

### DIFF
--- a/docs/decisions/0014-desktop-viewport-and-absolute-pane-minimums.md
+++ b/docs/decisions/0014-desktop-viewport-and-absolute-pane-minimums.md
@@ -1,0 +1,120 @@
+# 14. The real viewport, absolute pane minimums and one place where sideways scrolling is allowed
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #41 (part of the v0 epic #1)
+- **Builds on:** [0003 — Frontend state split and live updates](./0003-frontend-state-split-and-live-updates.md),
+  [0008 — Architecture canvas](./0008-architecture-canvas-layout-and-edge-bundling.md),
+  [0013 — Mandatory end-to-end acceptance](./0013-mandatory-end-to-end-acceptance.md)
+
+## Context
+
+The cockpit is desktop-only and its mandatory acceptance surface is
+1920 × 1080 in Chromium (epic #1). That is a floor for *acceptance*, not a
+statement that no other window exists. Three ordinary desktop situations
+produce a narrower CSS viewport without anybody choosing a different device:
+
+- a window that is not maximised,
+- two windows split across one screen,
+- **browser zoom** — 1920 px at 125 % is a 1536 px viewport, at 150 % a 1280 px
+  one. Zoom is an accessibility setting, and refusing to lay out for it is
+  refusing the setting.
+
+The shell was pinned against all three by `<meta name="viewport" content="width=1920">`
+and by pane minimums expressed in **percent**. Both are wrong for different
+reasons, and the second one is the one that actually hurt.
+
+## Decision
+
+### The viewport meta describes the device, not a wish
+
+`width=device-width, initial-scale=1`. The fixed `width=1920` told every
+viewport-honouring browser mode to lay the page out as if the window were
+1920 px and then scale the result — which is precisely the behaviour the issue
+reports. Desktop Chromium ignores the tag altogether, which is why the defect
+was invisible in the acceptance run and visible to users: the tag was wrong
+*and* inert on the one browser that gates the release.
+
+### Shares are relative, minimums are absolute
+
+The split stays a share of the window — 18 / 54 / 28 — because that is what
+keeps the architecture surface the visually dominant area at every width
+(ADR 0008), and a share does that by construction.
+
+The **minimums are pixels**, not percentages:
+
+| Pane | Minimum | Why that number |
+| --- | --- | --- |
+| Run and agents | 260 px | a run row is a 20-character monospace id plus its state badge; the agent tree indents four levels before it truncates |
+| Architecture | 500 px | the canvas toolbar is ~300 px and the minimap 168 px in the opposite corner — below ~500 px they meet and the graph has nothing left |
+| Inspector | 340 px | two 40 px line-number gutters plus a code column worth reading before it scrolls |
+
+A percentage minimum shrinks with the window, which inverts the intent: the
+content a pane must show does not get narrower because the window did. The old
+12 % floor on the run pane meant 230 px at 1920 and 154 px at 1280 — the width
+at which it is *least* affordable. The three pixel minimums add up to 1100 px
+and therefore fit into 1280 with room to spare; `state/paneSizing.test.ts`
+asserts that as an invariant rather than as a comment.
+
+At 1280 the default shares would give the run pane 230 px, so it is clamped up
+to 260 px and the difference comes out of the centre — 260 / 660 / 358. The
+centre is the pane that gives space up, because it is the only one with space
+to give. The measured splits:
+
+| Window | Run pane | Architecture | Inspector |
+| --- | --- | --- | --- |
+| 1280 | 260 px | 660 px (52 %) | 358 px |
+| 1440 | 260 px | 776 px (54 %) | 403 px |
+| 1536 (1920 @ 125 %) | 276 px | 828 px (54 %) | 430 px |
+| 1920 | 345 px | 1036 px (54 %) | 537 px |
+
+Deep focus stays the one documented exception to "the canvas is the widest
+pane" (ADR 0008). It is also the constraint that fixes the centre minimum: its
+41 % centre share is 524 px at 1280, so a minimum above that would turn the
+mode into a silently clamped, slightly different split.
+
+### Sideways scrolling belongs to the content, never to the page
+
+`body` keeps `overflow: hidden` and each pane owns its own scroll region. Wide
+technical content scrolls **inside the box that owns it**: a unified diff, a
+fenced code block, a markdown table, the React Flow viewport. Nothing that
+scrolls sideways is allowed to be a page-level scroller.
+
+That rule had one silent hole, and it was invisible at 1920. The Radix
+`ScrollArea` viewport wraps its children in a `display: table` box, which sizes
+to its own min-content width and may therefore be **wider than the viewport** —
+while the viewport itself clips horizontally, because this `ScrollArea` renders
+a vertical scrollbar only. The result is not a scroller, it is a guillotine: at
+a 260 px run pane the content box still claimed 341 px and 81 px of it was
+unreachable by any means. Forcing that wrapper to a block box makes the content
+wrap to the pane. It is a one-line override in `components/ui/scroll-area.tsx`
+and it is correct for both places the component is used, which are both
+vertical lists.
+
+### The measurement stays where it already is
+
+`e2e/tests/08-viewport.spec.ts` asks the browser, not the DOM: no horizontal
+page scrollbar, and every primary control rendered, inside the viewport and the
+element `elementFromPoint` finds at its own centre. That check is unchanged, and
+it still runs at exactly 1920 × 1080 — the acceptance resolution is a property
+of the release gate, not of the layout.
+
+Its documented Chromium oddity stays documented: `document.documentElement.scrollHeight`
+reads 2663 instead of 1080 over the Radix `ScrollArea` viewport, so the test
+measures `body` and `#root`. That is a measurement artefact and not a defect,
+and this decision does not touch it.
+
+## Consequences
+
+- 1280 px is now a supported width with a name — `MIN_SUPPORTED_WIDTH` — and
+  the pane minimums are checked against it. Adding a narrower supported width is
+  a decision, because the minimums no longer fit into it by arithmetic.
+- Browser zoom needs no separate handling. Zoom changes the CSS viewport and
+  nothing else, so "works at 1280" and "works at 1920 with 150 % zoom" are the
+  same statement, and the same measurement covers both.
+- The `ScrollArea` override is a Radix implementation detail pinned in our
+  wrapper. A Radix upgrade that stops emitting the `display: table` wrapper makes
+  the override a no-op rather than a breakage, but the comment has to be checked.
+- Truncation in the run pane is real at 260 px: long agent display names ellipse.
+  The agent area is being reworked in #39; giving those rows a hover title or a
+  second line belongs there, not here.

--- a/docs/decisions/0015-desktop-viewport-and-absolute-pane-minimums.md
+++ b/docs/decisions/0015-desktop-viewport-and-absolute-pane-minimums.md
@@ -1,4 +1,4 @@
-# 14. The real viewport, absolute pane minimums and one place where sideways scrolling is allowed
+# 15. The real viewport, absolute pane minimums and one place where sideways scrolling is allowed
 
 - **Status:** accepted
 - **Date:** 2026-08-04

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,14 @@
 <html lang="de" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=1920" />
+    <!-- The cockpit is desktop-only, but it must lay out against the window the
+         user actually has. A fixed `width=1920` told every viewport-honouring
+         browser mode to pretend the window were 1920 px wide, which broke
+         smaller desktop windows, split screens and browser zoom (issue #41).
+         `device-width` + `initial-scale=1` hands the layout the real CSS
+         viewport, so the pane minimums in `state/uiStore.ts` are what decides
+         how narrow a pane may get. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Visualise AI — Agent Cockpit</title>
   </head>
   <body>

--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -16,9 +16,21 @@ function ScrollArea({
       className={cn("relative", className)}
       {...props}
     >
+      {/*
+        `[&>div]:!block` overrides the `display: table` Radix sets inline on the
+        viewport's content wrapper.
+
+        Table sizing lets that wrapper grow to its own min-content width, wider
+        than the viewport. This ScrollArea renders a vertical scrollbar only and
+        the viewport clips horizontally, so anything past the viewport edge is
+        not scrolled to — it is cut off and unreachable. That is invisible at a
+        wide pane and appears as soon as the window gets smaller (issue #41): at
+        a 260 px run pane the content box still claimed 341 px and lost 81 px of
+        it. As a block box the content wraps to the pane instead.
+      */}
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 [&>div]:!block"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/frontend/src/components/workspace/WorkspaceLayout.tsx
+++ b/frontend/src/components/workspace/WorkspaceLayout.tsx
@@ -16,6 +16,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import {
   COLLAPSED_PANE_SIZE,
   PANE_IDS,
+  PANE_MAX_WIDTH,
+  PANE_MIN_WIDTH_PX,
   useUiStore,
   type PaneLayout,
 } from '@/state/uiStore'
@@ -37,6 +39,17 @@ export interface WorkspaceLayoutProps {
  *
  * Both side panes are independently collapsible. A collapsed pane keeps a thin
  * rail with its expand control, so the pane never disappears without a way back.
+ *
+ * The **shares** are relative and the **minimums are absolute** (issue #41).
+ * That split is deliberate: the proportions are what keeps the architecture
+ * surface dominant at every width, while a percentage minimum would shrink with
+ * the window and let a pane become unusable at 1280 — the width a 1920 px
+ * window has at 150 % browser zoom. The numbers live in `state/uiStore.ts`
+ * next to the layout they constrain.
+ *
+ * Nothing here scrolls. The group is exactly one viewport tall and each pane
+ * owns its own scroll region, which is what keeps the page itself free of a
+ * scrollbar in either direction.
  */
 export function WorkspaceLayout({ left, center, right }: WorkspaceLayoutProps) {
   const layout = useUiStore((state) => state.layout)
@@ -72,8 +85,8 @@ export function WorkspaceLayout({ left, center, right }: WorkspaceLayoutProps) {
         id={PANE_IDS.left}
         collapsible
         collapsedSize={`${COLLAPSED_PANE_SIZE}%`}
-        minSize="12%"
-        maxSize="32%"
+        minSize={PANE_MIN_WIDTH_PX[PANE_IDS.left]}
+        maxSize={PANE_MAX_WIDTH.left}
         panelRef={leftPanelRef}
         className="min-w-0"
         onResize={() => syncCollapsed(leftPanelRef, leftCollapsed, setLeftCollapsed)}
@@ -91,7 +104,11 @@ export function WorkspaceLayout({ left, center, right }: WorkspaceLayoutProps) {
 
       <ResizableHandle withHandle aria-label="Breite des Run- und Agent-Bereichs" />
 
-      <ResizablePanel id={PANE_IDS.center} minSize="30%" className="min-w-0">
+      <ResizablePanel
+        id={PANE_IDS.center}
+        minSize={PANE_MIN_WIDTH_PX[PANE_IDS.center]}
+        className="min-w-0"
+      >
         {center}
       </ResizablePanel>
 
@@ -101,8 +118,8 @@ export function WorkspaceLayout({ left, center, right }: WorkspaceLayoutProps) {
         id={PANE_IDS.right}
         collapsible
         collapsedSize={`${COLLAPSED_PANE_SIZE}%`}
-        minSize="16%"
-        maxSize="60%"
+        minSize={PANE_MIN_WIDTH_PX[PANE_IDS.right]}
+        maxSize={PANE_MAX_WIDTH.right}
         panelRef={rightPanelRef}
         className="min-w-0"
         onResize={() => syncCollapsed(rightPanelRef, rightCollapsed, setRightCollapsed)}

--- a/frontend/src/components/workspace/paneOverflow.test.tsx
+++ b/frontend/src/components/workspace/paneOverflow.test.tsx
@@ -1,0 +1,87 @@
+import { screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { PROJECT_ID, RUN_ID, createFakeFetch } from '@/test/fixtures'
+import { COMPONENT_ID, INSPECTOR_PATH, inspectorPage } from '@/test/inspectorFixtures'
+import { renderApp } from '@/test/renderApp'
+
+/**
+ * Where horizontal overflow is allowed to happen (issue #41).
+ *
+ * The rule of the cockpit is that **the page never scrolls sideways** and wide
+ * content scrolls inside the container that owns it. jsdom applies no
+ * stylesheet, so these tests assert the containment *declarations* — which is
+ * what a refactor deletes by accident. That the declarations add up to a page
+ * without a scrollbar is measured in a real browser by
+ * `e2e/tests/08-viewport.spec.ts`.
+ */
+
+const WORKSPACE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}?component=${COMPONENT_ID}`
+
+function renderWorkspace() {
+  return renderApp(WORKSPACE_URL, {
+    fetchImpl: createFakeFetch({ [INSPECTOR_PATH]: inspectorPage() }),
+  })
+}
+
+describe('horizontal overflow containment', () => {
+  it('lets the inspector scroll vertically and never sideways', async () => {
+    renderWorkspace()
+
+    const scroll = await screen.findByTestId('inspector-scroll')
+    expect(scroll.className).toContain('overflow-y-auto')
+    expect(scroll.className).toContain('overflow-x-hidden')
+  })
+
+  it('scrolls a unified diff inside its own box', async () => {
+    renderWorkspace()
+
+    const diffs = await screen.findAllByTestId('unified-diff')
+    expect(diffs.length).toBeGreaterThan(0)
+
+    for (const diff of diffs) {
+      // The figure clips, so a long line can never widen the inspector …
+      expect(diff.className).toContain('overflow-hidden')
+      // … and the box holding the table is what scrolls instead.
+      const scroller = diff.querySelector('div.overflow-auto')
+      expect(scroller).not.toBeNull()
+      // Diff lines are kept verbatim, which is why the box has to scroll.
+      expect(within(diff).getAllByRole('row').length).toBeGreaterThan(0)
+    }
+  })
+
+  it('keeps the architecture surface clipping its own canvas', async () => {
+    renderWorkspace()
+
+    const canvas = await screen.findByTestId('architecture-canvas')
+    const region = canvas.parentElement
+    expect(region).not.toBeNull()
+    expect(region!.className).toContain('overflow-hidden')
+    expect(region!.className).toContain('min-w-0')
+  })
+
+  it('makes the run pane wrap to the pane instead of growing past it', async () => {
+    renderWorkspace()
+
+    await screen.findByTestId('pane-run-agents')
+    const viewport = document.querySelector('[data-slot="scroll-area-viewport"]')
+    expect(viewport).not.toBeNull()
+    // Radix sizes the viewport's content wrapper as a table, which lets it grow
+    // to its own min-content width — wider than the pane, and clipped away
+    // because the viewport has no horizontal scrollbar. Forcing a block box is
+    // what makes the content wrap to the pane instead (issue #41).
+    expect(viewport!.className).toContain('[&>div]:!block')
+    expect(viewport!.firstElementChild).not.toBeNull()
+  })
+
+  it('gives every pane a zero minimum content width, so a wide child cannot push it', async () => {
+    renderWorkspace()
+
+    await screen.findByTestId('pane-run-agents')
+    for (const pane of ['pane-run-agents', 'pane-architecture', 'pane-inspector']) {
+      // `.pane-surface` carries `min-w-0`; without it a flex child refuses to
+      // shrink below its content and the whole row grows past the window.
+      expect(screen.getByTestId(pane).className).toContain('pane-surface')
+    }
+  })
+})

--- a/frontend/src/state/paneSizing.test.ts
+++ b/frontend/src/state/paneSizing.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  COLLAPSED_PANE_SIZE,
+  DEEP_FOCUS_PANE_LAYOUT,
+  DEFAULT_PANE_LAYOUT,
+  MIN_SUPPORTED_WIDTH,
+  PANE_IDS,
+  PANE_MAX_WIDTH,
+  PANE_MIN_WIDTH_PX,
+  type PaneId,
+  type PaneLayout,
+} from '@/state/uiStore'
+
+/**
+ * The pane geometry of issue #41, asserted as arithmetic.
+ *
+ * jsdom lays nothing out — every element is 0 × 0 — so `react-resizable-panels`
+ * cannot be observed resolving a constraint here. What *can* be checked, and
+ * what actually breaks in practice, is whether the numbers the panel group is
+ * given are consistent with each other at the widths the cockpit is used at.
+ * The rendered result is measured in Chromium by `e2e/tests/08-viewport.spec.ts`.
+ */
+
+/**
+ * Widths the cockpit has to work at.
+ *
+ * 1280 and 1440 are the desktop windows named in issue #41, 1920 is the
+ * mandatory acceptance surface (epic #1), and 1536 / 1280 are what that
+ * acceptance surface becomes at 125 % and 150 % browser zoom — which is the
+ * same measurement, since zoom changes the CSS viewport and nothing else.
+ */
+const SUPPORTED_WIDTHS = [1280, 1440, 1536, 1920] as const
+
+/** Two 1 px separators sit between the three panes. */
+const SEPARATOR_WIDTH = 2
+
+/** A pane's share of `windowWidth`, in pixels. A missing key is a test failure. */
+function paneWidth(layout: PaneLayout, paneId: PaneId, windowWidth: number): number {
+  const share = layout[paneId]
+  if (share === undefined) throw new Error(`layout has no entry for ${paneId}`)
+  return (share / 100) * (windowWidth - SEPARATOR_WIDTH)
+}
+
+const railWidth = (windowWidth: number) =>
+  (COLLAPSED_PANE_SIZE / 100) * (windowWidth - SEPARATOR_WIDTH)
+
+const sumOfShares = (layout: PaneLayout) =>
+  Object.values(layout).reduce((total, share) => total + share, 0)
+
+describe('pane minimums', () => {
+  it('are absolute pixels, so they do not shrink with the window', () => {
+    // The regression this guards: percentage minimums looked fine at 1920 and
+    // let a pane fall to 154 px at 1280.
+    for (const minimum of Object.values(PANE_MIN_WIDTH_PX)) {
+      expect(typeof minimum).toBe('number')
+      expect(minimum).toBeGreaterThan(0)
+    }
+  })
+
+  it('fit together into the narrowest supported window', () => {
+    const total =
+      PANE_MIN_WIDTH_PX[PANE_IDS.left] +
+      PANE_MIN_WIDTH_PX[PANE_IDS.center] +
+      PANE_MIN_WIDTH_PX[PANE_IDS.right] +
+      SEPARATOR_WIDTH
+
+    expect(total).toBeLessThanOrEqual(MIN_SUPPORTED_WIDTH)
+    // Every supported width is at least the narrowest one; a new entry that
+    // undercuts it would need its own decision, not a silent pass.
+    for (const width of SUPPORTED_WIDTHS) {
+      expect(width).toBeGreaterThanOrEqual(MIN_SUPPORTED_WIDTH)
+    }
+  })
+
+  it('give the architecture surface the most room of the three', () => {
+    expect(PANE_MIN_WIDTH_PX[PANE_IDS.center]).toBeGreaterThan(
+      PANE_MIN_WIDTH_PX[PANE_IDS.left],
+    )
+    expect(PANE_MIN_WIDTH_PX[PANE_IDS.center]).toBeGreaterThan(
+      PANE_MIN_WIDTH_PX[PANE_IDS.right],
+    )
+  })
+
+  it('stay below what a collapsed rail is allowed to be', () => {
+    // A collapsed pane is deliberately far below its minimum — `collapsedSize`
+    // is the escape hatch that makes the rail possible at all.
+    expect(railWidth(MIN_SUPPORTED_WIDTH)).toBeLessThan(
+      PANE_MIN_WIDTH_PX[PANE_IDS.left],
+    )
+  })
+})
+
+describe('default split', () => {
+  it('adds up to the whole window and names every pane', () => {
+    for (const layout of [DEFAULT_PANE_LAYOUT, DEEP_FOCUS_PANE_LAYOUT]) {
+      expect(sumOfShares(layout)).toBe(100)
+      expect(Object.keys(layout).sort()).toEqual([...Object.values(PANE_IDS)].sort())
+    }
+  })
+
+  it('keeps the architecture surface the widest pane at every supported width', () => {
+    // The product rule of ADR 0008, stated as a share so it holds at any width.
+    for (const width of SUPPORTED_WIDTHS) {
+      const left = paneWidth(DEFAULT_PANE_LAYOUT, PANE_IDS.left, width)
+      const center = paneWidth(DEFAULT_PANE_LAYOUT, PANE_IDS.center, width)
+      const right = paneWidth(DEFAULT_PANE_LAYOUT, PANE_IDS.right, width)
+
+      expect(center).toBeGreaterThan(left)
+      expect(center).toBeGreaterThan(right)
+      expect(center).toBeGreaterThan(left + right)
+    }
+  })
+
+  it('never asks the architecture surface for less than its minimum', () => {
+    // The side panes may well be clamped up at 1280 — that is what a minimum is
+    // for, and the space comes out of the centre. The centre itself must never
+    // need clamping, because there is nothing left to take it from.
+    for (const width of SUPPORTED_WIDTHS) {
+      const center = paneWidth(DEFAULT_PANE_LAYOUT, PANE_IDS.center, width)
+      expect(center).toBeGreaterThanOrEqual(PANE_MIN_WIDTH_PX[PANE_IDS.center])
+    }
+  })
+
+  it('leaves every pane its minimum even where a share falls short of it', () => {
+    // What the panel group has to be able to resolve at the narrowest width:
+    // clamp the short pane up and take the difference from a pane that has it.
+    const width = MIN_SUPPORTED_WIDTH
+    const clamped = {
+      left: Math.max(
+        paneWidth(DEFAULT_PANE_LAYOUT, PANE_IDS.left, width),
+        PANE_MIN_WIDTH_PX[PANE_IDS.left],
+      ),
+      right: Math.max(
+        paneWidth(DEFAULT_PANE_LAYOUT, PANE_IDS.right, width),
+        PANE_MIN_WIDTH_PX[PANE_IDS.right],
+      ),
+    }
+    const remainingForCenter = width - SEPARATOR_WIDTH - clamped.left - clamped.right
+
+    expect(remainingForCenter).toBeGreaterThanOrEqual(PANE_MIN_WIDTH_PX[PANE_IDS.center])
+    expect(remainingForCenter).toBeGreaterThan(clamped.left)
+    expect(remainingForCenter).toBeGreaterThan(clamped.right)
+  })
+})
+
+describe('deep focus split', () => {
+  it('folds the run pane into its rail and keeps the canvas above its minimum', () => {
+    expect(DEEP_FOCUS_PANE_LAYOUT[PANE_IDS.left]).toBe(COLLAPSED_PANE_SIZE)
+
+    for (const width of SUPPORTED_WIDTHS) {
+      const center = paneWidth(DEEP_FOCUS_PANE_LAYOUT, PANE_IDS.center, width)
+      expect(center).toBeGreaterThanOrEqual(PANE_MIN_WIDTH_PX[PANE_IDS.center])
+    }
+  })
+
+  it('fits inside the inspector maximum', () => {
+    // Deep focus is the one documented exception to "the canvas is the widest
+    // pane" (ADR 0008). Tightening the maximum below it would silently turn the
+    // mode into a clamped, slightly-off split instead of failing loudly.
+    const inspectorMax = Number.parseFloat(PANE_MAX_WIDTH.right)
+    expect(PANE_MAX_WIDTH.right.endsWith('%')).toBe(true)
+    expect(DEEP_FOCUS_PANE_LAYOUT[PANE_IDS.right] ?? 0).toBeLessThanOrEqual(inspectorMax)
+    expect(DEEP_FOCUS_PANE_LAYOUT[PANE_IDS.right] ?? 0).toBeGreaterThan(0)
+  })
+
+  it('caps the run pane below half the window, so it can never dominate', () => {
+    const runPaneMax = Number.parseFloat(PANE_MAX_WIDTH.left)
+    expect(PANE_MAX_WIDTH.left.endsWith('%')).toBe(true)
+    expect(runPaneMax).toBeLessThan(50)
+  })
+})

--- a/frontend/src/state/uiStore.ts
+++ b/frontend/src/state/uiStore.ts
@@ -44,9 +44,13 @@ export type PaneId = (typeof PANE_IDS)[keyof typeof PANE_IDS]
 export type PaneLayout = Record<string, number>
 
 /**
- * Default split at the mandatory acceptance resolution of 1920 × 1080:
- * 346 px | 1037 px | 537 px. The centre stays the dominant area — three times
- * the left pane and twice the inspector.
+ * Default split, as a share of the window.
+ *
+ * At the mandatory acceptance resolution of 1920 × 1080 this is
+ * 345 px | 1036 px | 537 px, and because the shares are relative it keeps the
+ * same proportions at every supported width: the architecture surface is always
+ * ~54 % — wider than the two side panes together — which is the product rule
+ * that it stays the visually dominant area (ADR 0008).
  */
 export const DEFAULT_PANE_LAYOUT: PaneLayout = {
   [PANE_IDS.left]: 18,
@@ -58,9 +62,62 @@ export const DEFAULT_PANE_LAYOUT: PaneLayout = {
 export const COLLAPSED_PANE_SIZE = 3
 
 /**
+ * Narrowest window the cockpit is designed for.
+ *
+ * The mandatory acceptance surface stays 1920 × 1080 (epic #1). 1280 is what a
+ * 1920 px window turns into at 150 % browser zoom and what a half-screen split
+ * on a 2560 px display gives — both are normal desktop situations and neither
+ * may make a pane unusable (issue #41).
+ */
+export const MIN_SUPPORTED_WIDTH = 1280
+
+/**
+ * Pane minimums in **CSS pixels**, not in percent.
+ *
+ * A percentage minimum shrinks with the window, which is exactly the wrong
+ * behaviour: the content a pane has to show does not get narrower because the
+ * window did. `react-resizable-panels` reads a bare number as pixels, so these
+ * are absolute floors that hold at 1280 as well as at 1920 — for the initial
+ * split, for a dragged separator and for a window resize alike.
+ *
+ * Each number is derived from what the pane has to fit, not from taste:
+ *
+ * * **left, 260 px** — a run row is a 20-character monospace id plus its state
+ *   badge, and the agent tree indents four levels before it truncates.
+ * * **centre, 500 px** — the canvas toolbar (`Einpassen`, minimap toggle,
+ *   detail level) is ~300 px and the minimap is 168 px in the opposite corner;
+ *   below ~500 px the two would overlap and the graph would have no room left.
+ * * **right, 340 px** — a unified diff is two 40 px line-number gutters plus a
+ *   code column that is worth reading before it starts scrolling sideways.
+ *
+ * They add up to 1100 px and therefore fit into {@link MIN_SUPPORTED_WIDTH}
+ * with room to spare; `paneSizing.test.ts` asserts that as an invariant.
+ */
+export const PANE_MIN_WIDTH_PX: Record<PaneId, number> = {
+  [PANE_IDS.left]: 260,
+  [PANE_IDS.center]: 500,
+  [PANE_IDS.right]: 340,
+}
+
+/**
+ * Pane maximums, as a share of the window.
+ *
+ * Only the two side panes are capped, and they are capped so the architecture
+ * surface cannot be squeezed out of the middle by dragging. The inspector's
+ * 60 % is what the deep-focus split (56 %) needs — that mode deliberately
+ * enlarges the inspector and is the one documented exception to "the canvas is
+ * the widest pane" (ADR 0008); the canvas stays visible throughout.
+ */
+export const PANE_MAX_WIDTH: Record<'left' | 'right', string> = {
+  left: '32%',
+  right: '60%',
+}
+
+/**
  * Deep-focus split: the inspector grows over the canvas and the run pane folds
  * into its rail, but the canvas keeps ~41 % of the width — roughly 790 px at
- * 1920 — so the architecture context never disappears.
+ * 1920 and still ~525 px at 1280 — so the architecture context never
+ * disappears and never falls below its pixel minimum.
  */
 export const DEEP_FOCUS_PANE_LAYOUT: PaneLayout = {
   [PANE_IDS.left]: COLLAPSED_PANE_SIZE,


### PR DESCRIPTION
Closes #41

## Problem

`frontend/index.html` pinned the layout with `<meta name="viewport" content="width=1920">`, and the three pane minimums were expressed in **percent**. Both ignore the window the user actually has:

- a fixed viewport width tells every viewport-honouring browser mode to lay out as if the window were 1920 px and then scale;
- a percentage minimum shrinks with the window, which inverts the intent — the content a pane must show does not get narrower because the window did. The 12 % floor on the run pane meant 230 px at 1920 and **154 px at 1280**.

1280 px is not an exotic width: it is what a 1920 px window becomes at **150 % browser zoom**, and what a half-screen split on a 2560 px display gives.

## What changed

| File | Change |
| --- | --- |
| `frontend/index.html` | `width=device-width, initial-scale=1` |
| `frontend/src/state/uiStore.ts` | `MIN_SUPPORTED_WIDTH`, `PANE_MIN_WIDTH_PX` (pixels), `PANE_MAX_WIDTH` (shares), with the reasoning per number |
| `frontend/src/components/workspace/WorkspaceLayout.tsx` | panes read those constants instead of inline percentages |
| `frontend/src/components/ui/scroll-area.tsx` | the Radix viewport's content wrapper is forced to a block box |
| `frontend/src/state/paneSizing.test.ts` | new — pane geometry as arithmetic invariants (11 tests) |
| `frontend/src/components/workspace/paneOverflow.test.tsx` | new — where horizontal overflow is allowed to happen (5 tests) |
| `docs/decisions/0014-…md` | new ADR |

**Shares stay relative, minimums become absolute.** The split remains 18 / 54 / 28, because a share is what keeps the architecture surface the visually dominant area at *every* width (ADR 0008). The minimums are pixels — 260 (run/agents) / 500 (architecture) / 340 (inspector) — derived from what each pane has to fit, not from taste. They add up to 1100 px and fit into 1280 with room to spare; a test asserts that as an invariant.

**One overflow hole was found and closed.** Radix's `ScrollArea` wraps its viewport content in a `display: table` box, which sizes to its own min-content width and can be **wider than the viewport** — while the viewport clips horizontally, because this `ScrollArea` renders only a vertical scrollbar. That is not a scroller, it is a guillotine: at a 260 px run pane the content box still claimed **341 px and 81 px of it were unreachable by any means**. Invisible at 1920 (the pane is 345 px there), which is why the acceptance run never saw it. Forcing the wrapper to a block box makes the content wrap to the pane.

## Measurements — real Chromium, production build

Against the Nginx-served bundle of this branch (own stack, `-p vai-issue41-e2e`, port 8103; ports 8080–8083 untouched). Measured programmatically at the live DOM (`getBoundingClientRect`, `elementFromPoint`, `document.body.scrollWidth`) — the numbers hit the criteria more directly than a screenshot would.

| Breite | Panes (Run / Architektur / Inspector) | Seiten-Scrollbar | primäre Steuerung erreichbar |
| --- | --- | --- | --- |
| 1280 | 260 / **660 (51,6 %)** / 358 px | nein (`document` 1280/1280, `body` 1280/1280) | 12/12 |
| 1440 | 260 / **776 (53,9 %)** / 403 px | nein (1440/1440) | 12/12 |
| 1920 | 345 / **1036 (54,0 %)** / 537 px | nein (1920/1920) | 12/12 |

The architecture surface is the widest pane at every width. The 1920 split is **exactly what it was before** this change — 345 / 1036 / 537.

### Browser zoom at 1920

Zoom is reproduced the way the page experiences it: at N % on a 1920 px window the CSS viewport is 1920/N wide and `devicePixelRatio` is N.

| Zoom | CSS-Viewport | Panes | Seiten-Scrollbar | Steuerung | Komponentenauswahl |
| --- | --- | --- | --- | --- | --- |
| 100 % | 1920 × 1080, dpr 1 | 345 / 1036 / 537 | nein | 12/12 | Klick → `?component=payment-provider`, Inspector zeigt „Payment Provider" |
| 125 % | 1536 × 864, dpr 1.25 | 276 / 828 / 430 | nein | 12/12 | Klick → `?component=payment-provider`, Inspector zeigt „Payment Provider" |
| 150 % | 1280 × 720, dpr 1.5 | 260 / 660 / 358 | nein | 12/12 | Klick → `?component=payment-provider`, Inspector zeigt „Payment Provider" |

Component selection was verified as a round trip, not as visibility: click a canvas node → the `component` search parameter carries its id → the inspector renders that component's body (`inspector-current-run`) with its name in the header.

Probed controls: run option, agent filter, both pane toggles, canvas fit-view, minimap toggle, canvas zoom in/out, both inspector tabs, live badge, header navigation. `elementFromPoint` at each control's own centre has to resolve to the control — DOM existence proves nothing.

### Minimums under pressure

A persisted layout that violates the minimums (stands in for a separator dragged as far as it goes, and for a window that shrank after the split was saved):

| Breite | Separator ganz nach links | Separator ganz nach rechts |
| --- | --- | --- |
| 1280 | 260 / 500 / 518 | 409 / 529 / 340 |
| 1440 | 260 / 500 / 679 | 460 / 638 / 340 |
| 1920 | 260 / 507 / 1151 | 614 / 964 / 340 |

No pane ever goes below its minimum. Deep focus at 1280: rail 38 / canvas 524 / inspector 716 — the canvas stays above its 500 px minimum, no page scrollbar. Both side panes collapsed at 1280: 38 / 1201 / 38, both rail expand controls operable.

### Horizontal scrolling stays in its containers

At 1280, after the `ScrollArea` fix, the only elements that scroll sideways are the ones meant to: the React Flow viewport, the minimap, and `truncate` elements (ellipsis, by design). Nothing is clipped and unreachable in the run pane or the inspector any more.

A unified diff scrolls **inside its own box** at every width:

| Breite | Inspector | Diff-Box | seitlich scrollbar bis |
| --- | --- | --- | --- |
| 1280 | 358 px, `scrollWidth` 358 → kein Seitenscrollen | `overflow-x: auto`, 314 → 653 | 339 px |
| 1440 | 403 px, `scrollWidth` 403 | 359 → 653 | 294 px |
| 1920 | 537 px, `scrollWidth` 537 | 493 → 653 | 160 px |

### Camera and keyboard

| Check | 1280 | 1920 | 1280 @ dpr 1.5 |
| --- | --- | --- | --- |
| `fitView` count before → after a component click | 1 → 1 | 1 → 1 | 1 → 1 |
| Fokusindikator auf den ersten 16 Tab-Stopps | 16/16 | 16/16 | — |
| Tab-Stopps im Viewport, nicht verdeckt | ja | ja | ja |

A viewport change triggers no camera movement, and selecting a component does not move it either — the camera policy of ADR 0008 is untouched by this change.

## Quality gate

```
$ npm run lint      → clean
$ npm run typecheck → clean
$ npm test          → Test Files 30 passed (30) · Tests 240 passed (240)
$ npm run build     → ✓ built in 22.41s
```

224 pre-existing tests plus 16 new ones. The chunk-size warning is pre-existing and accepted in ADR 0003.

### Mandatory acceptance run (#14)

```
$ cd e2e && npm install && COMPOSE_PROJECT_NAME=vai-issue41-e2e FRONTEND_HTTP_PORT=8103 npm test

Running 20 tests using 1 worker

  ok  1 [chromium-1920x1080] › tests\01-ingestion.spec.ts:67:1 › 1 · a refused event occupies no position, a retry repeats it, a conflict is rejected (78ms)
  ok  2 [chromium-1920x1080] › tests\01-ingestion.spec.ts:130:1 › 1 · the simulator retry and conflict scenarios answer as the contract promises (1.3s)
  ok  3 [chromium-1920x1080] › tests\01-ingestion.spec.ts:158:1 › 1 · the projections show the accepted content and nothing that was refused (820ms)
  ok  4 [chromium-1920x1080] › tests\02-live-updates.spec.ts:40:1 › 3 · every live change state is observed while the run is happening (30.7s)
  ok  5 [chromium-1920x1080] › tests\02-live-updates.spec.ts:163:1 › 3 · after a reload the watched states start empty again — which is why they had to be watched (694ms)
  ok  6 [chromium-1920x1080] › tests\03-architecture.spec.ts:77:1 › 2 · the canvas draws the reported hierarchy across four nesting levels (880ms)
  ok  7 [chromium-1920x1080] › tests\03-architecture.spec.ts:132:1 › 2 · every relationship kind is drawn, and every reported NATS topic stays individually identifiable (1.3s)
  ok  8 [chromium-1920x1080] › tests\04-run-agents.spec.ts:37:1 › 4 · the tree is three levels deep with two subagents running in parallel below one parent (688ms)
  ok  9 [chromium-1920x1080] › tests\04-run-agents.spec.ts:99:1 › 4 · an overall estimate and a counted subagent progress are told apart by shape, not colour (751ms)
  ok 10 [chromium-1920x1080] › tests\05-inspector.spec.ts:25:1 › 5 · clicking a component shows its agent, task, markdown feedback and grouped diffs (1.0s)
  ok 11 [chromium-1920x1080] › tests\05-inspector.spec.ts:110:1 › 5 · a diff reported without a changeId stays its own entry (686ms)
  ok 12 [chromium-1920x1080] › tests\05-inspector.spec.ts:127:1 › 5 · the rendered feedback contains no active element (674ms)
  ok 13 [chromium-1920x1080] › tests\06-run-history-focus.spec.ts:28:1 › 6 · the history is its own tab and never mixes into the current run (841ms)
  ok 14 [chromium-1920x1080] › tests\06-run-history-focus.spec.ts:68:1 › 6 · a historical run is a different URL and never overlays the current one (777ms)
  ok 15 [chromium-1920x1080] › tests\06-run-history-focus.spec.ts:99:1 › 6 · deep focus enlarges the inspector while the architecture stays on screen (944ms)
  ok 16 [chromium-1920x1080] › tests\07-sse-replay.spec.ts:41:1 › 7 · a forced disconnect replays from the last position, gapless, ordered and without duplicates (30.3s)
  ok 17 [chromium-1920x1080] › tests\07-sse-replay.spec.ts:161:1 › 7 · a cursor the project has not reached yet does not produce a silent stream (44ms)
  ok 18 [chromium-1920x1080] › tests\08-viewport.spec.ts:30:1 › 8 · the page has no horizontal scrollbar and every primary control is operable (683ms)
  ok 19 [chromium-1920x1080] › tests\08-viewport.spec.ts:127:1 › 8 · content below the fold is reachable inside its own pane, not by scrolling the page (716ms)
  ok 20 [chromium-1920x1080] › tests\08-viewport.spec.ts:187:1 › 8 · collapsing and reopening the side panes never produces a scrollbar either (819ms)

  20 passed (2.0m)
```

`e2e/tests/08-viewport.spec.ts` is unchanged. Its documented Chromium oddity — `document.documentElement.scrollHeight` reading 2663 instead of 1080 over the Radix `ScrollArea` viewport, which is why the test measures `body`/`#root` — was left alone, as instructed.

## Acceptance criteria of #41

- [x] Works at 1280, 1440 and 1920 px width — measured above.
- [x] No control is cut off outside the reachable area — 12/12 controls operable at every width, and the 81 px the run pane used to lose are gone.
- [x] Code diffs and wide technical content scroll inside their container — measured per width.
- [x] Browser zoom up to 150 % prevents neither navigation nor component selection — verified as a round trip through `?component=` and the inspector.
- [x] The existing 1920 × 1080 rendering stays stable — identical pane widths, all 20 acceptance tests green.

## Noticed but deliberately not fixed (belongs to other issues)

- **Long agent display names truncate at a 260 px run pane** (`AgentTreeItem`, `span.truncate`). The full id sits below the name in monospace, so nothing is lost outright, but there is no hover title. The agent area is being reworked in **#39** — a hover title or a second line belongs there.
- **React Flow's edge elements are tab stops without a visible focus indicator.** They sit in the tab order between the toolbar and the canvas controls at every width, including at 1920 before this change. Canvas accessibility is **#35**.
- **`elementFromPoint` at an edge's bounding-box centre lands on a node** for curved edges. Geometry, not obstruction — noted only so a future accessibility probe does not read it as a regression (**#35**).
- The Vite 500 kB chunk warning is unchanged and accepted in ADR 0003.

## ADR numbering

This branch adds `docs/decisions/0014-desktop-viewport-and-absolute-pane-minimums.md`. #38 and #39 are in flight in parallel and may claim 0014 as well — whichever merges second should renumber.
