### PR TITLE
[UX] Agentenbereich verdichten und lange Inhalte progressiv offenlegen (#39)

### DIFF
--- a/docs/decisions/0014-agent-pane-density-and-disclosure.md
+++ b/docs/decisions/0014-agent-pane-density-and-disclosure.md
@@ -1,0 +1,142 @@
+# 14. Agent pane density: what is painted first, and what is never removed
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #39 (part of the v0 epic #1)
+- **Builds on:** [0011 — Run and agent hierarchy](./0011-run-and-agent-hierarchy.md),
+  [0003 — Frontend state split and live updates](./0003-frontend-state-split-and-live-updates.md)
+
+## Context
+
+ADR 0011 gave the run/agent pane its content: every row answers role, assigned
+task, last reported timestamp, explicit status and reported progress, and every
+"nothing was reported" case has its own label. It did not say what any of that
+should *weigh*.
+
+Against real data the result flattens. A run of ten agents at three levels —
+what the simulator's `self` scenario reports — paints ten rows of seven lines,
+almost all of them at 11 px, all of them the same colour. Measured on `develop`
+at 1920 × 1080 the agent list is **2150 px tall in a 345 px pane**, with 240 of
+its 256 text elements at 11 px. Two of those rows fit fully on screen. The root
+orchestrator's `assignedTask` is a full paragraph and a subagent's is three issue
+titles chained with `·`, so the longest reports are also the ones that push
+everything else off the screen.
+
+Two failure modes are specific to *this* pane, and both are worse than the
+density problem they would solve:
+
+- Any rule that decides "this agent matters less" is a **verdict about agent
+  work**, which the product forbids (#1). The obvious rule — "nothing has
+  happened here for a while" — is exactly the stall detection ADR 0011 ruled out.
+- Any shortening done in JavaScript stores a **rewritten report**. An assigned
+  task with an ellipsis in it is not what the agent said.
+
+## Decision
+
+### Density follows the agent's own reported status, and no clock is read
+
+A row paints its detail block by default exactly when the agent's last reported
+status is one of `working`, `waiting`, `blocked` **and** it reported no
+`finishedOutcome`. Everything else — `done`, `idle`, a reported outcome, and "no
+status was ever reported" — starts compact. `reportedWorkState` in
+`runAgents/reporting.ts` is that rule, and it reads two fields: `status` and
+`finishedOutcome`.
+
+It reads no third field. `lastEventAt`, `startedAt` and `Date.now()` are not
+consulted, here or anywhere else in the module — ADR 0011's "there is no stall
+detection, and no clock is consulted" survives this change unchanged, and a test
+asserts it by giving a `working` agent a timestamp from 2020 and a `done` agent
+one from 2099: the density does not move.
+
+The reason for reading the status rather than the clock is not caution. An agent
+that reported `working` an hour ago and one that reported it a second ago have
+made the *same statement*, and the cockpit cannot tell the two apart. The
+reported word is the only thing the pane knows; deriving from anything else
+would produce a claim the data does not support.
+
+The word "inactive" does not appear in the interface. A compact row says what
+the agent reported — `fertig`, `untätig`, `kein Status gemeldet` — and the test
+that forbids the derived-verdict vocabulary covers the new markup too.
+
+Compact is a *smaller rendering of the same row*, not a smaller row: the agent,
+its role, its reported status, its status message and its assigned task are all
+still there. Only progress, the last reported timestamp, the reported outcome
+and the agent id move behind the disclosure. Two things never do: the reported
+status, because it is the sentence the row exists for, and the attachment notes
+of a malformed parent reference, because hiding those would hide the fact that
+the report was malformed.
+
+The user's own toggle wins over the derived default and is stored as an
+*override* keyed by agent id, in component state. A row somebody opened stays
+open when the next report for that agent arrives; a row nobody touched follows
+the report. Nothing about it is persisted — it describes one snapshot of one
+run, not a layout preference (ADR 0003).
+
+### Long reports are clipped by CSS, never shortened in code
+
+`ReportedText` renders the complete string and lets CSS `line-clamp` decide how
+many lines are painted. No substring is ever computed, so there is no code path
+on which a rewritten report could reach the user. The complete text stays in the
+DOM and in the accessibility tree at all times: it is selectable, copyable,
+findable with the browser's own search and read out in full by a screen reader,
+whether the control was used or not. The control changes the paint.
+
+Whether a control appears at all is decided by a character budget (90) rather
+than by measuring the rendered box. The budget is deterministic, independent of
+the current pane width, and therefore identical in Chromium and in jsdom, which
+is what makes "the full text is still reachable" a testable statement rather
+than a screenshot.
+
+### The two progress forms are untouched
+
+`ReportedProgress` keeps exactly the geometry ADR 0011 fixed: `scope: own_task`
+**and** `basis: completed_steps` is ten discrete segments with
+`role="progressbar"`; everything else, including every `scope: overall_estimate`,
+is a claim with no track, no fill, a leading `≈` and an attribution. Density
+moved *where* the block is painted, never *what* it is. The two forms still
+share no container and no shape, and the tests that assert that structurally now
+open the row first instead of asserting less.
+
+### 12 px is the floor; 11 px is a named exception
+
+Regular secondary information — labels, statuses, reported tasks, reported
+messages, section headings, badges — is 12 px or larger. The one exception is
+`.pane-meta`: monospaced identifiers and UTC timestamps. They have a fixed
+shape, they are compared rather than read, and they are the only place where the
+extra px buys real density. If a string does not fit "an id or a timestamp", it
+does not get the class.
+
+The shared `.pane-heading` moved from 11 px to 12 px with it. It is the same
+category of text in all three panes, and a floor that only holds in one pane is
+not a floor.
+
+### One focus treatment for the whole card
+
+Subtree toggle, selection, detail disclosure and the "show the whole text"
+controls carry the identical focus ring (2 px, `--ring`), and hover, focus and
+selection are painted on the row rather than on the control that happens to be
+under the cursor. Measured in Chromium, all six interactive controls of the pane
+resolve to `--tw-ring-shadow: 0 0 0 2px oklch(0.78 0.11 235)` when focused.
+
+## Consequences
+
+- The agent list of the `self` scenario is **1081 px instead of 2150 px** at
+  1920 × 1080, and the pane's horizontal overflow at 1280 drops from 111 px to
+  72 px. Five rows fit fully on screen instead of two, and 5 text elements sit
+  below 12 px instead of 240.
+- `sr-only` is `position: absolute`, and the shadcn `ScrollArea` root is the
+  nearest positioned ancestor of everything in the pane. A screen-reader label
+  therefore has to sit inside a positioned in-flow element, or it escapes the
+  scroll container's clipping and stretches the pane by its own offset. The
+  agent row and the status tally carry `relative` for that reason; it is not
+  decoration.
+- Reported numbers are no longer visible without an interaction for agents that
+  reported an outcome. That is the intended trade: a finished agent's 100 % meter
+  is the most redundant thing on the screen, and its status already says
+  `fertig`. Tests and the acceptance suite open the row rather than assert less.
+- A future feature that wants to fold rows by age, staleness or "recent
+  activity" has to re-open both this ADR and ADR 0011. That is intended.
+- `ReportedText` cannot know that a 100-character string happens to fit a very
+  wide pane, so its control can occasionally be a no-op. That is the price of a
+  rule that behaves identically in a test and in a browser, and the failure mode
+  is a harmless control rather than a hidden report.

--- a/docs/decisions/0016-agent-pane-density-and-disclosure.md
+++ b/docs/decisions/0016-agent-pane-density-and-disclosure.md
@@ -1,4 +1,4 @@
-# 14. Agent pane density: what is painted first, and what is never removed
+# 16. Agent pane density: what is painted first, and what is never removed
 
 - **Status:** accepted
 - **Date:** 2026-08-04

--- a/e2e/tests/04-run-agents.spec.ts
+++ b/e2e/tests/04-run-agents.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 
 import { getJson } from '../src/api.js'
 import { MAIN_PROJECT, MAIN_RUN } from '../src/config.js'
@@ -33,6 +33,21 @@ const ARCHITECT = 'subagent-architecture-mapper'
 const IMPLEMENTER = 'subagent-implementer'
 const REVIEWER = 'subagent-reviewer'
 const TESTER = 'subagent-test-engineer'
+
+/**
+ * Opens one agent row's detail block.
+ *
+ * By the end of the representative sequence every agent of this run has
+ * reported either an outcome or `idle`, so every row starts compact (#39). The
+ * detail is one click — or one `Enter` — away, and everything that used to be
+ * painted unconditionally is inside it.
+ */
+async function openDetails(page: Page, agentId: string) {
+  const toggle = page.getByTestId(`agent-detail-toggle-${agentId}`)
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  await toggle.click()
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+}
 
 test('4 · the tree is three levels deep with two subagents running in parallel below one parent', async ({
   page,
@@ -78,7 +93,8 @@ test('4 · the tree is three levels deep with two subagents running in parallel 
     )
   }
 
-  // Every row answers the four reporting questions with what was reported.
+  // Every row answers the four reporting questions with what was reported. The
+  // agent, its reported status and its assigned task are on the compact row …
   await expect(page.getByTestId(`agent-task-${TESTER}`)).toContainText(
     'Cover the new tax module with table tests.',
   )
@@ -86,6 +102,17 @@ test('4 · the tree is three levels deep with two subagents running in parallel 
     'data-status',
     'done',
   )
+
+  // … and the rest is one deliberate action away. Every agent here reported an
+  // outcome or `idle`, so every row starts compact — a density read off the
+  // reported status, not off a clock (#39).
+  for (const agentId of [ROOT, ARCHITECT, IMPLEMENTER, REVIEWER, TESTER]) {
+    await expect(page.getByTestId(`agent-row-${agentId}`)).toHaveAttribute(
+      'data-density',
+      'compact',
+    )
+  }
+  await openDetails(page, TESTER)
   await expect(page.getByTestId(`agent-outcome-${TESTER}`)).toHaveAttribute(
     'data-outcome',
     'completed',
@@ -101,6 +128,12 @@ test('4 · an overall estimate and a counted subagent progress are told apart by
 }) => {
   await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
   await expect(page.getByTestId('pane-run-agents')).toBeVisible()
+
+  // Reported numbers live in the row's detail block (#39). Opening it is the
+  // deliberate action; nothing about the two renderings changes with it.
+  await openDetails(page, ROOT)
+  await openDetails(page, TESTER)
+  await openDetails(page, IMPLEMENTER)
 
   const orchestratorProgress = page.getByTestId(`agent-progress-${ROOT}`)
   const testerProgress = page.getByTestId(`agent-progress-${TESTER}`)
@@ -166,4 +199,107 @@ test('4 · an overall estimate and a counted subagent progress are told apart by
   await expect(revisions).toHaveCount(2)
   await expect(page.getByTestId('plan-revisions')).toContainText('Revision 1')
   await expect(page.getByTestId('plan-revisions')).toContainText('Revision 2')
+})
+
+test('4 · the pane stays legible and keyboard-operable while it is dense (#39)', async ({
+  page,
+}) => {
+  await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
+  await expect(page.getByTestId('pane-run-agents')).toBeVisible()
+
+  // ---- type size: 11 px only for bounded, monospaced metadata ------------
+  const typography = await page.evaluate(() => {
+    const pane = document.querySelector('[data-testid="pane-run-agents"]')
+    if (pane === null) return null
+    const sizes: Record<string, number> = {}
+    const belowMinimum: { text: string; paneMeta: boolean; monospace: boolean }[] = []
+    const walk = (element: Element) => {
+      const ownsText = [...element.childNodes].some(
+        (node) => node.nodeType === Node.TEXT_NODE && (node.textContent ?? '').trim() !== '',
+      )
+      if (ownsText) {
+        const style = getComputedStyle(element)
+        const size = Number.parseFloat(style.fontSize)
+        sizes[size.toFixed(2)] = (sizes[size.toFixed(2)] ?? 0) + 1
+        if (size < 12) {
+          belowMinimum.push({
+            text: (element.textContent ?? '').trim().slice(0, 40),
+            paneMeta: element.className.toString().includes('pane-meta'),
+            monospace: style.fontFamily.toLowerCase().includes('mono'),
+          })
+        }
+      }
+      for (const child of element.children) walk(child)
+    }
+    walk(pane)
+    return { sizes, belowMinimum }
+  })
+
+  expect(typography).not.toBeNull()
+  // Regular secondary information is 12 px or larger; the exceptions are named.
+  for (const entry of typography?.belowMinimum ?? []) {
+    expect(entry.paneMeta, `sub-12 px text must be pane-meta: ${entry.text}`).toBe(true)
+    expect(entry.monospace, `pane-meta must be monospaced: ${entry.text}`).toBe(true)
+  }
+  expect(Number(typography?.sizes['12.00'] ?? 0)).toBeGreaterThan(0)
+
+  // ---- the disclosures are reachable and operable with the keyboard ------
+  const toggle = page.getByTestId(`agent-detail-toggle-${ROOT}`)
+  await toggle.focus()
+  await expect(toggle).toBeFocused()
+  const ring = await toggle.evaluate((element) =>
+    getComputedStyle(element).getPropertyValue('--tw-ring-shadow').trim(),
+  )
+  expect(ring, 'a focused control must carry the shared focus ring').toContain('2px')
+
+  await page.keyboard.press('Enter')
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  await expect(page.getByTestId(`agent-row-${ROOT}`)).toHaveAttribute(
+    'data-density',
+    'detailed',
+  )
+  await expect(toggle).toBeFocused()
+
+  await page.keyboard.press('Space')
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  await expect(page.getByTestId(`agent-row-${ROOT}`)).toHaveAttribute(
+    'data-density',
+    'compact',
+  )
+
+  // ---- reported texts are clipped, never shortened -----------------------
+  const response = await getJson(`/api/v1/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}/agents`)
+  const reportedTasks = new Map(
+    (response.body as AgentsResponse).agents.map((entry) => [
+      entry.agentId,
+      entry.assignedTask ?? '',
+    ]),
+  )
+
+  const painted = await page.evaluate(() =>
+    [
+      ...document.querySelectorAll(
+        '[data-testid^="agent-task-"]:not([data-testid$="-toggle"])',
+      ),
+    ].map((element) => ({
+      agentId: (element.getAttribute('data-testid') ?? '').replace('agent-task-', ''),
+      clipped: element.getAttribute('data-clipped'),
+      declaredLength: Number(element.getAttribute('data-full-length')),
+      text: element.textContent ?? '',
+      lineClamp: getComputedStyle(element).webkitLineClamp,
+    })),
+  )
+  expect(painted.length).toBe(5)
+
+  for (const entry of painted) {
+    const reported = reportedTasks.get(entry.agentId)
+    // The whole report is in the document, character for character. Nothing is
+    // shortened, re-worded or replaced by an ellipsis.
+    expect(entry.text, `the task of ${entry.agentId} must be quoted verbatim`).toBe(reported)
+    expect(entry.declaredLength).toBe(reported?.length)
+    // Clipping is decided by the character budget alone, and paints two lines.
+    const shouldClip = (reported?.length ?? 0) > 90
+    expect(entry.clipped).toBe(shouldClip ? 'true' : 'false')
+    expect(entry.lineClamp).toBe(shouldClip ? '2' : 'none')
+  }
 })

--- a/e2e/tests/08-viewport.spec.ts
+++ b/e2e/tests/08-viewport.spec.ts
@@ -132,7 +132,7 @@ test('8 · content below the fold is reachable inside its own pane, not by scrol
       'shop-platform.orders.domain.tax',
     )}`,
   )
-  await expect(page.getByTestId('agent-row-subagent-reviewer')).toBeVisible()
+  await expect(page.getByTestId('agent-row-subagent-test-engineer')).toBeVisible()
   await expect(page.getByTestId('diff-groups')).toBeVisible()
 
   // Both side panes have more content than height — otherwise this test would
@@ -152,19 +152,29 @@ test('8 · content below the fold is reachable inside its own pane, not by scrol
   expect(regions.runPane!.scrollHeight).toBeGreaterThan(regions.runPane!.clientHeight)
   expect(regions.inspector!.scrollHeight).toBeGreaterThan(regions.inspector!.clientHeight)
 
-  // The deepest agent row starts below the fold and is brought into view by
-  // scrolling the pane — the page itself stays where it is.
-  const before = await page.getByTestId('agent-row-subagent-reviewer').boundingBox()
+  // The last agent row starts below the fold and is brought into view by
+  // scrolling the pane — the page itself stays where it is. It is the last row
+  // rather than the deepest one because the rows are compact by default (#39):
+  // the reviewer now fits above the fold, the run pane still does not.
+  const before = await page.getByTestId('agent-row-subagent-test-engineer').boundingBox()
   expect(before).not.toBeNull()
   expect(
     before!.y + before!.height,
-    'the deepest agent row is expected to start below the fold',
+    'the last agent row is expected to reach past the fold',
   ).toBeGreaterThan(ACCEPTANCE_VIEWPORT.height)
 
-  await page.getByTestId('agent-row-subagent-reviewer').scrollIntoViewIfNeeded()
-  const after = await page.getByTestId('agent-row-subagent-reviewer').boundingBox()
+  await page.getByTestId('agent-row-subagent-test-engineer').scrollIntoViewIfNeeded()
+  const after = await page.getByTestId('agent-row-subagent-test-engineer').boundingBox()
   expect(after).not.toBeNull()
-  expect(after!.y).toBeLessThan(ACCEPTANCE_VIEWPORT.height - 100)
+  // Fully inside the viewport, top and bottom. Asserting the whole box rather
+  // than a fixed distance from the bottom edge keeps the check independent of
+  // how tall a row happens to be — compact rows are shorter than the margin the
+  // assertion used to assume (#39).
+  expect(after!.y, 'the row must start inside the viewport').toBeGreaterThanOrEqual(0)
+  expect(
+    after!.y + after!.height,
+    'the row must end inside the viewport',
+  ).toBeLessThanOrEqual(ACCEPTANCE_VIEWPORT.height)
 
   const pageOffset = await page.evaluate(() => ({
     x: window.scrollX,
@@ -175,7 +185,7 @@ test('8 · content below the fold is reachable inside its own pane, not by scrol
   const reports = await probeControls(page, [
     {
       name: 'deepest agent row after scrolling its pane',
-      selector: '[data-testid="agent-row-subagent-reviewer"]',
+      selector: '[data-testid="agent-row-subagent-test-engineer"]',
     },
   ])
   expect(

--- a/frontend/src/components/workspace/RunAgentPane.test.tsx
+++ b/frontend/src/components/workspace/RunAgentPane.test.tsx
@@ -8,10 +8,14 @@ import type { AgentListResponse } from '@/api/types'
 import { PROJECT_ID, RUN_ID, createFakeFetch, streamedEvent } from '@/test/fixtures'
 import { renderApp } from '@/test/renderApp'
 import {
+  CHAINED_TASK,
   HISTORICAL_RUN_ID,
+  LONG_STATUS_NOTE,
+  PARAGRAPH_TASK,
   historicalAgentsResponse,
   historicalPlansResponse,
   historicalRunResponse,
+  longTaskAgentsResponse,
   openRunResponse,
   runPaths,
   runsWithHistoryResponse,
@@ -96,6 +100,11 @@ async function renderPane(url = WORKSPACE_URL, extraOverrides: Record<string, un
   return { ...app, ...test }
 }
 
+/** The per-row detail disclosure of one agent. */
+function detailToggle(agentId: string) {
+  return screen.findByTestId(`agent-detail-toggle-${agentId}`)
+}
+
 // ---------------------------------------------------------------------------
 // Hierarchy
 // ---------------------------------------------------------------------------
@@ -136,11 +145,19 @@ describe('agent hierarchy in the pane', () => {
   })
 
   it('says so when an agent never reported a status or a number', async () => {
+    const user = userEvent.setup()
     await renderPane()
 
+    // The status is part of the compact row: "nothing was reported" is the
+    // sentence the row exists for and is never behind a disclosure.
     expect(screen.getByTestId('agent-status-subagent-tester')).toHaveTextContent(
       'kein Status gemeldet',
     )
+
+    // The reported number lives in the detail block. An agent that never
+    // reported a status starts compact (#39), so the row is opened first — and
+    // it then says "nothing was reported" there too, rather than showing a zero.
+    await user.click(await detailToggle('subagent-tester'))
     expect(screen.getByTestId('agent-progress-subagent-tester')).toHaveAttribute(
       'data-progress-form',
       'none',
@@ -351,7 +368,13 @@ describe('reported progress', () => {
   })
 
   it('keeps an estimate and counted steps structurally apart', async () => {
+    const user = userEvent.setup()
     await renderPane()
+
+    // The architect reported an outcome, so its row starts compact (#39). The
+    // separation asserted below is about the two renderings, not about which of
+    // them happens to be painted first, so the row is opened explicitly.
+    await user.click(await detailToggle('subagent-architect'))
 
     const estimate = screen.getByTestId('agent-progress-orchestrator-root')
     const counted = screen.getByTestId('agent-progress-subagent-architect')
@@ -417,6 +440,271 @@ describe('plan revisions', () => {
     expect(
       screen.getByTestId('plan-step-plan-2026-08-04-0001-2-step-rates'),
     ).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Density and progressive disclosure (#39)
+// ---------------------------------------------------------------------------
+
+/** Renders the pane against the long-text stress case of #39. */
+function renderLongTaskPane() {
+  return renderPane(WORKSPACE_URL, { [runPaths.agents]: longTaskAgentsResponse })
+}
+
+describe('default density of an agent row', () => {
+  it('starts compact unless the agent itself reported ongoing work', async () => {
+    await renderPane()
+
+    // Reported `working` / `waiting` and no outcome: details are painted.
+    expect(screen.getByTestId('agent-row-orchestrator-root')).toHaveAttribute(
+      'data-density',
+      'detailed',
+    )
+    expect(screen.getByTestId('agent-row-subagent-reviewer')).toHaveAttribute(
+      'data-density',
+      'detailed',
+    )
+
+    // Reported an outcome, and reported no status at all: compact.
+    expect(screen.getByTestId('agent-row-subagent-architect')).toHaveAttribute(
+      'data-density',
+      'compact',
+    )
+    expect(screen.getByTestId('agent-row-subagent-tester')).toHaveAttribute(
+      'data-density',
+      'compact',
+    )
+
+    // Compact is a smaller rendering, not a smaller report: agent, role, status
+    // and assigned task are all still on the row.
+    const compact = screen.getByTestId('agent-row-subagent-architect')
+    expect(within(compact).getByText('Architecture Mapper')).toBeInTheDocument()
+    expect(within(compact).getByText('Subagent')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-status-subagent-architect')).toHaveTextContent('fertig')
+    expect(screen.getByTestId('agent-task-subagent-architect')).toHaveTextContent(
+      'Angewandtes Architekturmodell veröffentlichen.',
+    )
+  })
+
+  it('reads the density off the reported status, never off a timestamp', async () => {
+    // Two agents whose timestamps say the opposite of their statuses: the
+    // "working" one reported hours ago, the "done" one seconds ago. If any clock
+    // were consulted, this is where it would show.
+    await renderPane(WORKSPACE_URL, {
+      [runPaths.agents]: {
+        ...treeAgentsResponse,
+        agents: treeAgentsResponse.agents.map((entry) =>
+          entry.agentId === 'subagent-implementer'
+            ? { ...entry, lastEventAt: '2020-01-01T00:00:00Z' }
+            : entry.agentId === 'subagent-architect'
+              ? { ...entry, lastEventAt: '2099-12-31T23:59:59Z' }
+              : entry,
+        ),
+      },
+    })
+
+    expect(screen.getByTestId('agent-row-subagent-implementer')).toHaveAttribute(
+      'data-density',
+      'detailed',
+    )
+    expect(screen.getByTestId('agent-row-subagent-implementer')).toHaveAttribute(
+      'data-work-state',
+      'ongoing',
+    )
+    expect(screen.getByTestId('agent-row-subagent-architect')).toHaveAttribute(
+      'data-density',
+      'compact',
+    )
+
+    // The stale timestamp is shown as what it is, without a word about it.
+    expect(screen.getByTestId('agent-last-event-subagent-implementer')).toHaveTextContent(
+      '01.01.2020, 00:00:00 UTC',
+    )
+    expect(screen.getByTestId('pane-run-agents').textContent ?? '').not.toMatch(
+      DERIVED_VERDICTS,
+    )
+  })
+
+  it('counts the reported status words without turning them into a verdict', async () => {
+    await renderPane()
+
+    const tally = screen.getByTestId('agent-status-tally')
+    expect(tally).toHaveTextContent('2 × arbeitet')
+    expect(tally).toHaveTextContent('1 × wartet')
+    expect(tally).toHaveTextContent('1 × fertig')
+    expect(tally).toHaveTextContent('1 × kein Status gemeldet')
+    expect(tally.textContent ?? '').not.toMatch(DERIVED_VERDICTS)
+  })
+})
+
+describe('opening and closing a row', () => {
+  it('is operable with the keyboard alone and keeps the focus on the control', async () => {
+    const user = userEvent.setup()
+    await renderPane()
+
+    const row = screen.getByTestId('agent-row-subagent-architect')
+    const select = within(row).getByRole('button', { pressed: false })
+    select.focus()
+
+    // The disclosure is the next stop in the tab order of the card.
+    await user.tab()
+    const toggle = screen.getByTestId('agent-detail-toggle-subagent-architect')
+    expect(toggle).toHaveFocus()
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    await user.keyboard('{Enter}')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(row).toHaveAttribute('data-density', 'detailed')
+    expect(screen.getByTestId('agent-progress-subagent-architect')).toBeInTheDocument()
+    expect(toggle).toHaveFocus()
+
+    // Space closes it again, and the focus never leaves the button.
+    await user.keyboard(' ')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(row).toHaveAttribute('data-density', 'compact')
+    expect(toggle).toHaveFocus()
+  })
+
+  it('keeps a row the user opened open when the next report arrives', async () => {
+    const user = userEvent.setup()
+    const { queryClient, setAgents } = await renderPane()
+
+    await user.click(await detailToggle('subagent-architect'))
+    expect(screen.getByTestId('agent-row-subagent-architect')).toHaveAttribute(
+      'data-density',
+      'detailed',
+    )
+
+    setAgents({
+      ...treeAgentsResponse,
+      agents: treeAgentsResponse.agents.map((entry) =>
+        entry.agentId === 'subagent-architect'
+          ? { ...entry, progress: { percent: 100, scope: 'own_task', basis: 'completed_steps' } }
+          : entry,
+      ),
+    })
+    await act(async () => {
+      applyLiveEvent(
+        queryClient as QueryClient,
+        streamedEvent(
+          'agent.progress_reported',
+          { percent: 100, scope: 'own_task', basis: 'completed_steps', note: '' },
+          { agentId: 'subagent-architect', position: 64 },
+        ),
+      )
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-progress-subagent-architect')).toHaveTextContent(
+        '100 %',
+      ),
+    )
+    expect(screen.getByTestId('agent-row-subagent-architect')).toHaveAttribute(
+      'data-density',
+      'detailed',
+    )
+  })
+})
+
+describe('long reported texts', () => {
+  it('clips the paint and keeps the whole report in the document', async () => {
+    await renderLongTaskPane()
+
+    const task = screen.getByTestId('agent-task-orchestrator-root')
+    // Clipped for the eye …
+    expect(task).toHaveAttribute('data-clipped', 'true')
+    expect(task.className).toContain('line-clamp-2')
+    // … and complete for everything else: no substring is ever computed, so the
+    // reported wording is reachable without any interaction at all.
+    expect(task).toHaveTextContent(PARAGRAPH_TASK)
+    expect(task).toHaveAttribute('data-full-length', String(PARAGRAPH_TASK.length))
+
+    const chained = screen.getByTestId('agent-task-subagent-backend-api')
+    expect(chained).toHaveTextContent(CHAINED_TASK)
+    expect(chained.textContent).toBe(CHAINED_TASK)
+
+    // A short task gets no control, because there is nothing to unfold.
+    expect(
+      screen.queryByTestId('agent-task-subagent-implementer-toggle'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('opens the full text through a deliberate, keyboard-operable action', async () => {
+    const user = userEvent.setup()
+    await renderLongTaskPane()
+
+    const toggle = screen.getByTestId('agent-task-orchestrator-root-toggle')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    toggle.focus()
+    expect(toggle).toHaveFocus()
+    await user.keyboard('{Enter}')
+
+    const task = screen.getByTestId('agent-task-orchestrator-root')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(task).toHaveAttribute('data-clipped', 'false')
+    expect(task.className).not.toContain('line-clamp')
+    expect(task).toHaveTextContent(PARAGRAPH_TASK)
+
+    await user.keyboard(' ')
+    expect(task).toHaveAttribute('data-clipped', 'true')
+    expect(task).toHaveTextContent(PARAGRAPH_TASK)
+  })
+
+  it('treats a long status message the same way, verbatim', async () => {
+    await renderLongTaskPane()
+
+    const note = screen.getByTestId('agent-status-note-orchestrator-root')
+    expect(note.textContent).toBe(LONG_STATUS_NOTE)
+    expect(note).toHaveAttribute('data-clipped', 'true')
+    expect(
+      screen.getByTestId('agent-status-note-orchestrator-root-toggle'),
+    ).toBeInTheDocument()
+  })
+
+  it('does not let a paragraph change the structure of the pane', async () => {
+    await renderLongTaskPane()
+
+    // The same sections, the same list, the same number of rows as with short
+    // texts — a long report grows a row, never the pane's skeleton.
+    expect(screen.getByTestId('run-state')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-tree-region')).toBeInTheDocument()
+    expect(screen.getByTestId('plan-revisions')).toBeInTheDocument()
+
+    const list = screen.getByRole('list', { name: 'Agenthierarchie' })
+    expect(list.querySelectorAll('[data-testid^="agent-row-"]')).toHaveLength(3)
+    expect(screen.getByTestId('agent-row-subagent-backend-api')).toHaveAttribute(
+      'data-depth',
+      '1',
+    )
+  })
+
+  it('keeps the two progress forms apart across a collapse and a reopen', async () => {
+    const user = userEvent.setup()
+    await renderLongTaskPane()
+
+    // The orchestrator reported an overall estimate and starts compact here.
+    await user.click(await detailToggle('orchestrator-root'))
+    await user.click(await detailToggle('subagent-backend-api'))
+
+    const claim = screen.getByTestId('agent-progress-orchestrator-root')
+    const counted = screen.getByTestId('agent-progress-subagent-backend-api')
+
+    expect(claim).toHaveAttribute('data-progress-form', 'claim')
+    expect(claim.querySelectorAll('[data-progress-segment]')).toHaveLength(0)
+    expect(within(claim).queryByRole('progressbar')).not.toBeInTheDocument()
+    expect(claim.querySelector('[data-claim-marker]')).not.toBeNull()
+
+    expect(counted).toHaveAttribute('data-progress-form', 'counted')
+    expect(counted.querySelectorAll('[data-progress-segment]')).toHaveLength(10)
+    expect(within(counted).getByRole('progressbar')).toBeInTheDocument()
+
+    expect(claim.contains(counted)).toBe(false)
+    expect(counted.contains(claim)).toBe(false)
+    expect(claim.getAttribute('data-progress-group')).not.toBe(
+      counted.getAttribute('data-progress-group'),
+    )
   })
 })
 

--- a/frontend/src/components/workspace/RunAgentPane.tsx
+++ b/frontend/src/components/workspace/RunAgentPane.tsx
@@ -45,6 +45,10 @@ export interface RunAgentPaneProps {
  *    (ADR 0003), so an `agent.progress_reported` refetches this run's agent list
  *    and nothing else. Selection and collapse state live outside the cache, so a
  *    refetch cannot move them.
+ * 5. **Density never removes anything.** Long reported texts are clipped by CSS
+ *    and stay complete in the DOM, and a compact agent row is one keystroke away
+ *    from its full detail. What a row shows first follows the agent's *own*
+ *    reported status — never elapsed time (#39, ADR 0014).
  */
 export function RunAgentPane({ projectId, runId }: RunAgentPaneProps) {
   const runs = useRuns(projectId)
@@ -106,9 +110,9 @@ export function RunAgentPane({ projectId, runId }: RunAgentPaneProps) {
                 skeletonRows={2}
               >
                 {run.data && (
-                  <dl className="space-y-0.5 text-2xs">
+                  <dl className="space-y-0.5 text-xs">
                     <Row label="Run">
-                      <span className="font-mono">{run.data.run.runId}</span>
+                      <span className="pane-meta">{run.data.run.runId}</span>
                     </Row>
                     <Row label="Zustand">
                       <span
@@ -125,16 +129,22 @@ export function RunAgentPane({ projectId, runId }: RunAgentPaneProps) {
                       </span>
                     </Row>
                     <Row label="Beginn">
-                      <span className="font-mono">
+                      <span className="pane-meta">
                         {formatTimestamp(run.data.run.startedAt)}
                       </span>
                     </Row>
                     <Row label="Ende">
-                      <span className="font-mono">
-                        {run.data.run.finishedAt
-                          ? formatTimestamp(run.data.run.finishedAt)
-                          : 'kein Ende gemeldet'}
-                      </span>
+                      {/*
+                        A timestamp is metadata and may be 11 px; "nothing was
+                        reported" is a sentence and is not (#39).
+                      */}
+                      {run.data.run.finishedAt ? (
+                        <span className="pane-meta">
+                          {formatTimestamp(run.data.run.finishedAt)}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">kein Ende gemeldet</span>
+                      )}
                     </Row>
                     <Row label="Umfang">
                       {counted(run.data.run.counts.agents, COUNT_LABELS.agent)} ·{' '}
@@ -153,7 +163,7 @@ export function RunAgentPane({ projectId, runId }: RunAgentPaneProps) {
             <div className="flex items-center justify-between gap-2">
               <span className="pane-heading">Agenthierarchie</span>
               {agents.isSuccess && (
-                <Badge variant="outline" className="text-2xs font-normal">
+                <Badge variant="outline" className="font-normal">
                   {agentList.length} gemeldet
                 </Badge>
               )}
@@ -224,7 +234,7 @@ function Section({
             <span className="pane-heading">{title}</span>
           </Button>
         </CollapsibleTrigger>
-        {count && <span className="text-muted-foreground text-2xs">{count}</span>}
+        {count && <span className="text-muted-foreground text-xs">{count}</span>}
       </div>
       <CollapsibleContent className="pt-1">{children}</CollapsibleContent>
     </Collapsible>

--- a/frontend/src/components/workspace/runAgents/AgentTree.tsx
+++ b/frontend/src/components/workspace/runAgents/AgentTree.tsx
@@ -1,5 +1,5 @@
 import { ChevronsDownUp, ChevronsUpDown, Search } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import type { AgentId, RunAgent } from '@/api/types'
 import { EmptyState } from '@/components/AsyncState'
@@ -13,6 +13,8 @@ import {
   filterAgentTree,
   visibleAgentRows,
 } from './agentHierarchy'
+import { AGENT_PANE_TEXT } from './paneText'
+import { AGENT_STATUS_GLYPH, AGENT_STATUS_LABEL, reportedWorkState, statusTally } from './reporting'
 
 export interface AgentTreeProps {
   agents: readonly RunAgent[]
@@ -28,16 +30,26 @@ export interface AgentTreeProps {
  * instead of drifting to the right, and collapsing a branch is a change to which
  * rows are produced, not to the DOM structure around them.
  *
- * Collapse state lives in the UI store (`collapsedAgentIds`) and is keyed by
- * agent id, so a live event that adds a subagent cannot fold anything the user
- * had opened. Selection is local and transient — it is a property of looking at
- * the run, not of the run (ADR 0003).
+ * Three pieces of viewer state meet here, and they are kept apart on purpose:
+ *
+ * * **Which subtrees are folded** lives in the UI store (`collapsedAgentIds`)
+ *   and is keyed by agent id, so a live event that adds a subagent cannot fold
+ *   anything the user had opened.
+ * * **Which row is selected** is local and transient — it is a property of
+ *   looking at the run, not of the run (ADR 0003).
+ * * **Which rows show their details** is local as well, and stored as an
+ *   *override* rather than as the state itself: without an override a row
+ *   follows the agent's own reported status (#39). A row the user opened
+ *   therefore stays open when the next report arrives, and a row nobody touched
+ *   follows the report. Nothing about it is persisted, because it describes a
+ *   snapshot of the run rather than a layout preference.
  */
 export function AgentTree({ agents, selectedAgentId, onSelectAgent }: AgentTreeProps) {
   const collapsedAgentIds = useUiStore((state) => state.collapsedAgentIds)
   const setAgentCollapsed = useUiStore((state) => state.setAgentCollapsed)
   const toggleAgentCollapsed = useUiStore((state) => state.toggleAgentCollapsed)
   const [filter, setFilter] = useState('')
+  const [detailOverrides, setDetailOverrides] = useState<Record<AgentId, boolean>>({})
 
   const tree = useMemo(() => buildAgentTree(agents), [agents])
   const visibleRoots = useMemo(() => filterAgentTree(tree.roots, filter), [tree.roots, filter])
@@ -50,6 +62,17 @@ export function AgentTree({ agents, selectedAgentId, onSelectAgent }: AgentTreeP
 
   const branches = useMemo(() => branchAgentIds(tree.roots), [tree.roots])
   const allCollapsed = branches.length > 0 && branches.every((id) => collapsedSet.has(id))
+  const tally = useMemo(() => statusTally(agents), [agents])
+
+  const toggleDetail = useCallback(
+    (agentId: AgentId) =>
+      setDetailOverrides((current) => {
+        const agent = agents.find((candidate) => candidate.agentId === agentId)
+        const byReport = agent !== undefined && reportedWorkState(agent) === 'ongoing'
+        return { ...current, [agentId]: !(current[agentId] ?? byReport) }
+      }),
+    [agents],
+  )
 
   return (
     <div data-testid="agent-tree" className="space-y-2">
@@ -71,8 +94,8 @@ export function AgentTree({ agents, selectedAgentId, onSelectAgent }: AgentTreeP
         {branches.length > 0 && (
           <Button
             variant="ghost"
-            size="icon"
-            className="size-7 shrink-0"
+            size="icon-sm"
+            className="focus-visible:ring-ring shrink-0 rounded-sm focus-visible:ring-2 focus-visible:outline-none"
             aria-label={allCollapsed ? 'Alle Subagents ausklappen' : 'Alle Subagents einklappen'}
             onClick={() => {
               for (const id of branches) setAgentCollapsed(id, !allCollapsed)
@@ -86,6 +109,31 @@ export function AgentTree({ agents, selectedAgentId, onSelectAgent }: AgentTreeP
           </Button>
         )}
       </div>
+
+      {/*
+        How often each status word was reported. A count of reported values, in
+        the same category as `run.counts` — never a share, never an aggregate of
+        the agents' own percentages, which ADR 0011 rules out.
+      */}
+      {tally.length > 0 && (
+        <p
+          data-testid="agent-status-tally"
+          // `relative` for the same reason as on an agent row: the `sr-only`
+          // headline is absolutely positioned and needs a containing block
+          // inside the scroll container.
+          className="text-muted-foreground relative flex flex-wrap gap-x-2 gap-y-0.5 text-xs"
+        >
+          <span className="sr-only">{AGENT_PANE_TEXT.statusTallyLabel}: </span>
+          {tally.map(({ status, count }) => (
+            <span key={status || 'unreported'} data-tally-status={status}>
+              <span aria-hidden="true" className="font-mono">
+                {AGENT_STATUS_GLYPH[status]}
+              </span>{' '}
+              {count} × {AGENT_STATUS_LABEL[status]}
+            </span>
+          ))}
+        </p>
+      )}
 
       {rows.length === 0 ? (
         <EmptyState
@@ -104,7 +152,12 @@ export function AgentTree({ agents, selectedAgentId, onSelectAgent }: AgentTreeP
               node={node}
               collapsed={collapsed}
               selected={node.agent.agentId === selectedAgentId}
+              detailOpen={
+                detailOverrides[node.agent.agentId] ??
+                reportedWorkState(node.agent) === 'ongoing'
+              }
               onToggleCollapsed={toggleAgentCollapsed}
+              onToggleDetail={toggleDetail}
               onSelect={onSelectAgent}
             />
           ))}

--- a/frontend/src/components/workspace/runAgents/AgentTreeItem.tsx
+++ b/frontend/src/components/workspace/runAgents/AgentTreeItem.tsx
@@ -1,4 +1,5 @@
-import { ChevronRight, CornerDownRight, RotateCcw, Unlink } from 'lucide-react'
+import { ChevronDown, ChevronRight, CornerDownRight, RotateCcw, Unlink } from 'lucide-react'
+import { useId, type ReactNode } from 'react'
 
 import type { AgentId } from '@/api/types'
 import { Badge } from '@/components/ui/badge'
@@ -7,43 +8,90 @@ import { cn } from '@/lib/utils'
 
 import type { AgentTreeNode } from './agentHierarchy'
 import { ReportedProgress } from './ProgressDisplay'
+import { ReportedText } from './ReportedText'
+import {
+  AGENT_PANE_TEXT,
+  TEXT_SUBJECT,
+  detailToggleLabel,
+  subtreeToggleLabel,
+} from './paneText'
 import {
   AGENT_ROLE_LABEL,
+  AGENT_STATUS_GLYPH,
   AGENT_STATUS_LABEL,
   OUTCOME_LABEL,
   formatTimestamp,
+  reportedWorkState,
 } from './reporting'
 
 /** Indent per level, in pixels. Kept small so depth 5 still fits the pane. */
 const INDENT_PX = 12
 
+/**
+ * The one focus treatment of this pane.
+ *
+ * Every control inside an agent card — subtree toggle, selection, detail
+ * disclosure, "show the whole text" — carries exactly this, so focus looks the
+ * same wherever the keyboard lands (#39). Hover and selection are properties of
+ * the card and live on the `<li>`; focus is a property of the control and lives
+ * here.
+ */
+const CONTROL_FOCUS =
+  'focus-visible:ring-ring rounded-sm focus-visible:ring-2 focus-visible:outline-none'
+
 export interface AgentTreeItemProps {
   node: AgentTreeNode
   collapsed: boolean
   selected: boolean
+  /** `true` while the row paints its full detail block. */
+  detailOpen: boolean
   onToggleCollapsed: (agentId: AgentId) => void
+  onToggleDetail: (agentId: AgentId) => void
   onSelect: (agentId: AgentId) => void
 }
 
 /**
- * One agent of the tree.
+ * One agent of the tree, in two densities.
  *
- * The row always answers the four questions the issue asks for — role, assigned
- * task, last reported point in time, explicitly reported status — and answers
- * them with what was reported, including "nothing was". `lastEventAt` is a
- * timestamp and never a judgement: the pane does not compare it against a clock
- * and has no notion of an agent being late.
+ * The row answers the same questions it always did — role, assigned task, last
+ * reported point in time, explicitly reported status, reported progress — and
+ * answers them with what was reported, including "nothing was". What changed
+ * with #39 is the **order and the weight**, not the content:
+ *
+ * 1. **Who** — the agent's name, alone on the first line so the tree can be
+ *    scanned vertically at a glance and the name has the whole row to shorten
+ *    into.
+ * 2. **What kind of agent, and what is it doing** — the reported role and the
+ *    reported status, the status carried by a glyph *and* a word so it survives
+ *    greyscale, followed by the reported status message.
+ * 3. **What it was asked to do** — the assigned task, clipped to two lines.
+ * 4. **Everything else** — progress, last reported timestamp, reported outcome
+ *    and the agent id — behind one disclosure per row.
+ *
+ * A row opens that disclosure by default when the agent's own last status names
+ * ongoing work (`reportedWorkState`). No clock is read to decide that, here or
+ * anywhere below: an old timestamp is an old timestamp and never a verdict
+ * (ADR 0011).
+ *
+ * Two things are deliberately *outside* the disclosure and always painted: the
+ * reported status, because it is the sentence the row exists for, and the
+ * attachment notes, because hiding a malformed parent reference would hide the
+ * fact that the report was malformed.
  */
 export function AgentTreeItem({
   node,
   collapsed,
   selected,
+  detailOpen,
   onToggleCollapsed,
+  onToggleDetail,
   onSelect,
 }: AgentTreeItemProps) {
   const { agent, depth, attachment, children, descendantCount } = node
   const hasChildren = children.length > 0
   const name = agent.displayName || agent.agentId
+  const workState = reportedWorkState(agent)
+  const detailId = useId()
 
   return (
     <li
@@ -53,8 +101,18 @@ export function AgentTreeItem({
       data-depth={depth}
       data-attachment={attachment}
       data-selected={selected ? 'true' : 'false'}
+      data-work-state={workState}
+      data-density={detailOpen ? 'detailed' : 'compact'}
       className={cn(
-        'border-l-2 py-1 pr-1',
+        // Hover, focus-within and selection are the same surface treatment, so
+        // the three states of a card can never drift apart.
+        //
+        // `relative` is load-bearing: the row carries `sr-only` labels, and
+        // `sr-only` is `position: absolute`. Without a positioned ancestor
+        // *inside* the scroll container they would be laid out against the
+        // ScrollArea root, escape its clipping and stretch the pane.
+        'relative border-l-2 py-1 pr-1 transition-colors',
+        'hover:bg-accent/30 has-[:focus-visible]:bg-accent/30',
         selected ? 'border-l-primary bg-accent/60' : 'border-l-transparent',
       )}
       style={{ paddingLeft: `${depth * INDENT_PX + 2}px` }}
@@ -63,19 +121,19 @@ export function AgentTreeItem({
         {hasChildren ? (
           <Button
             variant="ghost"
-            size="icon"
-            className="mt-0.5 size-5 shrink-0"
+            size="icon-xs"
+            className={cn('mt-px shrink-0', CONTROL_FOCUS)}
             aria-expanded={!collapsed}
-            aria-label={`Subagents von ${name} ${collapsed ? 'ausklappen' : 'einklappen'}`}
+            aria-label={subtreeToggleLabel(name, collapsed)}
             onClick={() => onToggleCollapsed(agent.agentId)}
           >
             <ChevronRight
-              className={cn('size-3.5 transition-transform', !collapsed && 'rotate-90')}
+              className={cn('transition-transform', !collapsed && 'rotate-90')}
               aria-hidden="true"
             />
           </Button>
         ) : (
-          <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center">
+          <span className="mt-px flex size-6 shrink-0 items-center justify-center">
             {depth > 0 && (
               <CornerDownRight
                 className="text-muted-foreground/60 size-3"
@@ -89,27 +147,108 @@ export function AgentTreeItem({
           type="button"
           aria-pressed={selected}
           onClick={() => onSelect(agent.agentId)}
-          className="focus-visible:ring-ring min-w-0 flex-1 rounded-sm text-left focus-visible:ring-2 focus-visible:outline-none"
+          className={cn('min-w-0 flex-1 py-0.5 text-left', CONTROL_FOCUS)}
         >
           <span className="flex min-w-0 items-center gap-1.5">
-            <span className="truncate text-sm font-medium">{name}</span>
-            <Badge variant="outline" className="shrink-0 text-2xs font-normal">
-              {AGENT_ROLE_LABEL[agent.role]}
-            </Badge>
+            <span
+              className={cn(
+                'truncate text-sm',
+                workState === 'ongoing'
+                  ? 'text-foreground font-semibold'
+                  : 'text-foreground/80 font-medium',
+              )}
+            >
+              {name}
+            </span>
             {collapsed && descendantCount > 0 && (
-              <Badge variant="secondary" className="shrink-0 text-2xs font-normal">
+              <Badge variant="secondary" className="shrink-0 font-normal">
                 +{descendantCount}
               </Badge>
             )}
           </span>
-
-          <span className="text-muted-foreground block truncate font-mono text-2xs">
-            {agent.agentId}
-          </span>
         </button>
+
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          className={cn('mt-px shrink-0', CONTROL_FOCUS)}
+          aria-expanded={detailOpen}
+          aria-controls={detailId}
+          aria-label={detailToggleLabel(name, detailOpen)}
+          data-testid={`agent-detail-toggle-${agent.agentId}`}
+          onClick={() => onToggleDetail(agent.agentId)}
+        >
+          <ChevronDown
+            className={cn('transition-transform', !detailOpen && '-rotate-90')}
+            aria-hidden="true"
+          />
+        </Button>
       </div>
 
-      <div className="space-y-1.5 pt-1 pl-6">
+      <div className="space-y-1 pt-0.5 pl-7">
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 gap-y-0.5 text-xs">
+          <Badge variant="outline" className="shrink-0 font-normal">
+            {AGENT_ROLE_LABEL[agent.role]}
+          </Badge>
+          {/*
+            The reported status cell: the status word and, when the agent sent
+            one, its status message. Both belong to the same statement, so they
+            stay in one element — `agent-status-<id>` is what the acceptance
+            suite reads to check that a projection carries the accepted note.
+          */}
+          <span
+            data-testid={`agent-status-${agent.agentId}`}
+            data-status={agent.status}
+            data-work-state={workState}
+            className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-1.5 gap-y-0.5"
+          >
+            <span className="sr-only">{AGENT_PANE_TEXT.statusLabel}: </span>
+            <span
+              className={cn(
+                'shrink-0 rounded-sm px-1 py-px',
+                workState === 'ongoing'
+                  ? 'bg-secondary text-foreground font-medium'
+                  : 'text-muted-foreground',
+              )}
+            >
+              <span aria-hidden="true" className="font-mono">
+                {AGENT_STATUS_GLYPH[agent.status]}
+              </span>{' '}
+              {AGENT_STATUS_LABEL[agent.status]}
+            </span>
+            {agent.statusNote && (
+              <span className="text-muted-foreground min-w-0 flex-1">
+                <ReportedText
+                  text={agent.statusNote}
+                  subject={TEXT_SUBJECT.statusNote}
+                  agentName={name}
+                  lines={detailOpen ? 3 : 1}
+                  testId={`agent-status-note-${agent.agentId}`}
+                />
+              </span>
+            )}
+          </span>
+        </div>
+
+        <div
+          className={cn('text-xs', !agent.assignedTask && 'text-muted-foreground italic')}
+        >
+          <span className="sr-only">{AGENT_PANE_TEXT.taskLabel}: </span>
+          {agent.assignedTask ? (
+            <ReportedText
+              text={agent.assignedTask}
+              subject={TEXT_SUBJECT.task}
+              agentName={name}
+              lines={2}
+              testId={`agent-task-${agent.agentId}`}
+            />
+          ) : (
+            <span data-testid={`agent-task-${agent.agentId}`}>
+              {AGENT_PANE_TEXT.noTaskReported}
+            </span>
+          )}
+        </div>
+
         {attachment === 'orphaned' && (
           <AttachmentNote
             icon={Unlink}
@@ -125,59 +264,53 @@ export function AgentTreeItem({
           />
         )}
 
-        <dl className="space-y-0.5 text-2xs">
-          <div className="flex gap-1.5">
-            <dt className="text-muted-foreground shrink-0">Aufgabe</dt>
-            <dd
-              data-testid={`agent-task-${agent.agentId}`}
-              className={cn('min-w-0', !agent.assignedTask && 'text-muted-foreground italic')}
-            >
-              {agent.assignedTask || 'keine Aufgabe gemeldet'}
-            </dd>
-          </div>
-          <div className="flex gap-1.5">
-            <dt className="text-muted-foreground shrink-0">Status</dt>
-            <dd
-              data-testid={`agent-status-${agent.agentId}`}
-              data-status={agent.status}
-              className={cn('min-w-0', !agent.status && 'text-muted-foreground italic')}
-            >
-              {AGENT_STATUS_LABEL[agent.status]}
-              {agent.statusNote && (
-                <span className="text-muted-foreground"> — {agent.statusNote}</span>
-              )}
-            </dd>
-          </div>
-          <div className="flex gap-1.5">
-            <dt className="text-muted-foreground shrink-0">Zuletzt</dt>
-            <dd
-              data-testid={`agent-last-event-${agent.agentId}`}
-              className="text-muted-foreground min-w-0 font-mono"
-            >
-              {formatTimestamp(agent.lastEventAt)}
-            </dd>
-          </div>
-          <div className="flex gap-1.5">
-            <dt className="text-muted-foreground shrink-0">Abschluss</dt>
-            <dd
-              data-testid={`agent-outcome-${agent.agentId}`}
-              data-outcome={agent.finishedOutcome ?? 'none'}
-              className={cn('min-w-0', !agent.finishedOutcome && 'text-muted-foreground italic')}
-            >
-              {agent.finishedOutcome
-                ? OUTCOME_LABEL[agent.finishedOutcome]
-                : 'kein Abschluss gemeldet'}
-            </dd>
-          </div>
-        </dl>
+        {detailOpen && (
+          <div id={detailId} className="space-y-1.5 pt-0.5">
+            <ReportedProgress
+              progress={agent.progress}
+              reportedBy={name}
+              testId={`agent-progress-${agent.agentId}`}
+            />
 
-        <ReportedProgress
-          progress={agent.progress}
-          reportedBy={name}
-          testId={`agent-progress-${agent.agentId}`}
-        />
+            <dl className="space-y-0.5 text-xs">
+              <DetailRow label={AGENT_PANE_TEXT.lastEventLabel}>
+                <span
+                  data-testid={`agent-last-event-${agent.agentId}`}
+                  className="pane-meta text-muted-foreground"
+                >
+                  {formatTimestamp(agent.lastEventAt)}
+                </span>
+              </DetailRow>
+              <DetailRow label={AGENT_PANE_TEXT.outcomeLabel}>
+                <span
+                  data-testid={`agent-outcome-${agent.agentId}`}
+                  data-outcome={agent.finishedOutcome ?? 'none'}
+                  className={cn(!agent.finishedOutcome && 'text-muted-foreground italic')}
+                >
+                  {agent.finishedOutcome
+                    ? OUTCOME_LABEL[agent.finishedOutcome]
+                    : AGENT_PANE_TEXT.noOutcomeReported}
+                </span>
+              </DetailRow>
+              <DetailRow label={AGENT_PANE_TEXT.agentIdLabel}>
+                <span className="pane-meta text-muted-foreground block truncate">
+                  {agent.agentId}
+                </span>
+              </DetailRow>
+            </dl>
+          </div>
+        )}
       </div>
     </li>
+  )
+}
+
+function DetailRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex gap-1.5">
+      <dt className="text-muted-foreground w-24 shrink-0">{label}</dt>
+      <dd className="min-w-0 flex-1">{children}</dd>
+    </div>
   )
 }
 
@@ -193,9 +326,9 @@ function AttachmentNote({
   return (
     <p
       data-testid={testId}
-      className="border-state-planned/60 text-muted-foreground flex items-start gap-1 rounded-md border border-dashed px-1.5 py-1 text-2xs"
+      className="border-state-planned/60 text-muted-foreground flex items-start gap-1 rounded-md border border-dashed px-1.5 py-1 text-xs"
     >
-      <Icon className="mt-px size-3 shrink-0" aria-hidden="true" />
+      <Icon className="mt-0.5 size-3 shrink-0" aria-hidden="true" />
       <span>{text}</span>
     </p>
   )

--- a/frontend/src/components/workspace/runAgents/PlanRevisions.tsx
+++ b/frontend/src/components/workspace/runAgents/PlanRevisions.tsx
@@ -40,7 +40,7 @@ export function PlanRevisions({ plans }: PlanRevisionsProps) {
         >
           <header className="border-border flex items-baseline gap-1.5 border-b px-2 py-1.5">
             <h4 className="truncate font-mono text-xs font-medium">{plan.planId}</h4>
-            <span className="text-muted-foreground shrink-0 text-2xs">
+            <span className="text-muted-foreground shrink-0 text-xs">
               {plan.revisions.length} Revision{plan.revisions.length === 1 ? '' : 'en'}
             </span>
           </header>
@@ -81,17 +81,17 @@ function PlanRevisionEntry({
       <div className="flex items-baseline gap-1.5">
         <h5 className="text-xs font-medium">Revision {revision.revision}</h5>
         {revision.isCurrent ? (
-          <Badge variant="secondary" className="text-2xs font-normal">
+          <Badge variant="secondary" className="font-normal">
             aktuell
           </Badge>
         ) : (
-          <Badge variant="outline" className="text-2xs font-normal">
+          <Badge variant="outline" className="font-normal">
             frühere Fassung
           </Badge>
         )}
       </div>
 
-      <p className="text-muted-foreground font-mono text-2xs">
+      <p className="pane-meta text-muted-foreground">
         {formatTimestamp(revision.createdAt)} · {revision.createdByAgentId}
       </p>
 
@@ -109,7 +109,7 @@ function PlanRevisionEntry({
               key={step.stepId}
               data-testid={`plan-step-${planId}-${revision.revision}-${step.stepId}`}
               data-step-state={step.state}
-              className="flex items-baseline gap-1.5 text-2xs"
+              className="flex items-baseline gap-1.5 text-xs"
             >
               <span
                 aria-hidden="true"

--- a/frontend/src/components/workspace/runAgents/ProgressDisplay.tsx
+++ b/frontend/src/components/workspace/runAgents/ProgressDisplay.tsx
@@ -37,7 +37,7 @@ export function ReportedProgress({ progress, reportedBy, testId }: ReportedProgr
       <p
         data-testid={testId}
         data-progress-form="none"
-        className="text-muted-foreground text-2xs"
+        className="text-muted-foreground text-xs"
       >
         Kein Fortschritt gemeldet
       </p>
@@ -98,7 +98,7 @@ function CountedProgress({
           />
         ))}
       </div>
-      <p className="text-muted-foreground text-2xs">
+      <p className="text-muted-foreground text-xs">
         <span className="text-foreground font-medium">{statement.percent} %</span>{' '}
         {statement.subject} · {statement.derivation}
       </p>
@@ -130,7 +130,7 @@ function ClaimedProgress({
       data-progress-form="claim"
       data-progress-scope={statement.scope}
       data-progress-basis={statement.basis}
-      className="border-border/70 text-muted-foreground rounded-md border border-dashed px-2 py-1 text-2xs"
+      className="border-border/70 text-muted-foreground rounded-md border border-dashed px-2 py-1 text-xs"
     >
       <p>
         <span data-claim-marker="" aria-hidden="true" className="font-mono">
@@ -200,7 +200,7 @@ export function CompletedStepsMeter({
           ))}
         </div>
       )}
-      <p className="text-muted-foreground text-2xs">
+      <p className="text-muted-foreground text-xs">
         {completion.done} von {completion.total} Schritten abgeschlossen
       </p>
     </div>

--- a/frontend/src/components/workspace/runAgents/ReportedText.tsx
+++ b/frontend/src/components/workspace/runAgents/ReportedText.tsx
@@ -1,0 +1,102 @@
+import { useId, useState } from 'react'
+
+import { cn } from '@/lib/utils'
+
+import { AGENT_PANE_TEXT, textToggleLabel } from './paneText'
+
+/**
+ * A reported text that is **clipped, never shortened**.
+ *
+ * Assigned tasks and status messages are agent reports: a root orchestrator's
+ * task can be a whole paragraph, and a subagent's task can be three issue titles
+ * chained with `·`. Painted in full, a handful of those rows push everything
+ * else out of a 346 px pane. Painted with an ellipsis produced in JavaScript,
+ * the cockpit would be storing a shortened version of what an agent said.
+ *
+ * So the clipping is done by CSS `line-clamp` only, and the rule that follows
+ * from it is the point of this module:
+ *
+ * * the **complete** string is always in the DOM and always in the accessibility
+ *   tree — it is selectable, copyable, findable with the browser's own search,
+ *   and read out in full by a screen reader, whether the control was used or not;
+ * * the control changes how many lines are painted and nothing else;
+ * * no substring is ever computed, so there is no code path on which a report
+ *   could reach the user altered.
+ *
+ * The control appears only when the text is long enough to be clipped. That is
+ * decided by a character budget rather than by measuring the rendered box: the
+ * budget is deterministic, it does not depend on the current pane width, and it
+ * is therefore the same in the browser and in a test.
+ */
+
+/**
+ * Characters above which a reported text gets a disclosure control.
+ *
+ * The left pane is ~346 px wide at the acceptance resolution, which carries
+ * roughly 45 characters per line at 12 px. Two clamped lines are therefore
+ * around 90 characters — the point from which a text starts being cut off.
+ */
+export const CLAMP_CHARS = 90
+
+const CLAMP_CLASS = {
+  1: 'line-clamp-1',
+  2: 'line-clamp-2',
+  3: 'line-clamp-3',
+} as const
+
+export interface ReportedTextProps {
+  /** The reported string, quoted verbatim. */
+  text: string
+  /** Names the reported text in the control's accessible name. */
+  subject: string
+  /** Whose report it is; also part of the accessible name. */
+  agentName: string
+  /** Lines painted while clipped. */
+  lines: 1 | 2 | 3
+  testId: string
+}
+
+export function ReportedText({
+  text,
+  subject,
+  agentName,
+  lines,
+  testId,
+}: ReportedTextProps) {
+  const [expanded, setExpanded] = useState(false)
+  const textId = useId()
+
+  const clampable = text.length > CLAMP_CHARS
+  const clipped = clampable && !expanded
+
+  return (
+    <>
+      <span
+        id={textId}
+        data-testid={testId}
+        data-clipped={clipped ? 'true' : 'false'}
+        data-full-length={text.length}
+        className={cn('block', clipped && CLAMP_CLASS[lines])}
+      >
+        {text}
+      </span>
+      {clampable && (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-controls={textId}
+          aria-label={textToggleLabel(subject, agentName, expanded)}
+          data-testid={`${testId}-toggle`}
+          onClick={() => setExpanded((current) => !current)}
+          className={cn(
+            'text-muted-foreground hover:text-foreground focus-visible:ring-ring',
+            'mt-0.5 rounded-sm text-xs underline underline-offset-2',
+            'focus-visible:ring-2 focus-visible:outline-none',
+          )}
+        >
+          {expanded ? AGENT_PANE_TEXT.showLessText : AGENT_PANE_TEXT.showFullText}
+        </button>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/workspace/runAgents/RunSelector.tsx
+++ b/frontend/src/components/workspace/runAgents/RunSelector.tsx
@@ -71,11 +71,11 @@ export function RunSelector({
             <History className="size-3.5 shrink-0" aria-hidden="true" />
             Historischer Run
           </p>
-          <p className="text-muted-foreground text-2xs">
+          <p className="text-muted-foreground text-xs">
             Diese Ansicht zeigt einen abgelegten Run, nicht den aktuellen. Aktuell ist{' '}
             <span className="font-mono">{currentRun.runId}</span>.
           </p>
-          <Button asChild variant="outline" size="sm" className="h-6 w-full text-2xs">
+          <Button asChild variant="outline" size="xs" className="w-full">
             <Link
               to="/projects/$projectId/runs/$runId"
               params={{ projectId, runId: currentRun.runId }}
@@ -92,7 +92,7 @@ export function RunSelector({
       {currentRun && showingCurrentRun && (
         <p
           data-testid="current-run-banner"
-          className="text-muted-foreground flex items-center gap-1.5 text-2xs"
+          className="text-muted-foreground flex items-center gap-1.5 text-xs"
         >
           <Radio className="text-state-applied size-3.5 shrink-0" aria-hidden="true" />
           Aktueller Run des Projekts
@@ -164,20 +164,20 @@ function RunLink({
       <span className="flex min-w-0 items-center gap-1.5">
         <span className="truncate font-mono text-xs">{run.runId}</span>
         {run.isCurrent && (
-          <Badge variant="secondary" className="shrink-0 text-2xs font-normal">
+          <Badge variant="secondary" className="shrink-0 font-normal">
             aktuell
           </Badge>
         )}
       </span>
-      <span className="text-muted-foreground block text-2xs">
+      <span className="text-muted-foreground block text-xs">
         {run.isOpen
           ? 'offen — kein Terminalereignis gemeldet'
           : `beendet: ${run.outcome ? OUTCOME_LABEL[run.outcome] : 'ohne gemeldetes Ergebnis'}`}
       </span>
-      <span className="text-muted-foreground block font-mono text-2xs">
+      <span className="pane-meta text-muted-foreground block">
         seit {formatTimestamp(run.startedAt)}
       </span>
-      <span className="text-muted-foreground block text-2xs">
+      <span className="text-muted-foreground block text-xs">
         {/*
           `RunSummary` carries no agent count — only `RunDetail.counts` does, on
           a different endpoint. The root agent is what the summary reports.

--- a/frontend/src/components/workspace/runAgents/paneText.ts
+++ b/frontend/src/components/workspace/runAgents/paneText.ts
@@ -1,0 +1,74 @@
+/**
+ * The chrome vocabulary of the run/agent pane — labels and control names the
+ * **cockpit** owns.
+ *
+ * Two things are deliberately *not* in here:
+ *
+ * * **Reported project data.** Agent names, assigned tasks, status notes and
+ *   plan step titles are quoted verbatim wherever they appear. The pane never
+ *   rewrites, shortens or translates them; it only decides how much of them is
+ *   painted at once.
+ * * **The vocabulary of the read model.** Role, status, outcome and plan-step
+ *   labels describe *what was reported* and live in `reporting.ts` next to the
+ *   rules that produce them.
+ *
+ * Everything is collected in one module so the localisation migration (#42) can
+ * lift the pane's own strings in a single move. The functions below build the
+ * accessible names of the disclosure controls; they exist here rather than in
+ * the components for the same reason.
+ */
+
+export const AGENT_PANE_TEXT = {
+  /**
+   * Field labels. `taskLabel` and `statusLabel` are rendered `sr-only`: the
+   * compact row drops the visible label column to win the space, but a screen
+   * reader still has to be told which reported text it is reading.
+   */
+  taskLabel: 'Aufgabe',
+  statusLabel: 'Status',
+  lastEventLabel: 'Zuletzt gemeldet',
+  outcomeLabel: 'Abschluss',
+  agentIdLabel: 'Agent-Id',
+
+  /** Explicit "the report did not contain this" statements. */
+  noTaskReported: 'keine Aufgabe gemeldet',
+  noOutcomeReported: 'kein Abschluss gemeldet',
+
+  /** Visible label of the "show the whole reported text" control. */
+  showFullText: 'Mehr anzeigen',
+  showLessText: 'Weniger anzeigen',
+
+  /** Screen-reader headline of the counted status tally above the tree. */
+  statusTallyLabel: 'Gemeldete Status',
+} as const
+
+/** Accessible name of the per-row detail disclosure. */
+export function detailToggleLabel(agentName: string, open: boolean): string {
+  return open ? `Details von ${agentName} ausblenden` : `Details von ${agentName} anzeigen`
+}
+
+/** Accessible name of the subtree disclosure. */
+export function subtreeToggleLabel(agentName: string, collapsed: boolean): string {
+  return `Subagents von ${agentName} ${collapsed ? 'ausklappen' : 'einklappen'}`
+}
+
+/**
+ * Accessible name of a "show the whole reported text" control.
+ *
+ * `subject` names *which* reported text is meant — the assigned task or the
+ * status message — so the control is unambiguous when a row carries both.
+ */
+export function textToggleLabel(
+  subject: string,
+  agentName: string,
+  expanded: boolean,
+): string {
+  return expanded
+    ? `${subject} von ${agentName} wieder kürzen`
+    : `${subject} von ${agentName} vollständig anzeigen`
+}
+
+export const TEXT_SUBJECT = {
+  task: 'Aufgabe',
+  statusNote: 'Statusmeldung',
+} as const

--- a/frontend/src/components/workspace/runAgents/reporting.ts
+++ b/frontend/src/components/workspace/runAgents/reporting.ts
@@ -47,6 +47,23 @@ export const AGENT_STATUS_LABEL: Record<ReportedStatus, string> = {
   done: 'fertig',
 }
 
+/**
+ * Second, colour-independent channel for a reported agent status.
+ *
+ * Same rule as `PLAN_STEP_STATE_GLYPH` and `src/state/workStates.ts` (ADR 0003):
+ * the information has to survive greyscale, so every status is carried by a
+ * glyph **and** its label, never by a hue alone. The glyphs are neutral marks,
+ * not verdicts — `blocked` gets the same kind of geometric symbol as `working`.
+ */
+export const AGENT_STATUS_GLYPH: Record<ReportedStatus, string> = {
+  '': '–',
+  working: '▶',
+  waiting: '⋯',
+  blocked: '⊘',
+  idle: '○',
+  done: '●',
+}
+
 export const OUTCOME_LABEL: Record<Outcome, string> = {
   completed: 'abgeschlossen',
   failed: 'fehlgeschlagen',
@@ -70,6 +87,83 @@ export const PLAN_STEP_STATE_GLYPH: Record<PlanStepState, string> = {
   in_progress: '◐',
   done: '●',
   skipped: '⊘',
+}
+
+// ---------------------------------------------------------------------------
+// How much of a row to paint: read off the reported status, never off a clock
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether an agent's **own last reported status** names work that is still
+ * going on.
+ *
+ * This is the input for the pane's default density (#39): a row whose agent
+ * reported ongoing work opens with its details, every other row starts compact.
+ * Three properties make that a rendering decision rather than a verdict:
+ *
+ * * **No clock is consulted.** `lastEventAt`, `startedAt` and the current time
+ *   are not read here and are not compared anywhere in this module (ADR 0011).
+ *   An agent that reported `working` an hour ago is `ongoing`, exactly like one
+ *   that reported it a second ago — because that is what it reported.
+ * * **The mapping is the reported vocabulary, nothing else.** `working`,
+ *   `waiting` and `blocked` are the three statuses that describe work in flight;
+ *   `done` and `idle` are what an agent says when it is not working. A reported
+ *   `finishedOutcome` wins over the status field, because an outcome is the
+ *   later and more specific statement.
+ * * **Nothing is hidden.** A compact row still shows the agent, its status, its
+ *   role and its assigned task, and one keystroke opens the rest. Density is
+ *   about what is painted first, never about what is available.
+ *
+ * `unreported` is kept apart from `settled` on purpose: "the agent said it is
+ * idle" and "the agent never said anything" are different statements, and the
+ * row labels them differently.
+ */
+export type ReportedWorkState = 'ongoing' | 'settled' | 'unreported'
+
+/** The reported statuses that describe work still in flight. */
+const ONGOING_STATUSES: ReadonlySet<ReportedStatus> = new Set<ReportedStatus>([
+  'working',
+  'waiting',
+  'blocked',
+])
+
+export function reportedWorkState(
+  agent: Pick<RunAgent, 'status' | 'finishedOutcome'>,
+): ReportedWorkState {
+  if (agent.finishedOutcome !== null) return 'settled'
+  if (agent.status === '') return 'unreported'
+  return ONGOING_STATUSES.has(agent.status) ? 'ongoing' : 'settled'
+}
+
+/**
+ * How often each status was reported across a list of agents, in the fixed
+ * order of the vocabulary.
+ *
+ * A count of reported values — the same kind of statement as `run.counts` — and
+ * deliberately not a percentage, not a share and not an aggregate of the agents'
+ * own progress numbers. ADR 0011 forbids the latter; counting how many agents
+ * reported which word is a fact about the log.
+ */
+const STATUS_TALLY_ORDER: readonly ReportedStatus[] = [
+  'working',
+  'waiting',
+  'blocked',
+  'idle',
+  'done',
+  '',
+]
+
+export function statusTally(
+  agents: readonly Pick<RunAgent, 'status'>[],
+): { status: ReportedStatus; count: number }[] {
+  const counts = new Map<ReportedStatus, number>()
+  for (const agent of agents) {
+    counts.set(agent.status, (counts.get(agent.status) ?? 0) + 1)
+  }
+
+  return STATUS_TALLY_ORDER.filter((status) => (counts.get(status) ?? 0) > 0).map(
+    (status) => ({ status, count: counts.get(status) as number }),
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -154,6 +154,22 @@
   }
 
   .pane-heading {
-    @apply text-2xs text-muted-foreground font-semibold tracking-[0.08em] uppercase;
+    @apply text-muted-foreground text-xs font-semibold tracking-[0.08em] uppercase;
+  }
+
+  /*
+   * The **only** sanctioned sub-12 px type in the cockpit (#39).
+   *
+   * It is reserved for bounded technical metadata: identifiers and UTC
+   * timestamps. Both have a fixed shape, both are monospaced, and both are read
+   * by comparing them rather than by reading them as prose. Everything a user
+   * actually reads — labels, statuses, reported tasks, reported messages — is
+   * 12 px or larger.
+   *
+   * If a new piece of text does not fit "an id or a timestamp", it does not get
+   * this class.
+   */
+  .pane-meta {
+    @apply text-2xs font-mono;
   }
 }

--- a/frontend/src/test/runFixtures.ts
+++ b/frontend/src/test/runFixtures.ts
@@ -141,6 +141,75 @@ export const treeAgentsResponse: AgentListResponse = {
   ],
 }
 
+/**
+ * The density stress case of #39, mirroring the simulator's `self` scenario:
+ * a root orchestrator whose `assignedTask` is a whole paragraph, a subagent
+ * whose task is three issue titles chained with `·`, and a long status note.
+ *
+ * The strings are copied verbatim from what the simulator reports, because the
+ * point of the fixture is exactly their length — a paraphrase would test a
+ * different sentence than the one the acceptance looks at.
+ */
+export const PARAGRAPH_TASK =
+  'Build the v0 agent cockpit of epic #1: a versioned event contract, a Compose ' +
+  'deployment behind one entry point, an append-only event store, the ingestion ' +
+  'and read surfaces, the live stream, the three-pane cockpit, a deterministic ' +
+  'simulator and a mandatory end-to-end acceptance run.'
+
+export const CHAINED_TASK =
+  '[v0] Event-Ingestion, Validierung und Lifecycle-Regeln implementieren (#20) · ' +
+  '[v0] Projektbezogene HTTP Read API implementieren (#21) · ' +
+  '[v0] SSE-Livestream mit positionsbasiertem Replay implementieren (#23)'
+
+export const LONG_STATUS_NOTE =
+  'Every subagent finished. The run is left open on purpose: no status is derived from silence.'
+
+export const longTaskAgentsResponse: AgentListResponse = {
+  projectPosition: 62,
+  agents: [
+    agent({
+      agentId: 'orchestrator-root',
+      parentAgentId: null,
+      role: 'orchestrator',
+      displayName: 'Root Orchestrator',
+      assignedTask: PARAGRAPH_TASK,
+      status: 'idle',
+      statusNote: LONG_STATUS_NOTE,
+      progress: { percent: 96, scope: 'overall_estimate', basis: 'reported_estimate' },
+      startedAt: '2026-08-04T09:00:49Z',
+      lastEventAt: '2026-08-04T10:41:59Z',
+      position: 122,
+    }),
+    agent({
+      agentId: 'subagent-backend-api',
+      parentAgentId: 'orchestrator-root',
+      role: 'subagent',
+      displayName: 'Backend HTTP Surface',
+      assignedTask: CHAINED_TASK,
+      status: 'done',
+      statusNote: '',
+      progress: { percent: 100, scope: 'own_task', basis: 'completed_steps' },
+      finishedOutcome: 'completed',
+      startedAt: '2026-08-04T09:08:26Z',
+      lastEventAt: '2026-08-04T09:46:31Z',
+      position: 56,
+    }),
+    agent({
+      agentId: 'subagent-implementer',
+      parentAgentId: 'orchestrator-root',
+      role: 'subagent',
+      displayName: 'Implementer',
+      assignedTask: 'VAT-Behandlung in ein eigenes Modul verschieben.',
+      status: 'working',
+      statusNote: 'Schreibt Total() um.',
+      progress: { percent: 70, scope: 'own_task', basis: 'completed_steps' },
+      startedAt: '2026-08-04T09:00:05Z',
+      lastEventAt: '2026-08-04T09:06:31Z',
+      position: 41,
+    }),
+  ],
+}
+
 export const historicalAgentsResponse: AgentListResponse = {
   projectPosition: 62,
   agents: [


### PR DESCRIPTION
Closes #39

Der Agentenbereich zeigte alles mit fast identischem Gewicht: zehn Agents mit je
sieben Zeilen, 240 von 256 Textelementen auf 11 px, ein Absatz als `assignedTask`
in voller Länge. Dieser PR gibt dem Bereich eine Informationshierarchie, legt
Details progressiv offen und hebt die Mindestschriftgröße an — **ohne** eine
Bewertung der Agentenarbeit einzuführen und **ohne** gemeldete Inhalte zu kürzen.

Die Entscheidung ist als ADR 0014 (`docs/decisions/0014-agent-pane-density-and-disclosure.md`)
dokumentiert; sie baut auf ADR 0011 auf und ändert nichts an dessen Zusagen.

## Vorher / Nachher

Gemessen im Browser gegen das laufende System, Projekt `visualise-ai-self`,
Run `run-v0-epic-1` (10 Agents, sehr lange Aufgabenbeschreibungen), linke Pane
345,2 px bei 1920 × 1080:

| | vorher (`develop`) | nachher |
| --- | --- | --- |
| Höhe der Agentenliste | 2150 px | **1081 px** |
| Zeilenhöhen | 184–300 px | **92–127 px** |
| vollständig sichtbare Agentenzeilen | 2 | **5** |
| Textelemente < 12 px | 240 | **5** (alle `.pane-meta`, monospace) |
| Textelemente auf 12 px | 5 | **188** |
| horizontaler Überlauf der Pane @1920 | 0 px | **0 px** |
| horizontaler Überlauf der Pane @1280 | 111 px | **72 px** |

### Informationshierarchie

Fünf Ebenen statt einer:

1. **Wer** — der Agentenname allein auf der ersten Zeile. Ein gemeldeter Status
   `working`/`waiting`/`blocked` hebt ihn zusätzlich hervor (`font-semibold`,
   voller Vordergrund), alles andere bleibt `font-medium` auf `foreground/80`.
2. **Was für ein Agent und was tut er** — Rollen-Badge und Status-Chip. Der
   Status trägt **Glyph + Wort** (`▶ arbeitet`, `● fertig`, `⊘ blockiert`,
   `– kein Status gemeldet`), Farbe ist nie der einzige Träger. Es wird bewusst
   **kein** Akzent-Hue verwendet, damit die vier Work-State-Farben aus ADR 0003
   ihre Bedeutung behalten — die Hervorhebung ist Kontrast, nicht Hue.
3. **Die gemeldete Statusmeldung**, auf eine Zeile begrenzt.
4. **Die gemeldete Aufgabe**, auf zwei Zeilen begrenzt.
5. **Alles Weitere** — Fortschritt, letzter Zeitstempel, gemeldeter Abschluss,
   Agent-Id — hinter genau einer Offenlegung pro Zeile.

Immer sichtbar und nie hinter der Offenlegung: der gemeldete Status (die Aussage,
für die die Zeile existiert) und die Attachment-Hinweise bei kaputter
Parent-Referenz (sie zu verstecken würde verstecken, dass der Report kaputt war).

Zusätzlich zählt eine Zeile über dem Baum, wie oft welches Statuswort gemeldet
wurde (`○ 1 × untätig · ● 9 × fertig`). Das ist eine Zählung gemeldeter Werte in
derselben Kategorie wie `run.counts` — kein Anteil, keine Aggregation der
Prozentzahlen (die ADR 0011 ausschließt).

### „Inaktiv" ohne jeden Zeitvergleich

`reportedWorkState(agent)` liest **zwei** Felder: `status` und `finishedOutcome`.

* `finishedOutcome !== null` → `settled`
* `status === ''` → `unreported`
* `status ∈ {working, waiting, blocked}` → `ongoing`, sonst `settled`

`ongoing` öffnet die Detailzeile, alles andere startet kompakt. `lastEventAt`,
`startedAt` und `Date.now()` werden nicht gelesen und nirgends verglichen —
ADR 0011 („there is no stall detection, and no clock is consulted") gilt
unverändert. Ein Test gibt einem `working`-Agenten einen Zeitstempel von 2020 und
einem `done`-Agenten einen von 2099: die Dichte bewegt sich nicht.

Das Wort „inaktiv" kommt in der Oberfläche nicht vor. Der bestehende Test, der
das abgeleitete Verdikt-Vokabular verbietet, deckt auch das neue Markup ab.

Die Nutzerentscheidung schlägt die Ableitung und wird als **Override** pro
Agent-Id in Komponenten-State gehalten: eine geöffnete Zeile bleibt offen, wenn
der nächste Report eintrifft; eine unberührte folgt dem Report. Nichts davon wird
persistiert (ADR 0003).

### Lange Meldungen: geclippt, nie gekürzt

`ReportedText` rendert **den vollständigen String** und überlässt das Clipping
CSS `line-clamp`. Es wird nirgends ein Substring berechnet, es gibt also keinen
Codepfad, auf dem ein umgeschriebener Report beim Nutzer ankommt. Der Text steht
jederzeit vollständig im DOM und im Accessibility-Tree — markierbar, kopierbar,
über die Browsersuche findbar, vom Screenreader vollständig vorgelesen, auch ohne
Bedienung des Controls.

Ob ein Control erscheint, entscheidet ein Zeichenbudget (90) statt einer Messung
der gerenderten Box: deterministisch, unabhängig von der aktuellen Panebreite,
im Browser und im Test identisch.

Gemessen in Chromium (Projekt `visualise-ai-self`):

| Agent | gemeldete Zeichen | im DOM | geclippt | gemalt / vollständig |
| --- | --- | --- | --- | --- |
| `orchestrator-v0` | 282 | 282 | ja | 32 px / 96 px |
| `subagent-cockpit-panes` | 287 | 287 | ja | 32 px / 112 px |
| `subagent-backend-api` (drei `·`-verkettete Titel) | 206 | 206 | ja | 32 px / 80 px |
| `subagent-verification` | 144 | 144 | ja | 32 px / 64 px |
| fünf weitere (56–78 Zeichen) | — | identisch | nein | — |

`textContent === assignedTask` gilt für jede Zeile; der neue e2e-Check vergleicht
das gegen die API-Antwort.

### Fortschritt: unverändert getrennt

`ProgressDisplay` ist inhaltlich unangetastet. `scope: own_task` **und**
`basis: completed_steps` bleibt eine Reihe aus zehn diskreten Segmenten mit
`role="progressbar"`; alles andere — insbesondere **jedes**
`scope: overall_estimate` — bleibt eine Behauptung ohne Track, ohne Füllung, mit
`≈` und Zuschreibung. Die beiden Formen teilen weiterhin keine Geometrie und
keinen Container. Die Verdichtung hat nur verschoben, **wo** der Block gemalt
wird, nicht **was** er ist.

### Schriftgrößen

* Neue Utility-Klasse `.pane-meta` (11 px, monospace) — die **einzige**
  zugelassene Ausnahme, reserviert für Identifier und UTC-Zeitstempel.
* Alles andere im Bereich auf ≥ 12 px.
* `.pane-heading` von 11 px auf 12 px. Das ist eine geteilte Klasse und wirkt
  damit auch im Inspector und im Architekturbereich — eine Untergrenze, die nur
  in einer Pane gilt, ist keine Untergrenze. Sonstige 11-px-Texte der anderen
  Panes bleiben unberührt (siehe „Aufgefallen, nicht behoben").

Gemessene `font-size`-Werte am DOM (`getComputedStyle`, nicht Tailwind-Klassen)
innerhalb `[data-testid="pane-run-agents"]`, identisch bei 1920 × 1080 und
1280 × 800:

```
11.00 px ×   5   → alle .pane-meta + monospace
12.00 px × 188
14.00 px ×  11
```

Die fünf Elemente auf 11 px: Run-Id, Run-Beginn, `seit <Zeitstempel>` in der
Runliste und zwei Plan-Revisions-Metazeilen (`<Zeitstempel> · <agentId>`). Im
geöffneten Detailblock kommen `Zuletzt gemeldet` und `Agent-Id` dazu — ebenfalls
`.pane-meta`.

### Fokus, Hover, Auswahl

Alle Controls einer Agentenkarte tragen dieselbe Fokusbehandlung; Hover, Fokus
und Auswahl liegen auf der Karte statt auf dem einzelnen Control:

```
li: hover:bg-accent/30  has-[:focus-visible]:bg-accent/30
    selected → bg-accent/60 + border-l-primary
```

Gemessen (`--tw-ring-shadow` im Zustand `:focus-visible`):

| Control | Ring |
| --- | --- |
| Subtree-Toggle | `0 0 0 calc(2px + 0px) oklch(0.78 0.11 235)` |
| Auswahl (Agentenkarte) | `0 0 0 calc(2px + 0px) oklch(0.78 0.11 235)` |
| Detail-Toggle | `0 0 0 calc(2px + 0px) oklch(0.78 0.11 235)` |
| Aufgabentext-Toggle | `0 0 0 calc(2px + 0px) oklch(0.78 0.11 235)` |
| Statusmeldung-Toggle | `0 0 0 calc(2px + 0px) oklch(0.78 0.11 235)` |
| Filterfeld | `0 0 0 calc(2px + 0px) oklch(0.78 0.11 235)` |

Auswahl gemessen: `background = oklab(0.25 … / 0.6)`,
`border-left = 2px oklch(0.83 0.006 265)`; unselektiert transparent.

### Tastatur

Alle Offenlegungen sind native `<button>`. Der neue e2e-Check fährt sie mit
`Enter` und `Space` auf und zu und prüft `aria-expanded`, `data-density` und dass
der Fokus auf dem Control bleibt. Der Unit-Test tabbt von der Auswahl auf den
Detail-Toggle und tut dasselbe.

## Geprüfte Auflösungen

* **1920 × 1080** (verbindliche Abnahmeauflösung): Pane 345,2 px, kein
  horizontaler Überlauf, kein zweiter Scrollbalken.
* **1280 × 800**: Pane 230 px, Seite ohne horizontalen Scrollbalken
  (`documentElement.scrollWidth === clientWidth`), Schriftgrößen identisch. Der
  Inhalt der Pane bleibt breiter als die Pane (72 px) — vorbestehend
  (`develop`: 111 px) und Teil von #41, siehe unten.

Die langen Aufgabentexte verändern die Grundstruktur nicht: dieselben Sektionen,
dieselbe Liste, dieselbe Zeilenzahl; ein langer Report lässt eine Zeile wachsen,
nie das Skelett der Pane. Ein Test sichert das ab.

## Tests

10 neue Unit-Tests, zwei bestehende an die neue Struktur angepasst, ein neuer
e2e-Check.

**Angepasst (beide behalten ihre Aussage, prüfen sie nur an der neuen Struktur):**

* `says so when an agent never reported a status or a number` — der Status steht
  weiterhin ohne Interaktion auf der kompakten Zeile; die gemeldete Zahl liegt im
  Detailblock, den der Test jetzt öffnet. Der Test prüft zusätzlich, dass die
  Offenlegung existiert.
* `keeps an estimate and counted steps structurally apart` — der Architect hat
  einen Abschluss gemeldet und startet kompakt; der Test öffnet die Zeile und
  prüft danach exakt dieselbe strukturelle Trennung (Segmentzahl, fehlende
  `progressbar`-Rolle, kein gemeinsamer Container, keine Verschachtelung).

**Neu:**

* kompakte Darstellung nach gemeldetem Status, inkl. „Agent, Rolle, Status und
  Aufgabe bleiben auch kompakt sichtbar"
* Dichte folgt dem Status, nicht der Uhr (Zeitstempel 2020 vs. 2099)
* Statuszählung ohne Verdikt-Vokabular
* Auf-/Zuklappen per Tastatur, Fokus bleibt auf dem Control
* eine vom Nutzer geöffnete Zeile bleibt beim nächsten Live-Report offen
* langer Text ist geclippt, aber vollständig im Dokument
* vollständiger Text über eine bewusste, tastaturbedienbare Aktion
* lange Statusmeldung wortgleich
* ein Absatz ändert die Pane-Struktur nicht
* Fortschrittstrennung übersteht Zu- und wieder Aufklappen

**Kommandos und Ergebnisse:**

```
$ cd frontend && npm run lint
> eslint .
(keine Befunde)

$ npm run typecheck
> tsc --build --force
(keine Befunde)

$ npm test
 Test Files  28 passed (28)
      Tests  234 passed (234)

$ npm run build
✓ built in 14.00s
```

```
$ cd e2e && npm test
  21 passed (2.0m)
```

Alle 224 bisherigen Unit-Tests bleiben grün (234 = 224 + 10 neue), einschließlich
der 24 Tests aus #11.

## Am e2e-Bestand angepasst

Der verpflichtende Abnahmelauf (#14) prüft diese Pane; drei Stellen mussten der
neuen Struktur folgen:

* `04-run-agents.spec.ts` — im Szenario `full` hat am Ende **jeder** Agent
  entweder ein Outcome oder `idle` gemeldet, alle Zeilen starten also kompakt.
  Der Test prüft das jetzt explizit und öffnet die Detailblöcke, bevor er
  Fortschritt und Abschluss liest. Die Aussagen zur Formentrennung sind
  unverändert.
* `04-run-agents.spec.ts` — neuer Check „the pane stays legible and
  keyboard-operable while it is dense (#39)": misst die berechneten
  `font-size`-Werte im DOM, fährt die Offenlegung per Tastatur und vergleicht
  jeden gemalten Aufgabentext zeichengenau mit der API-Antwort.
* `08-viewport.spec.ts` — der Test zielte auf `subagent-reviewer` als Zeile
  „unterhalb der Falz"; die passt jetzt darüber. Er zielt auf die **letzte**
  Zeile und prüft nach dem Scrollen die vollständige Box statt eines festen
  Abstands zur Unterkante (kompakte Zeilen sind niedriger als der angenommene
  Rand). Aussage unverändert: unterhalb der Falz liegender Inhalt wird durch
  Scrollen **der Pane** erreichbar, die Seite bleibt stehen.

## Aufgefallen, nicht behoben

* **#41 (Viewport):** Der Viewport der `ScrollArea` in der linken Pane wird auf
  `max-content` bemessen. Bei 1280 ist der Inhalt dadurch 72 px breiter als die
  Pane (auf `develop` 111 px) und `truncate` auf dem Agentennamen greift nie. Die
  Seite selbst scrollt in beiden Ständen nicht horizontal. Strukturelle Ursache,
  gehört zu #41 — hier nicht angefasst.
* **shadcn `ScrollArea`:** Die Root ist `position: relative`, der Viewport nicht.
  Jedes `position: absolute`-Kind — und `sr-only` ist genau das — wird deshalb
  gegen die Root positioniert, entkommt dem Clipping und dehnt die Pane (hier:
  410 px Phantomhöhe und ein zweiter Scrollbalken). Lokal gelöst (`relative` auf
  der Agentenzeile und auf der Statuszählung, mit Kommentar); die allgemeine
  Lösung wäre `relative` auf dem Viewport in `ui/scroll-area.tsx` und berührt
  alle drei Panes.
* **Inspector- und Architekturbereich** verwenden weiterhin großflächig 11 px
  (`text-2xs`). Außerhalb von #39; nur die geteilte `.pane-heading` wurde
  mitgehoben.
* **Keine i18n-Migration** (#42). Die neuen Texte sind hart codiert, liegen aber
  gesammelt in `frontend/src/components/workspace/runAgents/paneText.ts`, damit
  #42 sie in einem Zug ziehen kann. Gemeldete Projektdaten stehen dort bewusst
  nicht drin.
