### PR TITLE
Lesbaren initialen Architektur-Zoom und progressive Detailstufen einführen (#34)

### DIFF
--- a/docs/decisions/0017-readable-entry-zoom-and-progressive-disclosure.md
+++ b/docs/decisions/0017-readable-entry-zoom-and-progressive-disclosure.md
@@ -94,6 +94,44 @@ most once per project plus while the surface is settling, and **no new exception
 was added**: the readable floor changes *where* the camera goes, never *whether*
 it moves. A live event still returns `null`.
 
+### The selected component is an input to the first picture
+
+The floor and the anchoring together produced a defect worth naming, because it
+is the exact failure mode this ADR otherwise argues against. A deep link into a
+component four levels down opened the path to it and selected it — and then the
+readable zoom put it 732 px past the right edge of a 1036 px surface: **0 %
+visible**. The inspector described a component the architecture surface did not
+show anywhere. Fitting the whole model, for all its illegibility, had at least
+kept the linked node on screen.
+
+`viewportForBounds` therefore takes an optional `focus` rectangle, and the
+initial camera passes the box of the component the URL points at. It is brought
+in by **panning only** — by the least amount that gets it inside — and never by
+zooming out: the floor is not the price of following a link, and the two are not
+in competition, since a leaf node is 176 × 74 px at the readable zoom and fits
+any supported surface many times over. A focus that is already visible leaves
+the camera untouched.
+
+This is deliberately **not** a fourth `fitView` reason, and the alternative —
+treating a deep link as an explicit user action, i.e. a second movement — was
+rejected. There is only ever one automatic movement, and at the moment it
+happens no user has taken the camera over; letting it read the URL as well as
+the layout gives it one more input, not one more occasion. `data-fit-view-count`
+is `1` for a deep link exactly as it is without one.
+
+The boundary is where it has to be: `selectedComponentId` is in the dependency
+list of the layout effect, so a **later** selection change re-runs the policy —
+and the policy answers `null`. Choosing another component by clicking therefore
+leaves zoom and pan byte-identical, even when the newly selected component is
+off screen. From the first picture onwards the camera is the user's, and a
+selection is not a request to move it. `ArchitectureZoom.test.tsx` asserts both
+halves: the linked node lies inside the surface rectangle after the first
+render, and a click afterwards changes nothing about the viewport transform.
+
+"Systemebene" reproduces the entry picture and therefore honours the selection
+the same way. "Gesamtes Modell einpassen" does not: it is a statement about the
+model, not about one component of it.
+
 ### The hierarchy opens on the top two levels
 
 `src/canvas/collapse.ts` reduces the projected graph to what a set of collapsed
@@ -172,12 +210,14 @@ what contains it.
 
 It is resolved **with** the initial collapsed set, before the first layout, so a
 deep link still costs exactly one ELK run and one camera movement:
-`data-fit-view-count` is `1` on a deep link exactly as it is without one. And it
-changes visibility only — zoom and pan are not touched by it, so the deep link is
-not a camera exception either. The reverse case is handled explicitly: closing a
-container that holds the current selection moves the selection **up** to that
-container, so the URL never points at something that is not on screen and the
-inspector never describes an invisible component.
+`data-fit-view-count` is `1` on a deep link exactly as it is without one. Being
+drawn is not the same as being on screen, though — see "The selected component
+is an input to the first picture" above for the second half of this.
+
+The reverse case is handled explicitly: closing a container that holds the
+current selection moves the selection **up** to that container, so the URL never
+points at something that is not on screen and the inspector never describes an
+invisible component.
 
 ### The disclosure is transient, like the camera
 
@@ -213,8 +253,14 @@ Measured in Chromium at 1920 × 1080, centre pane 1035.7 × 932.5 px, with
   and fits it. "Systemebene" reproduces the entry picture on demand.
 - **A large model is now partly off-screen at the readable zoom.** 28 components
   on their top level lay out to 1944 × 518, which is 69 % of a 1036 px surface at
-  0.77. The minimap (ADR 0008) and the anchored overflow are what make that
-  navigable rather than disorienting.
+  0.77. The minimap (ADR 0008), the anchored overflow and the focus on the
+  selected component are what make that navigable rather than disorienting.
+- **A selection that is off screen stays off screen.** Only the *first* picture
+  pans to the selected component. Clicking a node the user can see cannot move
+  the camera, and neither can a selection arriving from anywhere else. If it
+  turns out that following a link from the inspector into an off-screen
+  component needs the camera too, that is a new, explicit user action and it
+  belongs in the toolbar next to "Einpassen" — not in the policy.
 - **Two canvas test files start from the open model.** `ArchitectureCanvas.test`
   and `ChangeOverlays.test` assert bundling, overlays and selection on components
   three and four levels down; they now pass `expandAllComponents` to `renderApp`,

--- a/docs/decisions/0017-readable-entry-zoom-and-progressive-disclosure.md
+++ b/docs/decisions/0017-readable-entry-zoom-and-progressive-disclosure.md
@@ -1,0 +1,238 @@
+# 17. A readable entry picture: a floor under the automatic zoom and a hierarchy that opens on demand
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #34 (part of the v0 epic #1)
+- **Builds on:** [0008 — Architecture canvas](./0008-architecture-canvas-layout-and-edge-bundling.md),
+  [0010 — Live change overlays](./0010-live-change-overlays.md)
+
+## Context
+
+The architecture canvas is the product (ADR 0008), and until now it opened by
+fitting the whole reported model into the centre pane. Measured in Chromium at
+1920 × 1080, with the centre pane at 1035.7 × 932.5 CSS px:
+
+| model | fitted zoom | leaf node | component name |
+| --- | --- | --- | --- |
+| `visualise-ai-self`, 28 components / 4 levels | **0.203** | 46.3 × 19.5 px | **2.6 px** |
+| a synthetic model of 32 components / 4 levels | **0.282** | 64.3 × 27.1 px | **3.7 px** |
+
+A 2.6 px glyph is not small type, it is not type. The most important surface of
+the cockpit was unreadable at the moment it opened, and it got worse with every
+component an agent reported — which is the direction a project only ever moves
+in.
+
+Two things were wrong, and they are independent:
+
+1. **The camera had no floor.** `fitView` accepted any zoom down to the canvas
+   minimum of 0.12 as long as everything fitted.
+2. **Everything was on screen at once.** A reported architecture is a hierarchy;
+   drawing all four levels of it in the entry picture spends the whole surface
+   on detail nobody asked for yet.
+
+Neither may be fixed by weakening what ADR 0008 and ADR 0010 secured: the layout
+stays deterministic, and after the first picture the camera belongs to the user —
+`data-fit-view-count` stays `1` for a whole simulator run.
+
+## Decision
+
+### The readable zoom is derived, not chosen
+
+`MIN_READABLE_ZOOM` in `src/canvas/detailLevel.ts` is computed from two numbers
+that already exist in the product:
+
+- a node's identifying label is `text-[13px]` (`NODE_LABEL_FONT_SIZE_PX`),
+- the smallest type the design system renders anywhere at zoom 1 is `text-[10px]`
+  — kind badges, technology rows, tags, both legends
+  (`MIN_LEGIBLE_FONT_SIZE_PX`).
+
+The canvas draws its nodes inside a CSS transform, so every glyph is scaled by
+the zoom. Requiring the component name to stay at or above the product's own
+legibility floor gives
+
+```
+13 px × zoom ≥ 10 px   ⇒   zoom ≥ 10 / 13 ≈ 0.7692   ⇒   0.77
+```
+
+rounded **up**, so the floor is never undercut by the rounding. The constant is
+a division of two constants, not a number picked because a screenshot looked
+acceptable, and `detailLevel.test.ts` asserts the derivation rather than the
+result. If the node label ever changes size, the floor moves with it.
+
+At 0.77 a leaf node measures 175.6 × 73.9 CSS px and its name renders at 10.0 px.
+
+The floor is not a function of the canvas width, and the derivation deliberately
+does not mention one: it is a statement about glyphs, not about how much fits.
+How much fits *is* a function of the actual surface, which is why the camera
+reads the measured width rather than the 1036 px of the acceptance layout —
+issue #41 moves the centre pane to 660 px at a 1280 px window, and nothing here
+changes because of it.
+
+### The floor applies to the automatic camera only
+
+`viewportForBounds` in `cameraPolicy.ts` takes a `minZoom`. There are exactly two
+callers:
+
+- the **initial** fit — the one movement the user did not ask for — passes
+  `MIN_READABLE_ZOOM`,
+- an **explicit** "Gesamtes Modell einpassen" passes the canvas minimum and is
+  free to go to 0.20 if that is what showing everything costs.
+
+That difference is the whole rule. The user may always choose to see a model too
+small to read; the cockpit may never choose it for them.
+
+`viewportForBounds` also owns the second half of the camera: a model that does
+not fit at the readable zoom is anchored at its **top-left** corner instead of
+being centred. The ELK layout runs left to right with the callers first
+(ADR 0008), so its beginning is where an architecture is read from; centring an
+oversized model drops the reader in the middle of a sentence. The inset is
+derived from the existing `FIT_VIEW_PADDING`, so an anchored model sits exactly
+as far from the edge as a centred one.
+
+The camera policy itself is unchanged. `onLayoutReady` still returns a reason at
+most once per project plus while the surface is settling, and **no new exception
+was added**: the readable floor changes *where* the camera goes, never *whether*
+it moves. A live event still returns `null`.
+
+### The hierarchy opens on the top two levels
+
+`src/canvas/collapse.ts` reduces the projected graph to what a set of collapsed
+containers leaves visible. A project opens with `initialCollapsedIds`: every
+container deeper than `INITIAL_EXPANDED_DEPTH` (= 1), i.e. root components and
+their direct children are drawn and everything below waits behind its container.
+
+On `visualise-ai-self` that is 10 of 28 components; on the 32-component model, 8
+of 32. The rule is a property of the reported hierarchy, not of the node count,
+so a model with 300 components opens with the same handful of boxes.
+
+**Why expand/collapse and not a zoom-driven semantic zoom.** Showing or hiding a
+container's children changes the ELK input and therefore the layout. Bound to the
+zoom, that would move every box under the camera while the user scrolls — the
+exact motion ADR 0008 exists to prevent, and the reason the node box size is
+already independent of the detail level. Expanding is an explicit act instead:
+the camera stays where it is and the boxes rearrange, which is precisely what
+ADR 0010 already established for an arriving proposal.
+
+The existing detail levels are untouched and keep their job — *how much a drawn
+node says*. This ADR adds the orthogonal question of *which nodes are drawn*.
+`MIN_READABLE_ZOOM` (0.77) lands in the `standard` level, so a project now opens
+showing names, kinds **and** technology, where it used to open in `overview`.
+
+### Collapsing hides components, it never hides information
+
+Three rules keep the closed picture honest, and each is a test:
+
+- **A relationship is lifted, not dropped.** An edge whose endpoint is hidden is
+  re-attached to the nearest visible ancestor and bundled there. Four leaves
+  writing to the store become one `Service → Store` edge that still carries all
+  four reported relationships; `resolveEdgeBundle` resolves it exactly as
+  ADR 0008 requires of every bundle. A relationship whose two ends collapse into
+  the same box is internal to it and is not drawn — a self loop on a container
+  states nothing — and it returns the moment the container is opened.
+- **A work state is rolled up.** A closed container carries the dominant state of
+  everything behind it, through the same `dominantOverlay` precedence as
+  everywhere else, with every contribution kept so the mark's `title` still lists
+  them one by one. Hiding a component must not hide what an agent is *doing* to
+  it; that is the one thing this cockpit exists to show. The **operation** is
+  deliberately not rolled up — `geplant · entfernen` on a container would claim
+  the container is being removed — and neither is the presence, so a proposal
+  inside an applied container does not dim it.
+- **The reported counts do not move.** `data-node-count` stays the number of
+  applied components of the model, and the pane header still says "28
+  Komponenten". `data-visible-node-count` and `data-hidden-node-count` are new
+  attributes for what is drawn. Collapsing is a way of looking, never a claim
+  about the model — the same distinction ADR 0008 draws for edge bundles and
+  ADR 0003 for dragged positions.
+
+`collapseGraph` returns its input arrays unchanged when nothing is collapsed, so
+an open canvas is provably the graph `projectArchitecture` produced.
+
+### Determinism survives, because the reduction is canonical
+
+The collapsed set is normalised and sorted, the reduction preserves the
+projection's canonical order (parents before children, siblings by id, edges by
+id), and node sizes stay declared constants — a closed container shrinks to
+`LEAF_NODE_SIZE`, which is a constant, not a measurement. ELK therefore still
+sees canonically ordered input with declared sizes and a pinned seed, and the
+determinism tests of ADR 0008 are untouched. `collapse.test.ts` asserts it
+directly: the same model with re-shuffled input lists and a reversed collapsed
+set produces an identical `projectionSignature`.
+
+One detail is load-bearing enough to name: a collapsed container keeps its React
+Flow **node type**. React Flow remounts a node whose type changed, and a
+remounted node is measured from the DOM — which would put a rendered box back
+into the layout path this canvas is built to keep out of it.
+
+### A deep link opens the path to its component
+
+A link into a component four levels down expands its ancestors. The alternative —
+land on a canvas where the linked component is not drawn — would make the deep
+link a broken promise, and there is no way to show a component without opening
+what contains it.
+
+It is resolved **with** the initial collapsed set, before the first layout, so a
+deep link still costs exactly one ELK run and one camera movement:
+`data-fit-view-count` is `1` on a deep link exactly as it is without one. And it
+changes visibility only — zoom and pan are not touched by it, so the deep link is
+not a camera exception either. The reverse case is handled explicitly: closing a
+container that holds the current selection moves the selection **up** to that
+container, so the URL never points at something that is not on screen and the
+inspector never describes an invisible component.
+
+### The disclosure is transient, like the camera
+
+`collapsedComponentIds` lives in `uiStore` next to the camera, the drag positions
+and the selection, and like them it is **not** persisted. It describes a concrete
+architecture snapshot; restoring it into a model whose hierarchy has meanwhile
+changed would hide components the user never chose to hide. It is reset when the
+project changes, and — like the camera — an arriving event never touches it.
+
+`null` means "this project has not been disclosed yet" and is materialised into
+an explicit list as soon as a layout exists, because a derived set cannot be
+toggled: opening one container would have to know which others were closed.
+
+## Consequences
+
+Measured in Chromium at 1920 × 1080, centre pane 1035.7 × 932.5 px, with
+`localStorage` cleared before each measurement:
+
+| | before | after |
+| --- | --- | --- |
+| `visualise-ai-self` (28) — initial zoom | 0.203 | **0.770** |
+| leaf node | 46.3 × 19.5 px | **175.6 × 73.9 px** |
+| name × zoom | 2.6 px | **10.0 px** |
+| detail level | `overview` | `standard` |
+| components drawn | 28 | 10 (18 behind 2 containers) |
+| 32 components / 4 levels — initial zoom | 0.282 | **1.000** |
+| leaf node | 64.3 × 27.1 px | **228 × 96 px** |
+| name × zoom | 3.7 px | **13.0 px** |
+
+- **The entry picture no longer shows the whole model.** That is the trade, and
+  it is the point. Everything stays reachable three ways — the chevron on a
+  container, a deep link, and "Gesamtes Modell einpassen", which opens everything
+  and fits it. "Systemebene" reproduces the entry picture on demand.
+- **A large model is now partly off-screen at the readable zoom.** 28 components
+  on their top level lay out to 1944 × 518, which is 69 % of a 1036 px surface at
+  0.77. The minimap (ADR 0008) and the anchored overflow are what make that
+  navigable rather than disorienting.
+- **Two canvas test files start from the open model.** `ArchitectureCanvas.test`
+  and `ChangeOverlays.test` assert bundling, overlays and selection on components
+  three and four levels down; they now pass `expandAllComponents` to `renderApp`,
+  which is the state the "Gesamtes Modell einpassen" button produces. Every
+  assertion in them is unchanged. The acceptance suite does the same through the
+  button itself (`e2e/src/canvas.ts`), so the end-to-end run exercises the real
+  control rather than a test seam.
+- **The toolbar grew a button** and now wraps instead of overflowing, because the
+  centre pane can be resized down to a few hundred pixels and a toolbar running
+  past its own edge takes its controls out of reach.
+- **A collapsed container is one more thing that will need an accessible name.**
+  Its disclosure control has one; the node itself does not, and neither did it
+  before — that is #35, which builds on this. A hidden node must not be a tab
+  stop either, which is a property #35 gets for free because a hidden node is not
+  rendered at all.
+- `INITIAL_EXPANDED_DEPTH` is a product decision disguised as a constant, like
+  `RECENT_APPLIED_LIMIT` in ADR 0010. One level below the roots is right for a
+  reported architecture, where depth 0 is the system and depth 1 its parts. A
+  model that puts everything interesting at depth 3 would open on a page of
+  containers; the fix would be to disclose by subtree size rather than by depth,
+  and it belongs in `initialCollapsedIds` alone.

--- a/e2e/src/canvas.ts
+++ b/e2e/src/canvas.ts
@@ -1,0 +1,21 @@
+import { expect, type Page } from '@playwright/test'
+
+/**
+ * Opens every collapsed container of the architecture canvas.
+ *
+ * A project opens on its system and container level with deeper containers
+ * collapsed, so that a model of thirty-odd components is readable at the
+ * resolution this suite accepts at (issue #34, ADR 0017). "Gesamtes Modell
+ * einpassen" is the explicit overview action that undoes it — the same button a
+ * user presses — so assertions about components three and four levels down go
+ * through it rather than around it.
+ *
+ * Waits for the re-layout, because expanding changes the ELK input.
+ */
+export async function showWholeModel(page: Page): Promise<void> {
+  const canvas = page.getByTestId('architecture-canvas')
+  await expect(canvas).toBeVisible()
+  await page.getByTestId('canvas-fit-view').click()
+  await expect(canvas).toHaveAttribute('data-hidden-node-count', '0')
+  await expect(canvas).toHaveAttribute('data-layouting', 'false')
+}

--- a/e2e/tests/02-live-updates.spec.ts
+++ b/e2e/tests/02-live-updates.spec.ts
@@ -7,6 +7,7 @@ import {
   MAIN_PROJECT,
   MAIN_RUN,
 } from '../src/config.js'
+import { showWholeModel } from '../src/canvas.js'
 import { installLiveObserver } from '../src/liveObserver.js'
 import { startSimulator, type SimulatorSummary } from '../src/simulator.js'
 
@@ -73,6 +74,13 @@ test('3 · every live change state is observed while the run is happening', asyn
   // screen long enough to be genuinely observable rather than inferred.
   const simulator = startSimulator({ scenario: 'full', speed: 1 })
 
+  // The architecture snapshot is the first thing the run publishes, and the
+  // canvas opens it on its top levels only (#34). The states below land on
+  // components two and three levels down, so the whole model is opened here —
+  // once, before any of them arrive — and stays open for the rest of the run.
+  await expect(page.getByTestId('architecture-canvas')).toBeVisible({ timeout: 120_000 })
+  await showWholeModel(page)
+
   // The applied removal is the last of the four states to appear; waiting for it
   // means the run reached its "Applied changes" phase with the page open.
   await expect
@@ -93,7 +101,9 @@ test('3 · every live change state is observed while the run is happening', asyn
   expect(summary.endPosition).toBe(summary.eventsSent + 1)
 
   // The last proposal of the run arrives after the applied changes; waiting for
-  // its node means the page processed the whole stream.
+  // its node means the page processed the whole stream. It is two levels down,
+  // so the whole model has to be open for it to be drawn (#34).
+  await showWholeModel(page)
   await expect(
     page.getByTestId('canvas-node-shop-platform.orders.domain.rounding'),
   ).toBeVisible()
@@ -173,6 +183,7 @@ test('3 · after a reload the watched states start empty again — which is why 
   )
   await expect(page.getByTestId('architecture-canvas')).toBeVisible()
   // The pending proposals come back from the read API's `activeChanges`.
+  await showWholeModel(page)
   await expect(
     page.getByTestId('canvas-node-shop-platform.orders.domain.rounding'),
   ).toBeVisible()

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
 import { getJson } from '../src/api.js'
+import { showWholeModel } from '../src/canvas.js'
 import { MAIN_PROJECT, MAIN_RUN } from '../src/config.js'
 
 /**
@@ -78,7 +79,10 @@ test('2 · the canvas draws the reported hierarchy across four nesting levels', 
   page,
 }) => {
   await openWorkspace(page)
-  await page.getByTestId('canvas-fit-view').click()
+  // The canvas opens on its top levels (#34); the hierarchy and the individual
+  // topic edges below them are what this check is about, so it opens the whole
+  // model first — through the button a user would press.
+  await showWholeModel(page)
 
   const canvas = page.getByTestId('architecture-canvas')
   await expect(canvas).toHaveAttribute('data-node-count', '17')
@@ -160,7 +164,10 @@ test('2 · every relationship kind is drawn, and every reported NATS topic stays
 
   // ---- what the canvas draws ----------------------------------------------
   await openWorkspace(page)
-  await page.getByTestId('canvas-fit-view').click()
+  // The canvas opens on its top levels (#34); the hierarchy and the individual
+  // topic edges below them are what this check is about, so it opens the whole
+  // model first — through the button a user would press.
+  await showWholeModel(page)
 
   // All six typed kinds are on screen, each with its own stroke pattern.
   for (const kind of RELATIONSHIP_KINDS) {

--- a/e2e/tests/05-inspector.spec.ts
+++ b/e2e/tests/05-inspector.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 
+import { showWholeModel } from '../src/canvas.js'
 import { MAIN_PROJECT, MAIN_RUN } from '../src/config.js'
 
 /**
@@ -32,6 +33,10 @@ test('5 · clicking a component shows its agent, task, markdown feedback and gro
   await expect(page.getByTestId('pane-inspector')).toContainText(
     'Keine Komponente ausgewählt',
   )
+
+  // `tax` sits three levels down and is therefore behind its container when the
+  // project opens (#34). The explicit overview action brings it on screen.
+  await showWholeModel(page)
 
   await page.getByTestId(`canvas-node-${TAX}`).click()
 

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -44,9 +44,22 @@ function architectureFetch(initial: ArchitectureResponse) {
   }
 }
 
+/**
+ * Renders the canvas with every container open.
+ *
+ * A project opens on its top levels with deeper containers collapsed (#34 /
+ * ADR 0017), which is what `ArchitectureZoom.test.tsx` covers. The assertions
+ * in this file are about bundling, selection and the camera on components that
+ * sit three and four levels down, so they start from the state the user reaches
+ * with "Gesamtes Modell einpassen" — a real, reachable state, and the one these
+ * tests have always described.
+ */
 function renderCanvas(url = WORKSPACE_URL, initial = nestedArchitectureResponse) {
   const architecture = architectureFetch(initial)
-  const app = renderApp(url, { fetchImpl: architecture.fetchImpl })
+  const app = renderApp(url, {
+    fetchImpl: architecture.fetchImpl,
+    expandAllComponents: true,
+  })
   return { ...app, ...architecture }
 }
 

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -168,12 +168,12 @@ function ArchitectureCanvasInner({
    * layout — the same model always ends up under the same camera.
    *
    * The two modes are the whole readability rule. `initial` may not zoom below
-   * `MIN_READABLE_ZOOM` and anchors an oversized model at its top-left corner;
-   * `user` fits whatever is there, however small that turns out, because the
-   * user asked for the overview.
+   * `MIN_READABLE_ZOOM`, anchors an oversized model at its top-left corner and
+   * keeps `focusComponentId` on screen; `user` fits whatever is there, however
+   * small that turns out, because the user asked for the overview.
    */
   const fitView = useCallback(
-    (mode: FitMode) => {
+    (mode: FitMode, focusComponentId: ComponentId | null = null) => {
       setFitViewCount((count) => count + 1)
 
       const { width, height, nodeLookup } = storeApi.getState()
@@ -182,11 +182,17 @@ function ArchitectureCanvasInner({
       const bounds = getNodesBounds([...nodeLookup.values()], { nodeLookup })
       if (width <= 0 || height <= 0 || bounds.width <= 0 || bounds.height <= 0) return
 
+      // The absolute box of the node the URL points at. `getNodesBounds` is what
+      // resolves a nested node's parent-relative position for us, so the focus
+      // arrives in the same coordinates as the model bounds.
+      const focusNode = focusComponentId === null ? undefined : nodeLookup.get(focusComponentId)
+      const focus = focusNode ? getNodesBounds([focusNode], { nodeLookup }) : null
+
       const viewport = viewportForBounds(
         bounds,
         { width, height },
         mode === 'initial'
-          ? { minZoom: MIN_READABLE_ZOOM, overflow: 'start' }
+          ? { minZoom: MIN_READABLE_ZOOM, overflow: 'start', focus }
           : { minZoom: MIN_ZOOM },
       )
       void flow.setViewport(viewport)
@@ -204,19 +210,26 @@ function ArchitectureCanvasInner({
    * rather than state: the parked request changes nothing on screen, and the
    * effect that redeems it already re-runs when the new layout lands.
    */
-  const pendingFitRef = useRef<FitMode | null>(null)
+  const pendingFitRef = useRef<{ mode: FitMode; focusComponentId: ComponentId | null } | null>(
+    null,
+  )
 
   /** Fits now if the graph is already the right one, otherwise after re-layout. */
   const requestFit = useCallback(
     (mode: FitMode, afterRelayout: boolean) => {
+      // "Systemebene" reproduces the entry picture, and the entry picture keeps
+      // the selected component on screen. The whole-model overview does not: it
+      // is about the model, not about one component of it.
+      const focusComponentId =
+        mode === 'initial' ? (selectedComponentId ?? null) : null
       if (afterRelayout) {
-        pendingFitRef.current = mode
+        pendingFitRef.current = { mode, focusComponentId }
         return
       }
       policyRef.current = onUserFitRequest(policyRef.current).state
-      fitView(mode)
+      fitView(mode, focusComponentId)
     },
-    [fitView],
+    [fitView, selectedComponentId],
   )
 
   // Switching projects makes the next model an initial one again — including
@@ -238,6 +251,13 @@ function ArchitectureCanvasInner({
   // and the user has not taken the camera over. Every later layout — an added
   // component, a removed relationship, a replacing snapshot — returns `null`
   // here and leaves zoom, pan and selection exactly where the user left them.
+  //
+  // `selectedComponentId` is an *input* to that one movement, not a trigger for
+  // a second one. A deep link says which component the picture is about, and
+  // the first picture is the only one nobody has taken over yet; honouring it
+  // there costs no extra fit. It is in the dependency list because a later
+  // selection change must run the policy again and be told `null` — which is
+  // exactly the assertion that a click never moves the camera.
   useEffect(() => {
     const decision = onLayoutReady(policyRef.current, {
       projectId,
@@ -247,8 +267,15 @@ function ArchitectureCanvasInner({
     })
     policyRef.current = decision.state
     if (decision.fit === null) return
-    fitView('initial')
-  }, [projectId, graph.nodes.length, surfaceWidth, surfaceHeight, fitView])
+    fitView('initial', selectedComponentId ?? null)
+  }, [
+    projectId,
+    graph.nodes.length,
+    surfaceWidth,
+    surfaceHeight,
+    selectedComponentId,
+    fitView,
+  ])
 
   // The initial disclosure, written down once it has been applied.
   //
@@ -271,7 +298,7 @@ function ArchitectureCanvasInner({
     if (pending === null || graph.isRelayouting || graph.nodes.length === 0) return
     pendingFitRef.current = null
     policyRef.current = onUserFitRequest(policyRef.current).state
-    fitView(pending)
+    fitView(pending.mode, pending.focusComponentId)
   }, [graph.isRelayouting, graph.nodes.length, graph.signature, fitView])
 
   const edges = useMemo<ArchitectureEdge[]>(() => {
@@ -386,6 +413,10 @@ function ArchitectureCanvasInner({
       data-visible-node-count={graph.visibleNodeCount}
       data-hidden-node-count={hiddenCount}
       data-collapsed-count={graph.collapsedIds.length}
+      // The surface the camera was computed against. Reported so "is this node
+      // actually on screen" is answerable from outside without a layout engine.
+      data-surface-width={surfaceWidth}
+      data-surface-height={surfaceHeight}
       data-layouting={graph.isRelayouting ? 'true' : 'false'}
     >
       <EdgeMarkerDefs />

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -7,7 +7,6 @@ import {
   ReactFlow,
   ReactFlowProvider,
   getNodesBounds,
-  getViewportForBounds,
   useReactFlow,
   useStore,
   useStoreApi,
@@ -15,7 +14,7 @@ import {
   type OnNodeDrag,
   type Viewport,
 } from '@xyflow/react'
-import { Map, MapPinOff, Maximize2, RotateCcw, TriangleAlert } from 'lucide-react'
+import { Layers2, Map, MapPinOff, Maximize2, RotateCcw, TriangleAlert } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import '@xyflow/react/dist/style.css'
@@ -31,11 +30,14 @@ import {
   onLayoutReady,
   onProjectChanged,
   onUserFitRequest,
+  viewportForBounds,
   type CameraPolicyState,
 } from './cameraPolicy'
 import {
   DETAIL_LEVEL_DESCRIPTIONS,
   DETAIL_LEVEL_LABELS,
+  DISCLOSURE_LABELS,
+  MIN_READABLE_ZOOM,
   detailLevelForZoom,
 } from './detailLevel'
 import { ARCHITECTURE_EDGE_TYPES, ARCHITECTURE_NODE_TYPES } from './flowRegistry'
@@ -45,6 +47,7 @@ import {
   type ArchitectureEdge,
   type ArchitectureModel,
 } from './graphProjection'
+import { CanvasNodeActionsContext, type CanvasNodeActions } from './nodeActions'
 import {
   applyTemporaryPositions,
   routesInvalidatedByDrag,
@@ -68,16 +71,26 @@ import {
  *    pick a drag up as a domain change.
  * 3. **The camera is the user's.** `fitView` runs on the first model of a
  *    project and on an explicit click, never because data arrived.
+ * 4. **The first picture is readable.** The automatic camera never goes below
+ *    `MIN_READABLE_ZOOM`, and a project opens on its top levels with deeper
+ *    containers collapsed (`collapse.ts`). Both are undone by an explicit
+ *    "Gesamtes Modell einpassen", never by anything the data does.
  */
 
 const MIN_ZOOM = 0.12
 const MAX_ZOOM = 2.5
-/** Never zoom *in* to fit: a two-component model must not fill the screen. */
-const FIT_VIEW_MAX_ZOOM = 1
-const FIT_VIEW_PADDING = 0.1
 
 const NODE_TYPES = ARCHITECTURE_NODE_TYPES
 const EDGE_TYPES = ARCHITECTURE_EDGE_TYPES
+
+/**
+ * Why the camera is being moved.
+ *
+ * `initial` is the one movement the user did not ask for, so it is the one that
+ * has to stay readable; `user` is an explicit request for the whole model and
+ * may zoom out as far as the model needs.
+ */
+type FitMode = 'initial' | 'user'
 
 export interface ArchitectureCanvasProps {
   projectId: ProjectId
@@ -100,7 +113,18 @@ function ArchitectureCanvasInner({
   selectedComponentId,
   onSelectComponent,
 }: ArchitectureCanvasProps) {
-  const graph = useArchitectureGraph(model)
+  const collapsedComponentIds = useUiStore((state) => state.collapsedComponentIds)
+  const setCollapsedComponentIds = useUiStore((state) => state.setCollapsedComponentIds)
+  const setComponentCollapsed = useUiStore((state) => state.setComponentCollapsed)
+
+  const graph = useArchitectureGraph(model, {
+    collapsedComponentIds,
+    // A deep link is a statement about *what to look at*. Opening the
+    // containers on the way to it changes what is drawn, not where the camera
+    // is — so a link into a component four levels down arrives, and the camera
+    // policy is untouched by it.
+    revealComponentId: selectedComponentId ?? null,
+  })
   const flow = useReactFlow()
   const storeApi = useStoreApi()
 
@@ -135,41 +159,79 @@ function ArchitectureCanvasInner({
     [graph.nodes, nodePositions, selectedComponentId],
   )
   /**
-   * Fits the whole model into the viewport.
+   * Puts the currently drawn graph under the camera.
    *
    * The viewport is computed and applied explicitly instead of going through
    * `instance.fitView()`: that call schedules itself through React Flow's node
    * change queue, which a fully controlled graph without `onNodesChange` never
    * drains. Computing it here also makes the result a pure function of the ELK
    * layout — the same model always ends up under the same camera.
+   *
+   * The two modes are the whole readability rule. `initial` may not zoom below
+   * `MIN_READABLE_ZOOM` and anchors an oversized model at its top-left corner;
+   * `user` fits whatever is there, however small that turns out, because the
+   * user asked for the overview.
    */
-  const fitView = useCallback(() => {
-    setFitViewCount((count) => count + 1)
+  const fitView = useCallback(
+    (mode: FitMode) => {
+      setFitViewCount((count) => count + 1)
 
-    const { width, height, nodeLookup } = storeApi.getState()
-    if (nodeLookup.size === 0) return
+      const { width, height, nodeLookup } = storeApi.getState()
+      if (nodeLookup.size === 0) return
 
-    const bounds = getNodesBounds([...nodeLookup.values()], { nodeLookup })
-    if (width <= 0 || height <= 0 || bounds.width <= 0 || bounds.height <= 0) return
+      const bounds = getNodesBounds([...nodeLookup.values()], { nodeLookup })
+      if (width <= 0 || height <= 0 || bounds.width <= 0 || bounds.height <= 0) return
 
-    const viewport = getViewportForBounds(
-      bounds,
-      width,
-      height,
-      MIN_ZOOM,
-      FIT_VIEW_MAX_ZOOM,
-      FIT_VIEW_PADDING,
-    )
-    void flow.setViewport(viewport)
-    setCamera(viewport)
-    setDetailLevel(detailLevelForZoom(viewport.zoom))
-  }, [flow, storeApi, setCamera])
+      const viewport = viewportForBounds(
+        bounds,
+        { width, height },
+        mode === 'initial'
+          ? { minZoom: MIN_READABLE_ZOOM, overflow: 'start' }
+          : { minZoom: MIN_ZOOM },
+      )
+      void flow.setViewport(viewport)
+      setCamera(viewport)
+      setDetailLevel(detailLevelForZoom(viewport.zoom))
+    },
+    [flow, storeApi, setCamera],
+  )
 
-  // Switching projects makes the next model an initial one again.
+  /**
+   * A fit the user asked for, held until the layout it is about exists.
+   *
+   * Expanding or collapsing containers changes the ELK input, so at the moment
+   * of the click the bounds the camera needs have not been computed yet. A ref
+   * rather than state: the parked request changes nothing on screen, and the
+   * effect that redeems it already re-runs when the new layout lands.
+   */
+  const pendingFitRef = useRef<FitMode | null>(null)
+
+  /** Fits now if the graph is already the right one, otherwise after re-layout. */
+  const requestFit = useCallback(
+    (mode: FitMode, afterRelayout: boolean) => {
+      if (afterRelayout) {
+        pendingFitRef.current = mode
+        return
+      }
+      policyRef.current = onUserFitRequest(policyRef.current).state
+      fitView(mode)
+    },
+    [fitView],
+  )
+
+  // Switching projects makes the next model an initial one again — including
+  // its disclosure: the containers the user opened in project A say nothing
+  // about project B. Only a real *change* resets it; a remount of the canvas
+  // must not throw away what the user opened.
+  const disclosedProjectRef = useRef<ProjectId | null>(null)
   useEffect(() => {
     policyRef.current = onProjectChanged(policyRef.current, projectId)
     clearExpandedEdges()
-  }, [projectId, clearExpandedEdges])
+    if (disclosedProjectRef.current !== null && disclosedProjectRef.current !== projectId) {
+      setCollapsedComponentIds(null)
+    }
+    disclosedProjectRef.current = projectId
+  }, [projectId, clearExpandedEdges, setCollapsedComponentIds])
 
   // The only automatic camera movement in the whole cockpit: the first laid-out
   // model of a project, plus a resize of the surface while it is still settling
@@ -185,8 +247,32 @@ function ArchitectureCanvasInner({
     })
     policyRef.current = decision.state
     if (decision.fit === null) return
-    fitView()
+    fitView('initial')
   }, [projectId, graph.nodes.length, surfaceWidth, surfaceHeight, fitView])
+
+  // The initial disclosure, written down once it has been applied.
+  //
+  // Until this runs the collapsed set is a *derivation* (`initialCollapsedIds`
+  // minus the path to a deep-linked component), and a derivation cannot be
+  // toggled: opening one container would have to know which others were closed.
+  // Materialising it makes every later expand and collapse a plain edit of an
+  // explicit list. It writes the set the canvas is already showing, so it
+  // changes no picture and triggers no re-layout.
+  useEffect(() => {
+    if (collapsedComponentIds !== null || graph.nodes.length === 0) return
+    setCollapsedComponentIds(graph.collapsedIds)
+  }, [collapsedComponentIds, graph.nodes.length, graph.collapsedIds, setCollapsedComponentIds])
+
+  // Redeems a parked fit once the layout it was asked about has landed. It goes
+  // through `onUserFitRequest`, so it stays an explicit movement and never
+  // becomes a second automatic one.
+  useEffect(() => {
+    const pending = pendingFitRef.current
+    if (pending === null || graph.isRelayouting || graph.nodes.length === 0) return
+    pendingFitRef.current = null
+    policyRef.current = onUserFitRequest(policyRef.current).state
+    fitView(pending)
+  }, [graph.isRelayouting, graph.nodes.length, graph.signature, fitView])
 
   const edges = useMemo<ArchitectureEdge[]>(() => {
     const invalidated = routesInvalidatedByDrag(graph.edges, nodePositions)
@@ -233,8 +319,55 @@ function ArchitectureCanvasInner({
     [setCamera],
   )
 
+  /**
+   * Opens or closes one container.
+   *
+   * Closing one that holds the current selection moves the selection up to it.
+   * The selection lives in the URL and drives the inspector, so leaving it on a
+   * component that is no longer drawn would put the three out of step — and
+   * re-opening the container just to keep a hidden selection alive would make
+   * the collapse impossible.
+   */
+  const onToggleCollapsed = useCallback<CanvasNodeActions['toggleCollapsed']>(
+    (componentId, collapsed) => {
+      if (
+        collapsed &&
+        selectedComponentId !== undefined &&
+        selectedComponentId !== componentId &&
+        graph.ancestorsOf(selectedComponentId).includes(componentId)
+      ) {
+        onSelectComponent(componentId)
+      }
+      setComponentCollapsed(componentId, collapsed)
+    },
+    [graph, selectedComponentId, onSelectComponent, setComponentCollapsed],
+  )
+
+  const nodeActions = useMemo<CanvasNodeActions>(
+    () => ({ toggleCollapsed: onToggleCollapsed }),
+    [onToggleCollapsed],
+  )
+
+  /** "Gesamtes Modell einpassen": everything open, everything on screen. */
+  const onShowWholeModel = useCallback(() => {
+    const willRelayout = graph.collapsedIds.length > 0
+    if (willRelayout) setCollapsedComponentIds([])
+    requestFit('user', willRelayout)
+  }, [graph.collapsedIds.length, requestFit, setCollapsedComponentIds])
+
+  /** Back to the picture the project opened with. */
+  const onBackToOverview = useCallback(() => {
+    const target = graph.initialCollapsedIds
+    const willRelayout =
+      target.length !== graph.collapsedIds.length ||
+      target.some((componentId, index) => graph.collapsedIds[index] !== componentId)
+    if (willRelayout) setCollapsedComponentIds(target)
+    requestFit('initial', willRelayout)
+  }, [graph.initialCollapsedIds, graph.collapsedIds, requestFit, setCollapsedComponentIds])
+
   const hasTemporaryPositions = Object.keys(nodePositions).length > 0
   const problemCount = diagnosticsCount(graph.diagnostics)
+  const hiddenCount = graph.hiddenComponentIds.size
 
   // The applied model and the overlay are counted separately on purpose: a
   // planned change must become visible on the canvas **without** changing what
@@ -250,182 +383,226 @@ function ArchitectureCanvasInner({
       data-edge-count={graph.appliedEdgeCount}
       data-overlay-node-count={graph.overlayNodeCount}
       data-overlay-edge-count={graph.overlayEdgeCount}
+      data-visible-node-count={graph.visibleNodeCount}
+      data-hidden-node-count={hiddenCount}
+      data-collapsed-count={graph.collapsedIds.length}
       data-layouting={graph.isRelayouting ? 'true' : 'false'}
     >
       <EdgeMarkerDefs />
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={NODE_TYPES}
-        edgeTypes={EDGE_TYPES}
-        defaultViewport={initialViewport}
-        minZoom={MIN_ZOOM}
-        maxZoom={MAX_ZOOM}
-        onNodeClick={onNodeClick}
-        onNodeDragStop={onNodeDragStop}
-        onMoveStart={onMoveStart}
-        onMove={onMove}
-        onMoveEnd={onMoveEnd}
-        nodesDraggable
-        nodesConnectable={false}
-        edgesReconnectable={false}
-        elementsSelectable
-        // Selection is owned by the URL, so React Flow must not manage its own.
-        selectNodesOnDrag={false}
-        multiSelectionKeyCode={null}
-        deleteKeyCode={null}
-        proOptions={{ hideAttribution: false }}
-        attributionPosition="bottom-left"
-        className="bg-canvas"
-        aria-label="Interaktiver Architekturgraph"
-      >
-        <Background
-          variant={BackgroundVariant.Dots}
-          gap={28}
-          size={1}
-          color="var(--canvas-grid)"
-        />
-        <Controls
-          showInteractive={false}
-          // The built-in fit control is replaced by "Einpassen" in the toolbar,
-          // which goes through the camera policy instead of around it.
-          showFitView={false}
-          position="bottom-right"
-          className="!border-border !bg-card/90 !shadow-none [&>button]:!border-border [&>button]:!bg-card [&>button]:!fill-current [&>button]:!text-foreground"
-        />
-        {minimapVisible && (
-          <MiniMap
-            position="top-right"
-            pannable
-            zoomable
-            ariaLabel="Übersichtskarte der Architektur"
-            className="!border-border !bg-card/80 !m-2 !rounded-md !border"
-            style={{ width: 168, height: 112 }}
-            maskColor="color-mix(in oklab, var(--background) 72%, transparent)"
-            nodeColor={(node) =>
-              node.type === COMPOUND_NODE_TYPE
-                ? 'var(--graphite-700)'
-                : 'var(--graphite-400)'
-            }
-            nodeStrokeWidth={0}
+      <CanvasNodeActionsContext value={nodeActions}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={NODE_TYPES}
+          edgeTypes={EDGE_TYPES}
+          defaultViewport={initialViewport}
+          minZoom={MIN_ZOOM}
+          maxZoom={MAX_ZOOM}
+          onNodeClick={onNodeClick}
+          onNodeDragStop={onNodeDragStop}
+          onMoveStart={onMoveStart}
+          onMove={onMove}
+          onMoveEnd={onMoveEnd}
+          nodesDraggable
+          nodesConnectable={false}
+          edgesReconnectable={false}
+          elementsSelectable
+          // Selection is owned by the URL, so React Flow must not manage its own.
+          selectNodesOnDrag={false}
+          multiSelectionKeyCode={null}
+          deleteKeyCode={null}
+          proOptions={{ hideAttribution: false }}
+          attributionPosition="bottom-left"
+          className="bg-canvas"
+          aria-label="Interaktiver Architekturgraph"
+        >
+          <Background
+            variant={BackgroundVariant.Dots}
+            gap={28}
+            size={1}
+            color="var(--canvas-grid)"
           />
-        )}
+          <Controls
+            showInteractive={false}
+            // The built-in fit control is replaced by "Einpassen" in the toolbar,
+            // which goes through the camera policy instead of around it.
+            showFitView={false}
+            position="bottom-right"
+            className="!border-border !bg-card/90 !shadow-none [&>button]:!border-border [&>button]:!bg-card [&>button]:!fill-current [&>button]:!text-foreground"
+          />
+          {minimapVisible && (
+            <MiniMap
+              position="top-right"
+              pannable
+              zoomable
+              ariaLabel="Übersichtskarte der Architektur"
+              className="!border-border !bg-card/80 !m-2 !rounded-md !border"
+              style={{ width: 168, height: 112 }}
+              maskColor="color-mix(in oklab, var(--background) 72%, transparent)"
+              nodeColor={(node) =>
+                node.type === COMPOUND_NODE_TYPE
+                  ? 'var(--graphite-700)'
+                  : 'var(--graphite-400)'
+              }
+              nodeStrokeWidth={0}
+            />
+          )}
 
-        <Panel position="top-left" className="!m-2">
-          <div className="border-border bg-card/90 flex items-center gap-1 rounded-md border px-1 py-1 backdrop-blur-sm">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1.5 px-2 text-xs"
-                  onClick={() => {
-                    policyRef.current = onUserFitRequest(policyRef.current).state
-                    fitView()
-                  }}
-                  data-testid="canvas-fit-view"
-                >
-                  <Maximize2 aria-hidden="true" />
-                  Einpassen
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                Ansicht auf das gesamte Modell einpassen. Die Kamera bewegt sich sonst nur
-                beim ersten Laden — nie durch eintreffende Ereignisse.
-              </TooltipContent>
-            </Tooltip>
-
-            {hasTemporaryPositions && (
+          <Panel position="top-left" className="!m-2">
+            {/* Wraps rather than overflows: the centre pane can be resized down
+                to a few hundred pixels, and a toolbar that runs past its edge
+                takes its own controls out of reach. */}
+            <div className="border-border bg-card/90 flex max-w-[min(100%,44rem)] flex-wrap items-center gap-1 rounded-md border px-1 py-1 backdrop-blur-sm">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     variant="ghost"
                     size="sm"
                     className="h-7 gap-1.5 px-2 text-xs"
-                    onClick={clearNodePositions}
-                    data-testid="canvas-reset-positions"
+                    onClick={onShowWholeModel}
+                    data-testid="canvas-fit-view"
                   >
-                    <RotateCcw aria-hidden="true" />
-                    Positionen zurücksetzen
+                    <Maximize2 aria-hidden="true" />
+                    {DISCLOSURE_LABELS.fitWholeModel}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-80">
+                  {DISCLOSURE_LABELS.fitWholeModelHint} Die Kamera bewegt sich sonst nur beim
+                  ersten Laden — nie durch eintreffende Ereignisse.
+                </TooltipContent>
+              </Tooltip>
+
+              {graph.initialCollapsedIds.length > 0 && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 gap-1.5 px-2 text-xs"
+                      onClick={onBackToOverview}
+                      data-testid="canvas-back-to-overview"
+                    >
+                      <Layers2 aria-hidden="true" />
+                      {DISCLOSURE_LABELS.backToOverview}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-80">
+                    {DISCLOSURE_LABELS.backToOverviewHint}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
+              {hasTemporaryPositions && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 gap-1.5 px-2 text-xs"
+                      onClick={clearNodePositions}
+                      data-testid="canvas-reset-positions"
+                    >
+                      <RotateCcw aria-hidden="true" />
+                      Positionen zurücksetzen
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Verschobene Knoten zurück auf das berechnete Layout. Verschiebungen sind
+                    ohnehin nur lokal und ändern das Architekturmodell nicht.
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    onClick={() => setMinimapVisible(!minimapVisible)}
+                    aria-pressed={minimapVisible}
+                    data-testid="canvas-toggle-minimap"
+                  >
+                    {minimapVisible ? (
+                      <Map aria-hidden="true" />
+                    ) : (
+                      <MapPinOff aria-hidden="true" />
+                    )}
+                    <span className="sr-only">
+                      Übersichtskarte {minimapVisible ? 'ausblenden' : 'einblenden'}
+                    </span>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  Verschobene Knoten zurück auf das berechnete Layout. Verschiebungen sind
-                  ohnehin nur lokal und ändern das Architekturmodell nicht.
+                  Übersichtskarte {minimapVisible ? 'ausblenden' : 'einblenden'}
                 </TooltipContent>
               </Tooltip>
-            )}
 
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="size-7"
-                  onClick={() => setMinimapVisible(!minimapVisible)}
-                  aria-pressed={minimapVisible}
-                  data-testid="canvas-toggle-minimap"
-                >
-                  {minimapVisible ? (
-                    <Map aria-hidden="true" />
-                  ) : (
-                    <MapPinOff aria-hidden="true" />
-                  )}
-                  <span className="sr-only">
-                    Übersichtskarte {minimapVisible ? 'ausblenden' : 'einblenden'}
-                  </span>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                Übersichtskarte {minimapVisible ? 'ausblenden' : 'einblenden'}
-              </TooltipContent>
-            </Tooltip>
+              <span className="bg-border mx-0.5 h-4 w-px" aria-hidden="true" />
 
-            <span className="bg-border mx-0.5 h-4 w-px" aria-hidden="true" />
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="text-muted-foreground px-1 text-[11px] whitespace-nowrap"
-                  data-testid="canvas-detail-level"
-                >
-                  Detailstufe: {DETAIL_LEVEL_LABELS[detailLevel]}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>{DETAIL_LEVEL_DESCRIPTIONS[detailLevel]}</TooltipContent>
-            </Tooltip>
-
-            {problemCount > 0 && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span
-                    className="text-state-planned flex items-center gap-1 px-1 text-[11px]"
-                    data-testid="canvas-diagnostics"
+                    className="text-muted-foreground px-1 text-[11px] whitespace-nowrap"
+                    data-testid="canvas-detail-level"
                   >
-                    <TriangleAlert className="size-3.5" aria-hidden="true" />
-                    {problemCount} unstimmige Angaben
+                    Detailstufe: {DETAIL_LEVEL_LABELS[detailLevel]}
                   </span>
                 </TooltipTrigger>
-                <TooltipContent className="max-w-80">
-                  <DiagnosticsSummary graph={graph} />
-                </TooltipContent>
+                <TooltipContent>{DETAIL_LEVEL_DESCRIPTIONS[detailLevel]}</TooltipContent>
               </Tooltip>
-            )}
-          </div>
-        </Panel>
 
-        {graph.isRelayouting && (
-          <Panel position="top-center" className="!m-2">
-            <span
-              className="border-border bg-card/90 text-muted-foreground rounded-md border px-2 py-1 text-[11px]"
-              role="status"
-              data-testid="canvas-layouting"
-            >
-              Layout wird berechnet…
-            </span>
+              {hiddenCount > 0 && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="text-muted-foreground px-1 text-[11px] whitespace-nowrap"
+                      data-testid="canvas-visibility"
+                    >
+                      {DISCLOSURE_LABELS.visibility(
+                        graph.visibleNodeCount,
+                        graph.visibleNodeCount + hiddenCount,
+                      )}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-80">
+                    {DISCLOSURE_LABELS.visibilityHint}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
+              {problemCount > 0 && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="text-state-planned flex items-center gap-1 px-1 text-[11px]"
+                      data-testid="canvas-diagnostics"
+                    >
+                      <TriangleAlert className="size-3.5" aria-hidden="true" />
+                      {problemCount} unstimmige Angaben
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-80">
+                    <DiagnosticsSummary graph={graph} />
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
           </Panel>
-        )}
-      </ReactFlow>
+
+          {graph.isRelayouting && (
+            <Panel position="top-center" className="!m-2">
+              <span
+                className="border-border bg-card/90 text-muted-foreground rounded-md border px-2 py-1 text-[11px]"
+                role="status"
+                data-testid="canvas-layouting"
+              >
+                Layout wird berechnet…
+              </span>
+            </Panel>
+          )}
+        </ReactFlow>
+      </CanvasNodeActionsContext>
     </div>
   )
 }

--- a/frontend/src/canvas/ArchitectureZoom.test.tsx
+++ b/frontend/src/canvas/ArchitectureZoom.test.tsx
@@ -1,0 +1,464 @@
+import { act, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import type { ArchitectureResponse } from '@/api/types'
+import { applyLiveEvent } from '@/api/useLiveStream'
+import { useUiStore } from '@/state/uiStore'
+import {
+  LARGE_COMPONENTS,
+  LARGE_DEEP_ANCESTORS,
+  LARGE_DEEP_COMPONENT_ID,
+  activeChange,
+  largeArchitectureResponse,
+  largeGrownArchitectureResponse,
+} from '@/test/architectureFixtures'
+import { PROJECT_ID, RUN_ID, createFakeFetch, streamedEvent } from '@/test/fixtures'
+import { renderApp } from '@/test/renderApp'
+
+import {
+  MIN_LEGIBLE_FONT_SIZE_PX,
+  MIN_READABLE_ZOOM,
+  NODE_LABEL_FONT_SIZE_PX,
+} from './detailLevel'
+import { LEAF_NODE_SIZE } from './graphProjection'
+
+/**
+ * The readable entry point (#34).
+ *
+ * Everything here is asserted on a model of **32 components over four levels**,
+ * because that is where the old behaviour broke: fitting all of it put the
+ * camera at a zoom where a node was 46 × 20 px and its name rendered at 2.6 px.
+ *
+ * Two mechanisms have to hold together, and both are checked as *numbers* on
+ * the rendered surface rather than as intentions:
+ *
+ * 1. the automatic camera never falls below `MIN_READABLE_ZOOM`,
+ * 2. a project opens on its top levels, and everything below stays reachable.
+ *
+ * And neither of them may cost the property the rest of the canvas is built
+ * on: after the first picture, the camera belongs to the user.
+ */
+
+const WORKSPACE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}`
+const ARCHITECTURE_PATH = `/api/v1/projects/${PROJECT_ID}/architecture`
+const CANVAS_TIMEOUT = 15_000
+
+function architectureFetch(initial: ArchitectureResponse) {
+  const state = { response: initial }
+  const fetchImpl = createFakeFetch({
+    get [ARCHITECTURE_PATH]() {
+      return state.response
+    },
+  })
+  return {
+    fetchImpl,
+    publish(next: ArchitectureResponse) {
+      state.response = next
+    },
+  }
+}
+
+function renderLargeModel(url = WORKSPACE_URL) {
+  const architecture = architectureFetch(largeArchitectureResponse)
+  const app = renderApp(url, { fetchImpl: architecture.fetchImpl })
+  return { ...app, ...architecture }
+}
+
+async function waitForCanvas(): Promise<HTMLElement> {
+  const canvas = await screen.findByTestId('architecture-canvas', undefined, {
+    timeout: CANVAS_TIMEOUT,
+  })
+  await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'), {
+    timeout: CANVAS_TIMEOUT,
+  })
+  return canvas
+}
+
+/** The rendered zoom and pan — the ground truth of where the camera is. */
+function viewportTransform(): string {
+  return (
+    document.querySelector<HTMLElement>('.react-flow__viewport')?.style.transform ?? ''
+  )
+}
+
+/** Resolves once the one automatic fit has run its course. */
+async function waitForCameraSettled(): Promise<void> {
+  await waitFor(() => expect(useUiStore.getState().camera.zoom).toBeGreaterThan(0), {
+    timeout: CANVAS_TIMEOUT,
+  })
+  let previous = useUiStore.getState().camera
+  await waitFor(
+    () => {
+      const current = useUiStore.getState().camera
+      const settled = current === previous
+      previous = current
+      expect(settled).toBe(true)
+    },
+    { timeout: CANVAS_TIMEOUT, interval: 40 },
+  )
+}
+
+describe('architecture canvas — a large model opens readable', () => {
+  it(
+    'never opens below the readable zoom, however many components there are',
+    async () => {
+      expect(LARGE_COMPONENTS.length).toBeGreaterThanOrEqual(30)
+
+      renderLargeModel()
+      const canvas = await waitForCanvas()
+      await waitForCameraSettled()
+
+      const { zoom } = useUiStore.getState().camera
+
+      // The acceptance criterion, as a measurement: the name of a visible
+      // component is at least as large as the smallest type the product
+      // renders anywhere else.
+      expect(zoom).toBeGreaterThanOrEqual(MIN_READABLE_ZOOM)
+      expect(NODE_LABEL_FONT_SIZE_PX * zoom).toBeGreaterThanOrEqual(
+        MIN_LEGIBLE_FONT_SIZE_PX,
+      )
+      expect(LEAF_NODE_SIZE.width * zoom).toBeGreaterThanOrEqual(175)
+      expect(LEAF_NODE_SIZE.height * zoom).toBeGreaterThanOrEqual(73)
+
+      // Still exactly one automatic camera movement.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'shows the system and container level and keeps the rest one click away',
+    async () => {
+      const user = userEvent.setup()
+      renderLargeModel()
+      const canvas = await waitForCanvas()
+
+      // The reported model is still the whole model — collapsing hides
+      // components, it does not remove them.
+      expect(canvas.getAttribute('data-node-count')).toBe(String(LARGE_COMPONENTS.length))
+      expect(canvas.getAttribute('data-visible-node-count')).toBe('8')
+      expect(canvas.getAttribute('data-hidden-node-count')).toBe(
+        String(LARGE_COMPONENTS.length - 8),
+      )
+
+      // The top level is drawn…
+      expect(screen.getByTestId('canvas-node-mesh.s1')).toHaveAttribute(
+        'data-collapsed',
+        'true',
+      )
+      expect(screen.getByTestId('canvas-node-mesh.s1')).toHaveAttribute(
+        'data-hidden-count',
+        '6',
+      )
+      // …and what is inside it is not.
+      expect(screen.queryByTestId(`canvas-node-${LARGE_DEEP_COMPONENT_ID}`)).toBeNull()
+
+      // Opening one container reveals its children and nothing else.
+      await user.click(screen.getByTestId('node-disclosure-mesh.s1'))
+      await waitFor(
+        () => expect(canvas.getAttribute('data-layouting')).toBe('false'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+
+      expect(await screen.findByTestId('canvas-node-mesh.s1.a')).toBeInTheDocument()
+      expect(screen.queryByTestId('canvas-node-mesh.s2.a')).toBeNull()
+      // Opening a container is not a reason to move the camera.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'keeps a hidden relationship visible by lifting it onto the container',
+    async () => {
+      renderLargeModel()
+      await waitForCanvas()
+
+      // `mesh.s1.a.l1 → mesh.db` is reported between two components, one of
+      // which is inside a closed container. The edge is drawn on the container,
+      // and it still carries both of the relationships it stands for.
+      const bundle = await screen.findByTestId('edge-bundle-rel:mesh.s1~>mesh.db')
+      expect(bundle).toBeInTheDocument()
+      expect(bundle).toHaveTextContent('2')
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('architecture canvas — hiding a component never hides the work on it', () => {
+  it(
+    'shows the state of a hidden component on the container that holds it',
+    async () => {
+      const architecture = architectureFetch({
+        ...largeArchitectureResponse,
+        activeChanges: [
+          activeChange({
+            changeId: 'change-deep-0001',
+            targetKind: 'component',
+            targetId: LARGE_DEEP_COMPONENT_ID,
+            operation: 'remove',
+            snapshot: LARGE_COMPONENTS.find(
+              (one) => one.componentId === LARGE_DEEP_COMPONENT_ID,
+            ) as unknown as Record<string, unknown>,
+          }),
+        ],
+      })
+      renderApp(WORKSPACE_URL, { fetchImpl: architecture.fetchImpl })
+      await waitForCanvas()
+
+      // The component the change is about is behind two closed containers…
+      expect(screen.queryByTestId(`canvas-node-${LARGE_DEEP_COMPONENT_ID}`)).toBeNull()
+
+      // …and the phase of the work on it is on the container the user can see.
+      const container = await screen.findByTestId('canvas-node-mesh.s1')
+      expect(container).toHaveAttribute('data-work-state', 'planned')
+      expect(container).toHaveAttribute('data-overlay-rolled-up', 'true')
+
+      // The *operation* is not rolled up: `geplant · entfernen` on the container
+      // would claim the container is being removed.
+      expect(container).toHaveAttribute('data-operation', 'none')
+      expect(container).toHaveAttribute('data-work-state-label', 'geplant')
+      // It is the container's own presence, not the proposal's.
+      expect(container).toHaveAttribute('data-presence', 'applied')
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('architecture canvas — the whole model stays one action away', () => {
+  it(
+    'expands everything and fits it when the user asks for the overview',
+    async () => {
+      const user = userEvent.setup()
+      renderLargeModel()
+      const canvas = await waitForCanvas()
+      await waitForCameraSettled()
+
+      await user.click(screen.getByTestId('canvas-fit-view'))
+      await waitFor(
+        () =>
+          expect(canvas.getAttribute('data-hidden-node-count')).toBe('0'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitFor(
+        () => expect(canvas.getAttribute('data-layouting')).toBe('false'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitFor(
+        () => expect(canvas.getAttribute('data-fit-view-count')).toBe('2'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+
+      // Every component is now drawn…
+      expect(canvas.getAttribute('data-visible-node-count')).toBe(
+        String(LARGE_COMPONENTS.length),
+      )
+      expect(
+        screen.getByTestId(`canvas-node-${LARGE_DEEP_COMPONENT_ID}`),
+      ).toBeInTheDocument()
+      // …and the camera was allowed below the readable zoom for it, because
+      // this is the overview the user explicitly asked for.
+      await waitFor(() =>
+        expect(useUiStore.getState().camera.zoom).toBeLessThan(MIN_READABLE_ZOOM),
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'returns to the readable entry picture on request',
+    async () => {
+      const user = userEvent.setup()
+      renderLargeModel()
+      const canvas = await waitForCanvas()
+      await waitForCameraSettled()
+
+      await user.click(screen.getByTestId('canvas-fit-view'))
+      await waitFor(() => expect(canvas.getAttribute('data-hidden-node-count')).toBe('0'), {
+        timeout: CANVAS_TIMEOUT,
+      })
+
+      await user.click(screen.getByTestId('canvas-back-to-overview'))
+      await waitFor(
+        () => expect(canvas.getAttribute('data-visible-node-count')).toBe('8'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitFor(
+        () =>
+          expect(useUiStore.getState().camera.zoom).toBeGreaterThanOrEqual(
+            MIN_READABLE_ZOOM,
+          ),
+        { timeout: CANVAS_TIMEOUT },
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('architecture canvas — a deep link reaches a deep component', () => {
+  it(
+    'opens the containers on the way, selects it and shows it in the inspector',
+    async () => {
+      renderLargeModel(`${WORKSPACE_URL}?component=${LARGE_DEEP_COMPONENT_ID}`)
+      const canvas = await waitForCanvas()
+
+      const node = await screen.findByTestId(
+        `canvas-node-${LARGE_DEEP_COMPONENT_ID}`,
+        undefined,
+        { timeout: CANVAS_TIMEOUT },
+      )
+      expect(node).toHaveAttribute('data-selected', 'true')
+
+      // Exactly the path to it was opened — its siblings' containers were not.
+      for (const ancestor of LARGE_DEEP_ANCESTORS) {
+        expect(screen.getByTestId(`canvas-node-${ancestor}`)).not.toHaveAttribute(
+          'data-collapsed',
+        )
+      }
+      expect(screen.getByTestId('canvas-node-mesh.s2')).toHaveAttribute(
+        'data-collapsed',
+        'true',
+      )
+
+      // URL, selection and inspector agree.
+      expect(useUiStore.getState().selectedComponentId).toBe(LARGE_DEEP_COMPONENT_ID)
+      expect(await screen.findByTestId('inspector-context')).toBeInTheDocument()
+
+      // And it still cost exactly one camera movement.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'moves the selection up when the user closes the container holding it',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderLargeModel(
+        `${WORKSPACE_URL}?component=${LARGE_DEEP_COMPONENT_ID}`,
+      )
+      await waitForCanvas()
+      await screen.findByTestId(`canvas-node-${LARGE_DEEP_COMPONENT_ID}`, undefined, {
+        timeout: CANVAS_TIMEOUT,
+      })
+
+      await user.click(screen.getByTestId('node-disclosure-mesh.s1'))
+
+      // The URL never points at something that is not on screen.
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ component: 'mesh.s1' }),
+      )
+      await waitFor(() =>
+        expect(screen.getByTestId('canvas-node-mesh.s1')).toHaveAttribute(
+          'data-collapsed',
+          'true',
+        ),
+      )
+      expect(screen.queryByTestId(`canvas-node-${LARGE_DEEP_COMPONENT_ID}`)).toBeNull()
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('architecture canvas — the user keeps the camera', () => {
+  it(
+    'leaves an explicitly chosen camera alone when an event arrives',
+    async () => {
+      const user = userEvent.setup()
+      const { queryClient, publish } = renderLargeModel(
+        `${WORKSPACE_URL}?component=mesh.db`,
+      )
+      const canvas = await waitForCanvas()
+      await waitForCameraSettled()
+
+      // The user takes the camera over with the one action that is allowed to
+      // move it: the explicit overview.
+      await user.click(screen.getByTestId('canvas-fit-view'))
+      await waitFor(() => expect(canvas.getAttribute('data-hidden-node-count')).toBe('0'), {
+        timeout: CANVAS_TIMEOUT,
+      })
+      await waitFor(
+        () => expect(canvas.getAttribute('data-layouting')).toBe('false'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitForCameraSettled()
+
+      const cameraBefore = useUiStore.getState().camera
+      const transformBefore = viewportTransform()
+      const fitsBefore = canvas.getAttribute('data-fit-view-count')
+      expect(transformBefore).not.toBe('')
+
+      // A real structural live update through the SSE apply path.
+      publish(largeGrownArchitectureResponse)
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent('architecture.snapshot_published', {
+            snapshotId: 'snapshot-large-2',
+            components: largeGrownArchitectureResponse.components,
+            relationships: largeGrownArchitectureResponse.relationships,
+          }),
+        )
+      })
+
+      expect(
+        await screen.findByTestId('canvas-node-mesh.s1.a.l3', undefined, {
+          timeout: CANVAS_TIMEOUT,
+        }),
+      ).toBeInTheDocument()
+      await waitFor(
+        () => expect(canvas.getAttribute('data-layouting')).toBe('false'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+
+      // The model grew; zoom, pan, selection and the fit count did not move.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe(fitsBefore)
+      expect(viewportTransform()).toBe(transformBefore)
+      expect(useUiStore.getState().camera).toEqual(cameraBefore)
+      expect(useUiStore.getState().selectedComponentId).toBe('mesh.db')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'does not re-disclose the model when an event adds a component',
+    async () => {
+      const { queryClient, publish } = renderLargeModel()
+      const canvas = await waitForCanvas()
+      await waitForCameraSettled()
+
+      const cameraBefore = useUiStore.getState().camera
+      const collapsedBefore = useUiStore.getState().collapsedComponentIds
+
+      publish(largeGrownArchitectureResponse)
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent('architecture.snapshot_published', {
+            snapshotId: 'snapshot-large-3',
+            components: largeGrownArchitectureResponse.components,
+            relationships: largeGrownArchitectureResponse.relationships,
+          }),
+        )
+      })
+      await waitFor(
+        () =>
+          expect(canvas.getAttribute('data-node-count')).toBe(
+            String(largeGrownArchitectureResponse.components.length),
+          ),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitFor(
+        () => expect(canvas.getAttribute('data-layouting')).toBe('false'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+
+      // What the user has open is theirs, exactly like the camera is.
+      expect(useUiStore.getState().collapsedComponentIds).toEqual(collapsedBefore)
+      expect(useUiStore.getState().camera).toEqual(cameraBefore)
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+    },
+    CANVAS_TIMEOUT,
+  )
+})

--- a/frontend/src/canvas/ArchitectureZoom.test.tsx
+++ b/frontend/src/canvas/ArchitectureZoom.test.tsx
@@ -82,6 +82,41 @@ function viewportTransform(): string {
   )
 }
 
+/**
+ * Where a rendered node actually sits on the drawing surface, in CSS px.
+ *
+ * jsdom has no layout engine, so `getBoundingClientRect` answers zero for
+ * everything. The two inputs that decide the answer are both observable
+ * without one: React Flow writes each node's **absolute** flow position into
+ * its `transform`, and the canvas reports the surface it computed the camera
+ * against. Applying the camera to the first gives the same number a browser
+ * would measure.
+ */
+function nodeRectOnSurface(canvas: HTMLElement, componentId: string) {
+  const node = document.querySelector<HTMLElement>(
+    `.react-flow__node[data-id="${componentId}"]`,
+  )
+  if (!node) throw new Error(`node ${componentId} is not rendered`)
+
+  const translate = /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)/.exec(node.style.transform)
+  if (!translate) throw new Error(`node ${componentId} has no position: ${node.style.transform}`)
+
+  const { x, y, zoom } = useUiStore.getState().camera
+  const left = Number(translate[1]) * zoom + x
+  const top = Number(translate[2]) * zoom + y
+
+  return {
+    left,
+    top,
+    right: left + LEAF_NODE_SIZE.width * zoom,
+    bottom: top + LEAF_NODE_SIZE.height * zoom,
+    surface: {
+      width: Number(canvas.getAttribute('data-surface-width')),
+      height: Number(canvas.getAttribute('data-surface-height')),
+    },
+  }
+}
+
 /** Resolves once the one automatic fit has run its course. */
 async function waitForCameraSettled(): Promise<void> {
   await waitFor(() => expect(useUiStore.getState().camera.zoom).toBeGreaterThan(0), {
@@ -327,6 +362,67 @@ describe('architecture canvas — a deep link reaches a deep component', () => {
 
       // And it still cost exactly one camera movement.
       expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'puts it inside the drawing surface, without a second camera movement',
+    async () => {
+      renderLargeModel(`${WORKSPACE_URL}?component=${LARGE_DEEP_COMPONENT_ID}`)
+      const canvas = await waitForCanvas()
+      await screen.findByTestId(`canvas-node-${LARGE_DEEP_COMPONENT_ID}`, undefined, {
+        timeout: CANVAS_TIMEOUT,
+      })
+      await waitForCameraSettled()
+
+      // Being drawn is not the same as being on screen. Before the initial
+      // camera learned about the deep link, the linked node sat several hundred
+      // pixels past the right edge: the inspector described a component the
+      // architecture surface did not show anywhere.
+      const rect = nodeRectOnSurface(canvas, LARGE_DEEP_COMPONENT_ID)
+      expect(rect.surface.width).toBeGreaterThan(0)
+      expect(rect.left).toBeGreaterThanOrEqual(0)
+      expect(rect.top).toBeGreaterThanOrEqual(0)
+      expect(rect.right).toBeLessThanOrEqual(rect.surface.width)
+      expect(rect.bottom).toBeLessThanOrEqual(rect.surface.height)
+
+      // Reached by panning, not by zooming out: the readable floor holds.
+      expect(useUiStore.getState().camera.zoom).toBeGreaterThanOrEqual(MIN_READABLE_ZOOM)
+      // And it is still the one automatic movement, not two.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'does not move the camera when the user selects another component by clicking',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderLargeModel(
+        `${WORKSPACE_URL}?component=${LARGE_DEEP_COMPONENT_ID}`,
+      )
+      const canvas = await waitForCanvas()
+      await screen.findByTestId(`canvas-node-${LARGE_DEEP_COMPONENT_ID}`, undefined, {
+        timeout: CANVAS_TIMEOUT,
+      })
+      await waitForCameraSettled()
+
+      const cameraBefore = useUiStore.getState().camera
+      const transformBefore = viewportTransform()
+      expect(transformBefore).not.toBe('')
+
+      // The deep link is an input to the *first* picture only. From then on the
+      // camera is the user's, and choosing another component is not a request
+      // to move it — even when that component is off screen.
+      await user.click(screen.getByTestId('canvas-node-mesh.s4'))
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ component: 'mesh.s4' }),
+      )
+
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+      expect(viewportTransform()).toBe(transformBefore)
+      expect(useUiStore.getState().camera).toEqual(cameraBefore)
     },
     CANVAS_TIMEOUT,
   )

--- a/frontend/src/canvas/ChangeOverlays.test.tsx
+++ b/frontend/src/canvas/ChangeOverlays.test.tsx
@@ -65,9 +65,17 @@ function architectureFetch(initial: ArchitectureResponse) {
   }
 }
 
+/**
+ * Every container open: the proposals and ghosts these tests assert on sit two
+ * levels down, and the progressive disclosure of #34 is not what is under test
+ * here. See `renderApp`'s `expandAllComponents`.
+ */
 function renderCanvas(url = WORKSPACE_URL, initial = nestedArchitectureResponse) {
   const architecture = architectureFetch(initial)
-  const app = renderApp(url, { fetchImpl: architecture.fetchImpl })
+  const app = renderApp(url, {
+    fetchImpl: architecture.fetchImpl,
+    expandAllComponents: true,
+  })
   return { ...app, ...architecture }
 }
 

--- a/frontend/src/canvas/ComponentNode.tsx
+++ b/frontend/src/canvas/ComponentNode.tsx
@@ -1,6 +1,8 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react'
-import { memo } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { memo, use } from 'react'
 
+import type { ComponentId } from '@/api/types'
 import { cn } from '@/lib/utils'
 import { COUNT_LABELS, counted } from '@/lib/plural'
 import { WORK_STATE_BY_ID } from '@/state/workStates'
@@ -8,8 +10,9 @@ import { WORK_STATE_BY_ID } from '@/state/workStates'
 import { ChangeOverlayMark } from './ChangeOverlayMark'
 import type { ChangeOverlay } from './changeOverlays'
 import { componentKindStyle, componentTags, technologyParts } from './componentKinds'
-import { showsTags, showsTechnology } from './detailLevel'
+import { DISCLOSURE_LABELS, showsTags, showsTechnology } from './detailLevel'
 import { HANDLE_IDS, type ArchitectureNode } from './graphProjection'
+import { CanvasNodeActionsContext } from './nodeActions'
 import { useDetailLevel } from './useDetailLevel'
 
 /**
@@ -54,6 +57,46 @@ function overlayBoxProps(overlay: ChangeOverlay | null, applied: boolean) {
       'data-agent-count': String(overlay.agentIds.length),
     } as Record<string, string>,
   }
+}
+
+interface DisclosureToggleProps {
+  componentId: ComponentId
+  collapsed: boolean
+  /** Components hidden behind this container right now. */
+  hiddenCount: number
+}
+
+/**
+ * Expands or collapses one container.
+ *
+ * `nodrag`/`nopan` stop React Flow from turning the press into a node drag or a
+ * canvas pan, and `stopPropagation` keeps it from also selecting the node —
+ * opening a container and choosing one are two different intents.
+ */
+function DisclosureToggle({ componentId, collapsed, hiddenCount }: DisclosureToggleProps) {
+  const { toggleCollapsed } = use(CanvasNodeActionsContext)
+  const Icon = collapsed ? ChevronRight : ChevronDown
+  const label = collapsed
+    ? `${DISCLOSURE_LABELS.expand} (${counted(hiddenCount, COUNT_LABELS.component)})`
+    : DISCLOSURE_LABELS.collapse
+
+  return (
+    <button
+      type="button"
+      className="nodrag nopan text-muted-foreground hover:text-foreground hover:bg-secondary/70 focus-visible:ring-ring -m-0.5 flex shrink-0 items-center gap-0.5 rounded-sm p-0.5 focus-visible:ring-2 focus-visible:outline-none"
+      title={label}
+      aria-label={label}
+      aria-expanded={!collapsed}
+      data-testid={`node-disclosure-${componentId}`}
+      onPointerDown={(event) => event.stopPropagation()}
+      onClick={(event) => {
+        event.stopPropagation()
+        toggleCollapsed(componentId, !collapsed)
+      }}
+    >
+      <Icon className="size-3.5" aria-hidden="true" />
+    </button>
+  )
 }
 
 /** Invisible, non-interactive connection points. v0 is read-only. */
@@ -182,17 +225,24 @@ export const CompoundNode = memo(function CompoundNode({
   selected,
 }: NodeProps<ArchitectureNode>) {
   const level = useDetailLevel()
-  const { component, childCount, overlay, applied } = data
+  const { component, childCount, overlay, applied, collapsed, hiddenDescendantCount } =
+    data
   const kind = componentKindStyle(component.kind)
   const Icon = kind.icon
   const technology = technologyParts(component.technology)
   const box = overlayBoxProps(overlay, applied)
+  const hiddenCount = hiddenDescendantCount ?? 0
 
   return (
     <div
       className={cn(
         'border-border/90 bg-card/35 h-full w-full rounded-lg border',
         'transition-[border-color,opacity] duration-150',
+        // Closed, the container carries what is behind it as a stacked edge —
+        // "there is more inside" without a second box and without a size that
+        // depends on the contents.
+        collapsed &&
+          'bg-card/95 shadow-[4px_4px_0_-1px_var(--card),4px_4px_0_var(--border)]',
         box.className,
         selected && 'ring-ring border-ring/70 ring-2',
       )}
@@ -202,11 +252,28 @@ export const CompoundNode = memo(function CompoundNode({
       data-detail-level={level}
       data-compound="true"
       data-selected={selected ? 'true' : 'false'}
+      {...(collapsed
+        ? {
+            'data-collapsed': 'true',
+            'data-hidden-count': String(hiddenCount),
+            ...(data.overlayRolledUp ? { 'data-overlay-rolled-up': 'true' } : {}),
+          }
+        : {})}
       {...box.attributes}
     >
       {/* Header row. The ELK padding reserves exactly this height at the top of
           the container, so it never overlaps a child. */}
-      <div className="border-border/70 flex h-10 items-center gap-1.5 border-b px-2.5">
+      <div
+        className={cn(
+          'border-border/70 flex h-10 items-center gap-1.5 px-2.5',
+          !collapsed && 'border-b',
+        )}
+      >
+        <DisclosureToggle
+          componentId={component.componentId}
+          collapsed={collapsed === true}
+          hiddenCount={collapsed ? hiddenCount : childCount}
+        />
         <Icon className="text-muted-foreground size-3.5 shrink-0" aria-hidden="true" />
         <span
           className="text-foreground min-w-0 flex-1 truncate text-[13px] leading-tight font-medium"
@@ -215,7 +282,11 @@ export const CompoundNode = memo(function CompoundNode({
         >
           {component.name}
         </span>
-        {showsTechnology(level) && technology.length > 0 && (
+        {/* A closed container is only as wide as a leaf, so the metadata moves
+            out of the header — squeezed between a technology string and two
+            badges, the name is the first thing to lose its space, and the name
+            is the one thing that has to stay readable. */}
+        {!collapsed && showsTechnology(level) && technology.length > 0 && (
           <span
             className="text-muted-foreground max-w-40 truncate font-mono text-[10px]"
             data-testid="node-technology"
@@ -224,11 +295,25 @@ export const CompoundNode = memo(function CompoundNode({
           </span>
         )}
         {overlay && <ChangeOverlayMark overlay={overlay} />}
-        <span className="text-muted-foreground shrink-0 text-[10px]">
-          {counted(childCount, COUNT_LABELS.child)}
-        </span>
+        {!collapsed && (
+          <span className="text-muted-foreground shrink-0 text-[10px]">
+            {counted(childCount, COUNT_LABELS.child)}
+          </span>
+        )}
         <KindBadge label={kind.label} />
       </div>
+
+      {collapsed && (
+        <div className="flex flex-col gap-1 px-2.5 pt-1.5">
+          <p
+            className="text-muted-foreground text-[10px] leading-tight"
+            data-testid="node-hidden-count"
+          >
+            {counted(hiddenCount, COUNT_LABELS.component)} eingeklappt
+          </p>
+          {showsTechnology(level) && <TechnologyRow parts={technology} />}
+        </div>
+      )}
 
       <NodeHandles />
     </div>

--- a/frontend/src/canvas/cameraPolicy.test.ts
+++ b/frontend/src/canvas/cameraPolicy.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  FIT_VIEW_PADDING,
   INITIAL_CAMERA_POLICY,
   MIN_FIT_VIEWPORT,
   onLayoutReady,
   onProjectChanged,
   onUserFitRequest,
+  viewportForBounds,
   type CameraPolicyInput,
 } from './cameraPolicy'
+import { MIN_LEGIBLE_FONT_SIZE_PX, MIN_READABLE_ZOOM } from './detailLevel'
+import { LEAF_NODE_SIZE } from './graphProjection'
 
 /** A settled 1920 × 1080 workspace: the centre pane is ~1036 × 933. */
 const SURFACE = { width: 1036, height: 933 }
@@ -119,5 +123,80 @@ describe('camera policy', () => {
     expect(onLayoutReady(switched, input({ projectId: 'project-b' })).fit).toBe(
       'initial-model',
     )
+  })
+})
+
+describe('where the camera goes', () => {
+  /** The layout of `visualise-ai-self`, all 28 components expanded. */
+  const WHOLE_MODEL = { x: 0, y: 0, width: 4684, height: 1263 }
+  /** The same model on its system and container level, everything else closed. */
+  const TOP_LEVELS = { x: 0, y: 0, width: 1944, height: 518 }
+
+  it('centres a model that fits, exactly like a plain fit does', () => {
+    const bounds = { x: 0, y: 0, width: 600, height: 400 }
+    const viewport = viewportForBounds(bounds, SURFACE, { minZoom: 0.12 })
+
+    // Small model, so the fit is capped at 1 rather than blown up.
+    expect(viewport.zoom).toBe(1)
+    expect(viewport.x).toBeCloseTo(SURFACE.width / 2 - 300, 5)
+    expect(viewport.y).toBeCloseTo(SURFACE.height / 2 - 200, 5)
+  })
+
+  it('never opens a large model below the readable zoom', () => {
+    const automatic = viewportForBounds(TOP_LEVELS, SURFACE, {
+      minZoom: MIN_READABLE_ZOOM,
+      overflow: 'start',
+    })
+
+    // Fitting all of it would need 0.48; the floor wins.
+    expect(automatic.zoom).toBe(MIN_READABLE_ZOOM)
+    expect(LEAF_NODE_SIZE.width * automatic.zoom).toBeGreaterThan(170)
+    expect(13 * automatic.zoom).toBeGreaterThanOrEqual(MIN_LEGIBLE_FONT_SIZE_PX)
+  })
+
+  it('holds the floor however many components there are', () => {
+    for (const width of [2_000, 20_000, 200_000]) {
+      const viewport = viewportForBounds({ x: 0, y: 0, width, height: width / 4 }, SURFACE, {
+        minZoom: MIN_READABLE_ZOOM,
+        overflow: 'start',
+      })
+      expect(viewport.zoom).toBe(MIN_READABLE_ZOOM)
+    }
+  })
+
+  it('anchors an oversized model at its top-left corner rather than its middle', () => {
+    const anchored = viewportForBounds(TOP_LEVELS, SURFACE, {
+      minZoom: MIN_READABLE_ZOOM,
+      overflow: 'start',
+    })
+    const centred = viewportForBounds(TOP_LEVELS, SURFACE, {
+      minZoom: MIN_READABLE_ZOOM,
+    })
+
+    // The layout runs left to right with the callers first, so its beginning is
+    // where the picture is read from. Centring would start in mid-sentence.
+    const gap = (SURFACE.width * FIT_VIEW_PADDING) / (2 * (1 + FIT_VIEW_PADDING))
+    expect(anchored.x).toBeCloseTo(gap, 5)
+    expect(centred.x).toBeLessThan(0)
+
+    // The height fits at this zoom, so that axis is centred either way.
+    expect(anchored.y).toBeCloseTo(centred.y, 5)
+  })
+
+  it('lets an explicit request zoom out as far as the whole model needs', () => {
+    const overview = viewportForBounds(WHOLE_MODEL, SURFACE, { minZoom: 0.12 })
+
+    // This is the number the issue complains about — and it is fine here,
+    // because the user asked to see everything at once.
+    expect(overview.zoom).toBeCloseTo(0.2, 2)
+    expect(overview.zoom).toBeLessThan(MIN_READABLE_ZOOM)
+  })
+
+  it('never returns a zoom outside the canvas limits', () => {
+    const clamped = viewportForBounds({ x: 0, y: 0, width: 10, height: 10 }, SURFACE, {
+      minZoom: MIN_READABLE_ZOOM,
+      maxZoom: 1,
+    })
+    expect(clamped.zoom).toBe(1)
   })
 })

--- a/frontend/src/canvas/cameraPolicy.test.ts
+++ b/frontend/src/canvas/cameraPolicy.test.ts
@@ -192,6 +192,64 @@ describe('where the camera goes', () => {
     expect(overview.zoom).toBeLessThan(MIN_READABLE_ZOOM)
   })
 
+  it('pans a focus that would fall off the edge back onto the surface', () => {
+    // A node four levels down, far to the right of a model that does not fit at
+    // the readable zoom. Without the focus it sat past the right edge: drawn,
+    // selected, described by the inspector — and nowhere on screen.
+    const node = { x: 1700, y: 300, width: 228, height: 96 }
+
+    const blind = viewportForBounds(TOP_LEVELS, SURFACE, {
+      minZoom: MIN_READABLE_ZOOM,
+      overflow: 'start',
+    })
+    expect(node.x * blind.zoom + blind.x + node.width * blind.zoom).toBeGreaterThan(
+      SURFACE.width,
+    )
+
+    const focused = viewportForBounds(TOP_LEVELS, SURFACE, {
+      minZoom: MIN_READABLE_ZOOM,
+      overflow: 'start',
+      focus: node,
+    })
+
+    const left = node.x * focused.zoom + focused.x
+    const top = node.y * focused.zoom + focused.y
+    expect(left).toBeGreaterThanOrEqual(0)
+    expect(top).toBeGreaterThanOrEqual(0)
+    expect(left + node.width * focused.zoom).toBeLessThanOrEqual(SURFACE.width)
+    expect(top + node.height * focused.zoom).toBeLessThanOrEqual(SURFACE.height)
+
+    // Panned, never zoomed: the readability floor is not the price of a link.
+    expect(focused.zoom).toBe(blind.zoom)
+  })
+
+  it('leaves the camera alone for a focus that is already on screen', () => {
+    const options = {
+      minZoom: MIN_READABLE_ZOOM,
+      overflow: 'start' as const,
+    }
+    const without = viewportForBounds(TOP_LEVELS, SURFACE, options)
+    const withFocus = viewportForBounds(TOP_LEVELS, SURFACE, {
+      ...options,
+      focus: { x: 40, y: 40, width: 228, height: 96 },
+    })
+    expect(withFocus).toEqual(without)
+  })
+
+  it('shows where an oversized focus begins rather than where it ends', () => {
+    // A container wider than the surface cannot be contained; its top-left is
+    // the part worth showing, for the same reason `overflow: start` exists.
+    const huge = { x: 900, y: 0, width: 4000, height: 200 }
+    const viewport = viewportForBounds(TOP_LEVELS, SURFACE, {
+      minZoom: MIN_READABLE_ZOOM,
+      overflow: 'start',
+      focus: huge,
+    })
+    const left = huge.x * viewport.zoom + viewport.x
+    expect(left).toBeGreaterThan(0)
+    expect(left).toBeLessThan(SURFACE.width / 2)
+  })
+
   it('never returns a zoom outside the canvas limits', () => {
     const clamped = viewportForBounds({ x: 0, y: 0, width: 10, height: 10 }, SURFACE, {
       minZoom: MIN_READABLE_ZOOM,

--- a/frontend/src/canvas/cameraPolicy.ts
+++ b/frontend/src/canvas/cameraPolicy.ts
@@ -121,3 +121,101 @@ export function onProjectChanged(
 ): CameraPolicyState {
   return state.fittedProjectId === projectId ? state : INITIAL_CAMERA_POLICY
 }
+
+// ---------------------------------------------------------------------------
+// Where the camera goes when it is allowed to move
+// ---------------------------------------------------------------------------
+
+/** Bounding box of the laid-out graph, in flow coordinates. */
+export interface LayoutBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface CameraViewport {
+  x: number
+  y: number
+  zoom: number
+}
+
+/** Share of the surface kept free around the model. */
+export const FIT_VIEW_PADDING = 0.1
+/** Never zoom *in* to fit: a two-component model must not fill the screen. */
+export const FIT_VIEW_MAX_ZOOM = 1
+
+export interface ViewportOptions {
+  /**
+   * Smallest zoom the result may use. The automatic first camera passes the
+   * readable zoom here, an explicit "fit the whole model" passes the canvas
+   * minimum — that difference *is* the readability rule.
+   */
+  minZoom: number
+  maxZoom?: number
+  padding?: number
+  /**
+   * How to place a model that does not fit at `minZoom`. `center` keeps the
+   * middle of the model on screen, `start` puts its top-left corner there.
+   *
+   * The initial camera uses `start`: the layout runs left to right with the
+   * callers first (ADR 0008), so its top-left corner is where an architecture
+   * is read from. Landing in the geometric middle of a model that does not fit
+   * drops the reader somewhere in the middle of a sentence.
+   */
+  overflow?: 'center' | 'start'
+}
+
+/**
+ * The viewport that shows `bounds` on a surface of `surface`.
+ *
+ * Deliberately computed here rather than taken from React Flow's
+ * `getViewportForBounds`: the camera has to be a pure function of the ELK
+ * layout (ADR 0008), and the two rules this canvas adds — a floor under the
+ * zoom and an anchored overflow — are exactly the two things that function does
+ * not do. With `minZoom` at the canvas minimum and `overflow: 'center'` it
+ * reproduces React Flow's result.
+ */
+export function viewportForBounds(
+  bounds: LayoutBounds,
+  surface: ViewportSize,
+  options: ViewportOptions,
+): CameraViewport {
+  const padding = options.padding ?? FIT_VIEW_PADDING
+  const maxZoom = options.maxZoom ?? FIT_VIEW_MAX_ZOOM
+  const overflow = options.overflow ?? 'center'
+
+  const fitZoom = Math.min(
+    surface.width / (bounds.width * (1 + padding)),
+    surface.height / (bounds.height * (1 + padding)),
+  )
+  const zoom = clamp(fitZoom, Math.min(options.minZoom, maxZoom), maxZoom)
+
+  return {
+    x: axisOffset(surface.width, bounds.x, bounds.width, zoom, padding, overflow),
+    y: axisOffset(surface.height, bounds.y, bounds.height, zoom, padding, overflow),
+    zoom,
+  }
+}
+
+function axisOffset(
+  surfaceSize: number,
+  boundsStart: number,
+  boundsSize: number,
+  zoom: number,
+  padding: number,
+  overflow: 'center' | 'start',
+): number {
+  const scaled = boundsSize * zoom
+  // The same gap `padding` would leave on each side of a model that fits, so an
+  // anchored model is inset exactly as far as a centred one.
+  const gap = (surfaceSize * padding) / (2 * (1 + padding))
+  if (overflow === 'start' && scaled + 2 * gap > surfaceSize) {
+    return gap - boundsStart * zoom
+  }
+  return surfaceSize / 2 - (boundsStart + boundsSize / 2) * zoom
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}

--- a/frontend/src/canvas/cameraPolicy.ts
+++ b/frontend/src/canvas/cameraPolicy.ts
@@ -164,6 +164,20 @@ export interface ViewportOptions {
    * drops the reader somewhere in the middle of a sentence.
    */
   overflow?: 'center' | 'start'
+  /**
+   * A rectangle the result must contain — the node a deep link points at.
+   *
+   * It is brought in by **panning only**; the zoom is already decided when this
+   * is applied. Zooming out to reach it would trade the readability the floor
+   * exists for against the very thing the link was followed for, and the two
+   * are not in competition: a leaf node is 176 × 74 px at the readable zoom and
+   * fits any supported surface many times over.
+   *
+   * A focus larger than the surface (a wide container) is aligned at its
+   * top-left corner rather than being centred, for the same reason `overflow`
+   * anchors there: that is where the box is read from.
+   */
+  focus?: LayoutBounds | null
 }
 
 /**
@@ -171,10 +185,10 @@ export interface ViewportOptions {
  *
  * Deliberately computed here rather than taken from React Flow's
  * `getViewportForBounds`: the camera has to be a pure function of the ELK
- * layout (ADR 0008), and the two rules this canvas adds — a floor under the
- * zoom and an anchored overflow — are exactly the two things that function does
- * not do. With `minZoom` at the canvas minimum and `overflow: 'center'` it
- * reproduces React Flow's result.
+ * layout (ADR 0008), and the three rules this canvas adds — a floor under the
+ * zoom, an anchored overflow and a focus that must stay on screen — are exactly
+ * what that function does not do. With `minZoom` at the canvas minimum,
+ * `overflow: 'center'` and no `focus` it reproduces React Flow's result.
  */
 export function viewportForBounds(
   bounds: LayoutBounds,
@@ -184,6 +198,7 @@ export function viewportForBounds(
   const padding = options.padding ?? FIT_VIEW_PADDING
   const maxZoom = options.maxZoom ?? FIT_VIEW_MAX_ZOOM
   const overflow = options.overflow ?? 'center'
+  const focus = options.focus ?? null
 
   const fitZoom = Math.min(
     surface.width / (bounds.width * (1 + padding)),
@@ -191,10 +206,17 @@ export function viewportForBounds(
   )
   const zoom = clamp(fitZoom, Math.min(options.minZoom, maxZoom), maxZoom)
 
-  return {
+  const viewport = {
     x: axisOffset(surface.width, bounds.x, bounds.width, zoom, padding, overflow),
     y: axisOffset(surface.height, bounds.y, bounds.height, zoom, padding, overflow),
     zoom,
+  }
+  if (focus === null) return viewport
+
+  return {
+    zoom,
+    x: panIntoView(viewport.x, focus.x, focus.width, surface.width, zoom, padding),
+    y: panIntoView(viewport.y, focus.y, focus.height, surface.height, zoom, padding),
   }
 }
 
@@ -214,6 +236,38 @@ function axisOffset(
     return gap - boundsStart * zoom
   }
   return surfaceSize / 2 - (boundsStart + boundsSize / 2) * zoom
+}
+
+/**
+ * Shifts one axis by the least amount that brings `focus` inside the surface.
+ *
+ * "The least amount" matters: a deep link should show the linked component
+ * *and* as much of its surroundings as it can, so the camera moves exactly far
+ * enough and no further. A focus that is already fully visible returns the
+ * offset unchanged, which is what keeps this a no-op for the common case.
+ */
+function panIntoView(
+  offset: number,
+  focusStart: number,
+  focusSize: number,
+  surfaceSize: number,
+  zoom: number,
+  padding: number,
+): number {
+  const gap = (surfaceSize * padding) / (2 * (1 + padding))
+  const alignStart = gap - focusStart * zoom
+  const start = focusStart * zoom + offset
+  const end = start + focusSize * zoom
+
+  // Too far past the far edge: pull it back, but never so far that its own
+  // beginning leaves the surface — for a focus wider than the surface, seeing
+  // where it starts beats seeing where it ends.
+  if (end > surfaceSize - gap) {
+    const pulled = offset - (end - (surfaceSize - gap))
+    return focusStart * zoom + pulled < gap ? alignStart : pulled
+  }
+  if (start < gap) return alignStart
+  return offset
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/frontend/src/canvas/collapse.test.ts
+++ b/frontend/src/canvas/collapse.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  LARGE_COMPONENTS,
+  LARGE_DEEP_ANCESTORS,
+  LARGE_DEEP_COMPONENT_ID,
+  LARGE_RELATIONSHIPS,
+  NESTED_COMPONENTS,
+  NESTED_RELATIONSHIPS,
+  reorder,
+} from '@/test/architectureFixtures'
+
+import {
+  ancestorIds,
+  collapseGraph,
+  containerIds,
+  initialCollapsedIds,
+} from './collapse'
+import { INITIAL_EXPANDED_DEPTH } from './detailLevel'
+import {
+  LEAF_NODE_SIZE,
+  projectArchitecture,
+  projectionSignature,
+  resolveEdgeBundle,
+} from './graphProjection'
+
+const nested = projectArchitecture({
+  components: NESTED_COMPONENTS,
+  relationships: NESTED_RELATIONSHIPS,
+})
+
+const large = projectArchitecture({
+  components: LARGE_COMPONENTS,
+  relationships: LARGE_RELATIONSHIPS,
+})
+
+describe('initial disclosure', () => {
+  it('opens the top levels and closes every container below them', () => {
+    const collapsed = new Set(initialCollapsedIds(large.nodes))
+
+    for (const node of large.nodes) {
+      if (!node.data.isCompound) continue
+      expect(collapsed.has(node.id)).toBe(node.data.depth >= INITIAL_EXPANDED_DEPTH)
+    }
+
+    // The rule is about the hierarchy, not about the number of components:
+    // `mesh` is the only container that stays open, whatever is inside it.
+    expect(initialCollapsedIds(large.nodes)).not.toContain('mesh')
+  })
+
+  it('leaves a flat model alone — there is nothing to disclose progressively', () => {
+    const flat = projectArchitecture({
+      components: NESTED_COMPONENTS.filter((one) => one.parentComponentId === null),
+      relationships: [],
+    })
+    expect(initialCollapsedIds(flat.nodes)).toEqual([])
+    expect(containerIds(flat.nodes)).toEqual([])
+  })
+
+  it('is deterministic, whatever order the read API sent its rows in', () => {
+    const shuffled = projectArchitecture({
+      components: reorder(LARGE_COMPONENTS),
+      relationships: reorder(LARGE_RELATIONSHIPS),
+    })
+    expect(initialCollapsedIds(shuffled.nodes)).toEqual(initialCollapsedIds(large.nodes))
+  })
+})
+
+describe('ancestors of a component', () => {
+  it('names the containers a deep link has to open, root first', () => {
+    expect(ancestorIds(large.nodes, LARGE_DEEP_COMPONENT_ID)).toEqual([
+      ...LARGE_DEEP_ANCESTORS,
+    ])
+  })
+
+  it('is empty for a root and for a component that is not in the snapshot', () => {
+    expect(ancestorIds(large.nodes, 'mesh')).toEqual([])
+    expect(ancestorIds(large.nodes, 'nothing-like-this')).toEqual([])
+  })
+})
+
+describe('collapsing the graph', () => {
+  it('is the identity when nothing is collapsed', () => {
+    const visible = collapseGraph(large.nodes, large.edges, [])
+    expect(visible.nodes).toBe(large.nodes)
+    expect(visible.edges).toBe(large.edges)
+    expect(visible.hiddenComponentIds.size).toBe(0)
+  })
+
+  it('hides exactly the descendants of the collapsed containers', () => {
+    const collapsed = initialCollapsedIds(large.nodes)
+    const visible = collapseGraph(large.nodes, large.edges, collapsed)
+
+    expect(large.nodes).toHaveLength(32)
+    // One system, four services, two stores, one external client.
+    expect(visible.nodes.map((node) => node.id)).toEqual([
+      'edge.client',
+      'mesh',
+      'mesh.db',
+      'mesh.queue',
+      'mesh.s1',
+      'mesh.s2',
+      'mesh.s3',
+      'mesh.s4',
+    ])
+    expect(visible.hiddenComponentIds.size).toBe(32 - 8)
+    expect(visible.hiddenComponentIds.has(LARGE_DEEP_COMPONENT_ID)).toBe(true)
+  })
+
+  it('draws a collapsed container as a leaf-sized box that says how much it holds', () => {
+    const visible = collapseGraph(large.nodes, large.edges, ['mesh.s1'])
+    const service = visible.nodes.find((node) => node.id === 'mesh.s1')
+    const expanded = large.nodes.find((node) => node.id === 'mesh.s1')
+
+    // The type does not change: React Flow remounts a node whose type changed,
+    // and a remounted node is measured from the DOM instead of from the layout.
+    expect(service?.type).toBe(expanded?.type)
+    expect(service?.width).toBe(LEAF_NODE_SIZE.width)
+    expect(service?.height).toBe(LEAF_NODE_SIZE.height)
+    expect(service?.data.collapsed).toBe(true)
+    // Two modules with two leaves each.
+    expect(service?.data.hiddenDescendantCount).toBe(6)
+    // It is still known to be a container, so it can be opened again.
+    expect(service?.data.isCompound).toBe(true)
+  })
+
+  it('lifts a relationship onto the nearest visible ancestor instead of dropping it', () => {
+    const visible = collapseGraph(large.nodes, large.edges, initialCollapsedIds(large.nodes))
+
+    // Eight leaves write to the store; with every service closed that is one
+    // drawn edge per service, and each of them still carries its two reported
+    // relationships individually.
+    const toStore = visible.edges.filter((edge) => edge.target === 'mesh.db')
+    expect(toStore.map((edge) => edge.source)).toEqual([
+      'mesh.s1',
+      'mesh.s2',
+      'mesh.s3',
+      'mesh.s4',
+    ])
+
+    const first = toStore[0]
+    expect(first?.data?.bundled).toBe(true)
+    expect(resolveEdgeBundle(first!).map((one) => one.relationship.relationshipId)).toEqual([
+      'lr-1a1',
+      'lr-1b1',
+    ])
+  })
+
+  it('does not draw a relationship whose two ends collapsed into the same box', () => {
+    const inner = projectArchitecture({
+      components: NESTED_COMPONENTS,
+      relationships: NESTED_RELATIONSHIPS,
+    })
+    // `platform.core.orders → platform.core.billing` would become a self loop
+    // on `platform.core`; a loop on a container states nothing.
+    const withInternal = collapseGraph(
+      inner.nodes,
+      [
+        ...inner.edges,
+        {
+          ...inner.edges[0]!,
+          id: 'rel:platform.core.orders~>platform.core.billing',
+          source: 'platform.core.orders',
+          target: 'platform.core.billing',
+          data: {
+            ...inner.edges[0]!.data!,
+            sourceComponentId: 'platform.core.orders',
+            targetComponentId: 'platform.core.billing',
+          },
+        },
+      ],
+      ['platform.core'],
+    )
+
+    expect(
+      withInternal.edges.some(
+        (edge) => edge.source === 'platform.core' && edge.target === 'platform.core',
+      ),
+    ).toBe(false)
+  })
+
+  it('keeps the canonical order, so the ELK layout stays deterministic', () => {
+    const collapsed = initialCollapsedIds(large.nodes)
+    const once = collapseGraph(large.nodes, large.edges, collapsed)
+
+    const shuffled = projectArchitecture({
+      components: reorder(LARGE_COMPONENTS),
+      relationships: reorder(LARGE_RELATIONSHIPS),
+    })
+    const twice = collapseGraph(
+      shuffled.nodes,
+      shuffled.edges,
+      [...collapsed].reverse(),
+    )
+
+    expect(projectionSignature(twice)).toBe(projectionSignature(once))
+    expect(twice.nodes.map((node) => node.id)).toEqual(once.nodes.map((node) => node.id))
+    expect(twice.edges.map((edge) => edge.id)).toEqual(once.edges.map((edge) => edge.id))
+  })
+
+  it('ignores a collapsed id that is not a container of this snapshot', () => {
+    const visible = collapseGraph(nested.nodes, nested.edges, [
+      'platform.db',
+      'gone.missing',
+    ])
+    expect(visible.nodes).toBe(nested.nodes)
+    expect(visible.collapsedComponentIds.size).toBe(0)
+  })
+})

--- a/frontend/src/canvas/collapse.ts
+++ b/frontend/src/canvas/collapse.ts
@@ -1,0 +1,359 @@
+import type { ComponentId, Identifier } from '@/api/types'
+
+import { dominantOverlay, type ChangeOverlay } from './changeOverlays'
+import { INITIAL_EXPANDED_DEPTH } from './detailLevel'
+import {
+  HANDLE_IDS,
+  LEAF_NODE_SIZE,
+  RELATIONSHIP_EDGE_TYPE,
+  bundleEdgeId,
+  nodeHandles,
+  overlayEdgeId,
+  type ArchitectureEdge,
+  type ArchitectureNode,
+} from './graphProjection'
+
+/**
+ * Expand and collapse: which part of the reported hierarchy is drawn.
+ *
+ * The architecture canvas fits its model into the viewport once, when a project
+ * is opened. With a flat picture of every component that fit is the whole
+ * problem this module exists for: 28 components over four levels lay out to
+ * ~4700 × 1260, which fits a 1036 px wide surface at zoom 0.20 — a node is then
+ * 46 × 20 px and its name renders at 2.6 px. The surface the product is *about*
+ * is unreadable at the moment it opens.
+ *
+ * The answer is not a different camera, it is less picture: a project opens on
+ * the top `INITIAL_EXPANDED_DEPTH + 1` levels and everything deeper waits
+ * behind its container.
+ *
+ * This module is pure and free of React, like `graphProjection`, because three
+ * properties have to be checkable without rendering anything:
+ *
+ * 1. **Nothing is dropped.** A relationship whose endpoint is hidden is not
+ *    removed — it is *lifted* onto the nearest visible ancestor and bundled
+ *    there, so the collapsed picture still says "the backend talks to
+ *    PostgreSQL". `resolveEdgeBundle` still resolves the lifted edge into the
+ *    individual reported relationships, which is what ADR 0008 requires of
+ *    every bundle.
+ * 2. **It is the identity when nothing is collapsed.** The same arrays come
+ *    back, so an expanded canvas is byte-for-byte the graph of ADR 0008 and
+ *    cannot have been changed by this module.
+ * 3. **It is deterministic.** The collapsed set is normalised and every output
+ *    array keeps the canonical order the projection produced — parents before
+ *    children, siblings by id, edges by id. The ELK determinism argument of
+ *    ADR 0008 therefore survives unchanged: the solver still sees canonically
+ *    ordered input with declared sizes.
+ */
+
+/** The graph as it is drawn, after hiding everything inside collapsed containers. */
+export interface VisibleGraph {
+  /** Visible nodes, in the projection's canonical order. */
+  nodes: ArchitectureNode[]
+  /** Visible edges, endpoints lifted onto visible ancestors, sorted by id. */
+  edges: ArchitectureEdge[]
+  /** Components that are inside a collapsed container and therefore not drawn. */
+  hiddenComponentIds: Set<ComponentId>
+  /** Containers that are collapsed and really had something to hide. */
+  collapsedComponentIds: Set<ComponentId>
+}
+
+const compareIds = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
+
+/** Parent of every node, `null` for a root. */
+function parentIndex(
+  nodes: readonly ArchitectureNode[],
+): Map<ComponentId, ComponentId | null> {
+  return new Map(nodes.map((node) => [node.id, node.parentId ?? null]))
+}
+
+/**
+ * Every container of the graph, in canonical order.
+ *
+ * "Container" is the projection's own notion — a component that has at least
+ * one child in *this* snapshot — so a component whose children were all removed
+ * stops being expandable without any extra bookkeeping.
+ */
+export function containerIds(nodes: readonly ArchitectureNode[]): ComponentId[] {
+  return nodes.filter((node) => node.data.isCompound).map((node) => node.id)
+}
+
+/**
+ * The containers a project opens with collapsed.
+ *
+ * Every container deeper than `INITIAL_EXPANDED_DEPTH`. A container *at* that
+ * depth stays open, because collapsing it would hide the level the rule is
+ * meant to show.
+ */
+export function initialCollapsedIds(nodes: readonly ArchitectureNode[]): ComponentId[] {
+  return nodes
+    .filter((node) => node.data.isCompound && node.data.depth >= INITIAL_EXPANDED_DEPTH)
+    .map((node) => node.id)
+    .sort(compareIds)
+}
+
+/**
+ * The ancestors of a component, root first.
+ *
+ * This is the path that has to be open for the component to be on screen — the
+ * answer to "a deep link points at a component four levels down; what has to
+ * happen for the user to see it".
+ */
+export function ancestorIds(
+  nodes: readonly ArchitectureNode[],
+  componentId: ComponentId,
+): ComponentId[] {
+  const parentOf = parentIndex(nodes)
+  if (!parentOf.has(componentId)) return []
+
+  const path: ComponentId[] = []
+  const guard = new Set<ComponentId>([componentId])
+  let current = parentOf.get(componentId) ?? null
+  while (current !== null && !guard.has(current)) {
+    guard.add(current)
+    path.push(current)
+    current = parentOf.get(current) ?? null
+  }
+  return path.reverse()
+}
+
+/**
+ * Reduces the projected graph to what a given collapsed set leaves visible.
+ *
+ * Returns the input arrays unchanged when nothing is hidden, so the expanded
+ * canvas is provably the graph `projectArchitecture` produced.
+ */
+export function collapseGraph(
+  nodes: readonly ArchitectureNode[],
+  edges: readonly ArchitectureEdge[],
+  collapsed: readonly ComponentId[],
+): VisibleGraph {
+  const requested = new Set(collapsed)
+  const parentOf = parentIndex(nodes)
+
+  // ---- 1. which nodes are hidden, and which containers really collapse -----
+  // The pre-order of the projection guarantees a parent is classified before
+  // its children, so a single pass is enough to propagate "hidden".
+  const hidden = new Set<ComponentId>()
+  const collapsedContainers = new Set<ComponentId>()
+  const hiddenBelow = new Map<ComponentId, number>()
+
+  for (const node of nodes) {
+    const parentId = parentOf.get(node.id) ?? null
+    if (parentId !== null && (hidden.has(parentId) || collapsedContainers.has(parentId))) {
+      hidden.add(node.id)
+    }
+    if (node.data.isCompound && requested.has(node.id) && !hidden.has(node.id)) {
+      collapsedContainers.add(node.id)
+    }
+  }
+
+  if (hidden.size === 0) {
+    return {
+      nodes: nodes as ArchitectureNode[],
+      edges: edges as ArchitectureEdge[],
+      hiddenComponentIds: hidden,
+      collapsedComponentIds: collapsedContainers,
+    }
+  }
+
+  // How much each collapsed container is holding back, and what is happening in
+  // there. Counted on the full hierarchy so a nested collapse still reports
+  // everything below it.
+  const overlaysBelow = new Map<ComponentId, ChangeOverlay[]>()
+  for (const node of nodes) {
+    if (!hidden.has(node.id)) continue
+    for (const ancestor of ancestorChain(parentOf, node.id)) {
+      if (!collapsedContainers.has(ancestor)) continue
+      hiddenBelow.set(ancestor, (hiddenBelow.get(ancestor) ?? 0) + 1)
+      const overlay = node.data.overlay
+      if (!overlay) continue
+      const collected = overlaysBelow.get(ancestor)
+      if (collected) collected.push(overlay)
+      else overlaysBelow.set(ancestor, [overlay])
+    }
+  }
+
+  // ---- 2. visible nodes; a collapsed container shrinks to a leaf box -------
+  // Its size drops to `LEAF_NODE_SIZE` because ELK derives "is a container"
+  // from having children, and it no longer has any. The size stays a declared
+  // constant either way, which is what keeps the layout independent of the DOM.
+  //
+  // The node **type** deliberately does not change. React Flow remounts a node
+  // whose type changed, and a remounted node is measured from the DOM again —
+  // which would put a rendered box back into the layout path the whole canvas
+  // is built to keep out of it. A collapsed container stays a container and
+  // renders its closed state itself.
+  const visibleNodes = nodes
+    .filter((node) => !hidden.has(node.id))
+    .map((node) => {
+      if (!collapsedContainers.has(node.id)) return node
+      const below = overlaysBelow.get(node.id) ?? []
+      const rolledUp = rollUpOverlay(node.id, node.data.overlay, below)
+      return {
+        ...node,
+        width: LEAF_NODE_SIZE.width,
+        height: LEAF_NODE_SIZE.height,
+        measured: { width: LEAF_NODE_SIZE.width, height: LEAF_NODE_SIZE.height },
+        handles: nodeHandles(LEAF_NODE_SIZE.width, LEAF_NODE_SIZE.height),
+        data: {
+          ...node.data,
+          collapsed: true,
+          hiddenDescendantCount: hiddenBelow.get(node.id) ?? 0,
+          overlay: rolledUp.overlay,
+          overlayRolledUp: rolledUp.rolledUp,
+        },
+      } satisfies ArchitectureNode
+    })
+
+  // ---- 3. edges, lifted onto the nearest visible ancestor ------------------
+  const liftCache = new Map<ComponentId, ComponentId | null>()
+  const lift = (componentId: ComponentId): ComponentId | null => {
+    const cached = liftCache.get(componentId)
+    if (cached !== undefined) return cached
+    let current: ComponentId | null = componentId
+    const guard = new Set<ComponentId>()
+    while (current !== null && hidden.has(current) && !guard.has(current)) {
+      guard.add(current)
+      current = parentOf.get(current) ?? null
+    }
+    const resolved = current !== null && !hidden.has(current) ? current : null
+    liftCache.set(componentId, resolved)
+    return resolved
+  }
+
+  interface Bundle {
+    id: string
+    source: ComponentId
+    target: ComponentId
+    applied: boolean
+    relationships: NonNullable<ArchitectureEdge['data']>['relationships']
+    overlays: Record<Identifier, ChangeOverlay>
+    /** The untouched edge, when this bundle is exactly one unlifted edge. */
+    original: ArchitectureEdge | null
+  }
+
+  const bundles = new Map<string, Bundle>()
+  for (const edge of edges) {
+    const data = edge.data
+    if (!data) continue
+    const source = lift(data.sourceComponentId)
+    const target = lift(data.targetComponentId)
+    // A relationship whose two endpoints collapsed into the same box is
+    // internal to that box. It is not drawn — a self loop on a container says
+    // nothing — and it comes back the moment the container is expanded.
+    if (source === null || target === null || source === target) continue
+
+    const untouched = source === data.sourceComponentId && target === data.targetComponentId
+    const id = data.applied ? bundleEdgeId(source, target) : overlayEdgeId(source, target)
+    const existing = bundles.get(id)
+    if (existing) {
+      existing.relationships = [...existing.relationships, ...data.relationships]
+      existing.overlays = { ...existing.overlays, ...data.overlays }
+      existing.original = null
+      continue
+    }
+    bundles.set(id, {
+      id,
+      source,
+      target,
+      applied: data.applied,
+      relationships: data.relationships,
+      overlays: data.overlays,
+      original: untouched ? edge : null,
+    })
+  }
+
+  const visibleEdges = [...bundles.values()]
+    .sort((a, b) => compareIds(a.id, b.id))
+    .map((bundle) => {
+      if (bundle.original) return bundle.original
+      const relationships = [...bundle.relationships].sort((a, b) =>
+        compareIds(a.relationshipId, b.relationshipId),
+      )
+      return {
+        id: bundle.id,
+        type: RELATIONSHIP_EDGE_TYPE,
+        source: bundle.source,
+        target: bundle.target,
+        sourceHandle: HANDLE_IDS.source,
+        targetHandle: HANDLE_IDS.target,
+        data: {
+          sourceComponentId: bundle.source,
+          targetComponentId: bundle.target,
+          relationships,
+          applied: bundle.applied,
+          overlays: bundle.overlays,
+          bundled: relationships.length > 1,
+        },
+      } as ArchitectureEdge
+    })
+
+  return {
+    nodes: visibleNodes,
+    edges: visibleEdges,
+    hiddenComponentIds: hidden,
+    collapsedComponentIds: collapsedContainers,
+  }
+}
+
+/**
+ * The work state a collapsed container shows.
+ *
+ * Hiding a component must not hide what an agent is *doing* to it — that is the
+ * one thing this cockpit exists to show. A closed container therefore carries
+ * the dominant state of everything behind it, resolved with the same precedence
+ * as everywhere else (`dominantOverlay`, ADR 0010), with every contribution of
+ * every hidden element kept so the mark's `title` still lists them one by one.
+ *
+ * Two things are deliberately *not* rolled up:
+ *
+ * * the **operation**. `geplant · entfernen` on a container would read as "this
+ *   container is being removed", which is a claim about the wrong element. A
+ *   rolled-up mark says the phase and no more; the operation is one expansion
+ *   away, on the element that actually reported it.
+ * * the **presence**. A proposal or a ghost inside an applied container does not
+ *   make the container itself a proposal, so it is never dimmed for one.
+ */
+function rollUpOverlay(
+  componentId: ComponentId,
+  own: ChangeOverlay | null,
+  below: readonly ChangeOverlay[],
+): { overlay: ChangeOverlay | null; rolledUp: boolean } {
+  if (below.length === 0) return { overlay: own, rolledUp: false }
+
+  const dominant = dominantOverlay(own ? [own, ...below] : below)
+  if (dominant === null) return { overlay: own, rolledUp: false }
+  if (dominant === own) return { overlay: own, rolledUp: false }
+
+  const all = own ? [own, ...below] : [...below]
+  return {
+    overlay: {
+      ...dominant,
+      targetKind: 'component',
+      targetId: componentId,
+      presence: own?.presence ?? 'applied',
+      operation: null,
+      contributions: all.flatMap((overlay) => overlay.contributions),
+      agentIds: [...new Set(all.flatMap((overlay) => overlay.agentIds))],
+      descriptor: null,
+    },
+    rolledUp: true,
+  }
+}
+
+/** Ancestors of a node, nearest first. */
+function ancestorChain(
+  parentOf: ReadonlyMap<ComponentId, ComponentId | null>,
+  componentId: ComponentId,
+): ComponentId[] {
+  const chain: ComponentId[] = []
+  const guard = new Set<ComponentId>([componentId])
+  let current = parentOf.get(componentId) ?? null
+  while (current !== null && !guard.has(current)) {
+    guard.add(current)
+    chain.push(current)
+    current = parentOf.get(current) ?? null
+  }
+  return chain
+}

--- a/frontend/src/canvas/detailLevel.test.ts
+++ b/frontend/src/canvas/detailLevel.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it } from 'vitest'
 import {
   DETAIL_LEVEL_LABELS,
   DETAIL_LEVEL_THRESHOLDS,
+  INITIAL_EXPANDED_DEPTH,
+  MIN_LEGIBLE_FONT_SIZE_PX,
+  MIN_READABLE_ZOOM,
+  NODE_LABEL_FONT_SIZE_PX,
   detailLevelForZoom,
+  effectiveLabelSize,
+  isReadableZoom,
   showsTags,
   showsTechnology,
   unfoldsBundles,
@@ -49,5 +55,47 @@ describe('progressive detail levels', () => {
     // The size is a constant, not a function of the level: if it were, zooming
     // would re-layout the graph and move everything under the camera.
     expect(LEAF_NODE_SIZE).toEqual({ width: 228, height: 96 })
+  })
+})
+
+describe('the readable zoom', () => {
+  it('is the zoom at which the node name reaches the smallest type of the design system', () => {
+    // Not a chosen number: the node name is 13 px and the product's own floor
+    // for legible type is 10 px, so the canvas may not scale a name below
+    // 10 / 13 ≈ 0.769. Rounded up, never down.
+    expect(NODE_LABEL_FONT_SIZE_PX).toBe(13)
+    expect(MIN_LEGIBLE_FONT_SIZE_PX).toBe(10)
+    expect(MIN_READABLE_ZOOM).toBe(0.77)
+    expect(MIN_READABLE_ZOOM).toBeGreaterThanOrEqual(
+      MIN_LEGIBLE_FONT_SIZE_PX / NODE_LABEL_FONT_SIZE_PX,
+    )
+  })
+
+  it('measures readability as an effective size, not as a zoom level', () => {
+    expect(effectiveLabelSize(MIN_READABLE_ZOOM)).toBeGreaterThanOrEqual(
+      MIN_LEGIBLE_FONT_SIZE_PX,
+    )
+    expect(isReadableZoom(MIN_READABLE_ZOOM)).toBe(true)
+    // The zoom a 28-component model used to be fitted to: a 2.6 px name.
+    expect(isReadableZoom(0.2)).toBe(false)
+    expect(effectiveLabelSize(0.2)).toBeCloseTo(2.6, 5)
+  })
+
+  it('turns the leaf box into something with room for a name', () => {
+    const width = LEAF_NODE_SIZE.width * MIN_READABLE_ZOOM
+    const height = LEAF_NODE_SIZE.height * MIN_READABLE_ZOOM
+    expect(Math.round(width)).toBe(176)
+    expect(Math.round(height)).toBe(74)
+    // Against 46 × 20 at the old fitted zoom.
+    expect(Math.round(LEAF_NODE_SIZE.width * 0.2)).toBe(46)
+  })
+
+  it('is a readable level, not the lowest detail level', () => {
+    // A model opened at the readable zoom shows technology as well as names.
+    expect(detailLevelForZoom(MIN_READABLE_ZOOM)).toBe('standard')
+  })
+
+  it('opens on the system and container levels', () => {
+    expect(INITIAL_EXPANDED_DEPTH).toBe(1)
   })
 })

--- a/frontend/src/canvas/detailLevel.ts
+++ b/frontend/src/canvas/detailLevel.ts
@@ -42,6 +42,111 @@ export function detailLevelForZoom(zoom: number): DetailLevel {
   return 'overview'
 }
 
+// ---------------------------------------------------------------------------
+// Readability: the floor under the *automatic* camera
+// ---------------------------------------------------------------------------
+
+/**
+ * `font-size` of the text that identifies a node — the component name in
+ * `ComponentNode` and in the `CompoundNode` header (`text-[13px]`).
+ *
+ * It is repeated here as a number because the readable zoom below is derived
+ * from it. A change to the class has to change this constant, and
+ * `detailLevel.test.ts` is what makes that visible.
+ */
+export const NODE_LABEL_FONT_SIZE_PX = 13
+
+/**
+ * The smallest type the design system renders at zoom 1: `text-[10px]`, used
+ * for the kind badge, the technology row, the tags and the legends.
+ *
+ * This is the product's own legibility floor. It is not a number invented for
+ * this rule — it is the size the cockpit already considers readable everywhere
+ * that is *not* under a zoom transform.
+ */
+export const MIN_LEGIBLE_FONT_SIZE_PX = 10
+
+/**
+ * Smallest zoom at which a node is still readable.
+ *
+ * The canvas draws its nodes inside a CSS transform, so every glyph on them is
+ * scaled by the zoom: the effective size of the component name is
+ * `NODE_LABEL_FONT_SIZE_PX × zoom`. Requiring that product to stay at or above
+ * the product's own legibility floor gives
+ *
+ * ```
+ * 13 px × zoom ≥ 10 px   ⇒   zoom ≥ 10 / 13 ≈ 0.7692
+ * ```
+ *
+ * rounded *up* to 0.77, so the floor is never undercut by the rounding. At that
+ * zoom a leaf node measures 228 × 96 × 0.77 ≈ 176 × 74 CSS px and its name
+ * renders at 10.0 px — against 46 × 20 px and 2.6 px at the zoom a 28-component
+ * model used to be fitted to.
+ *
+ * The floor applies to the **automatic** camera only: the first picture of a
+ * project, which the user did not ask for. An explicit "Gesamtes Modell
+ * einpassen" still zooms out as far as the model needs, because the user asked
+ * for the overview and knows what they traded for it.
+ */
+export const MIN_READABLE_ZOOM =
+  Math.ceil((MIN_LEGIBLE_FONT_SIZE_PX / NODE_LABEL_FONT_SIZE_PX) * 100) / 100
+
+/** Effective size of the node label on screen at a given zoom, in CSS px. */
+export function effectiveLabelSize(zoom: number): number {
+  return NODE_LABEL_FONT_SIZE_PX * zoom
+}
+
+/** `true` when a node's name is at or above the legibility floor at this zoom. */
+export function isReadableZoom(zoom: number): boolean {
+  return effectiveLabelSize(zoom) >= MIN_LEGIBLE_FONT_SIZE_PX
+}
+
+// ---------------------------------------------------------------------------
+// Progressive disclosure: how much of the hierarchy is open to begin with
+// ---------------------------------------------------------------------------
+
+/**
+ * Hierarchy levels a project opens with.
+ *
+ * `1` means: root components (depth 0) and their direct children (depth 1) are
+ * drawn, and every container **below** that starts collapsed. On a reported
+ * architecture that is exactly the system and container level — the levels that
+ * describe what the thing *is*, rather than how one of its parts is built.
+ *
+ * Depth is a property of the reported hierarchy, not of the zoom, so the rule
+ * is independent of the number of components: a model with 30, 300 or 3000
+ * components opens with the same handful of top-level boxes.
+ *
+ * The disclosure is deliberately **not** driven by the zoom. Showing or hiding
+ * a container's children changes the ELK input and therefore the layout; if
+ * that were bound to the zoom, zooming in would move every box under the
+ * camera — the one motion ADR 0008 exists to prevent. Expanding is an explicit
+ * act instead, and the camera stays where it was while the boxes rearrange.
+ */
+export const INITIAL_EXPANDED_DEPTH = 1
+
+/**
+ * Every string the disclosure controls show.
+ *
+ * Collected in one object rather than spread over the components so the i18n
+ * migration (#42) has a single place to pick up, and so two controls cannot
+ * drift into naming the same action differently.
+ */
+export const DISCLOSURE_LABELS = {
+  expand: 'Aufklappen',
+  collapse: 'Einklappen',
+  fitWholeModel: 'Gesamtes Modell einpassen',
+  fitWholeModelHint:
+    'Klappt alle Container auf und passt das vollständige Modell in die Fläche ein. Bei vielen Komponenten wird die Darstellung dabei bewusst klein — das ist die Übersichtsaktion.',
+  backToOverview: 'Systemebene',
+  backToOverviewHint:
+    'Zurück auf System- und Container-Ebene: tiefere Komponenten werden wieder eingeklappt und die Ansicht in lesbarer Größe eingepasst.',
+  visibility: (visible: number, total: number) =>
+    `${visible} von ${total} Komponenten sichtbar`,
+  visibilityHint:
+    'Tiefere Komponenten sind hinter ihrem Container eingeklappt, damit die oberen Ebenen lesbar bleiben. Aufklappen über das Dreieck am Container, über einen Deep Link oder über „Gesamtes Modell einpassen".',
+} as const
+
 export const DETAIL_LEVEL_LABELS: Record<DetailLevel, string> = {
   overview: 'Übersicht',
   standard: 'Standard',

--- a/frontend/src/canvas/graphProjection.ts
+++ b/frontend/src/canvas/graphProjection.ts
@@ -105,6 +105,20 @@ export interface ComponentNodeData extends Record<string, unknown> {
   isCompound: boolean
   /** Reported work state of this component, or `null` when none was reported. */
   overlay: ChangeOverlay | null
+  /**
+   * `true` when this container is collapsed: its children are not drawn and it
+   * is rendered as a leaf-sized box. Set by `collapse.ts`, never by the
+   * projection — what is *reported* does not depend on what is *open*.
+   */
+  collapsed?: boolean
+  /** Components hidden inside this collapsed container, at any depth below it. */
+  hiddenDescendantCount?: number
+  /**
+   * `true` when `overlay` describes something *inside* this collapsed container
+   * rather than the container itself. Hiding a component must not hide what an
+   * agent is doing to it.
+   */
+  overlayRolledUp?: boolean
 }
 
 export type ArchitectureNode = Node<ComponentNodeData, ArchitectureNodeType>
@@ -615,7 +629,9 @@ export function countRelationships(edges: readonly ArchitectureEdge[]): number {
  * signature therefore have the same layout, which is what lets the canvas skip
  * a re-layout after a refetch that changed nothing structural.
  */
-export function projectionSignature(projection: ArchitectureProjection): string {
+export function projectionSignature(
+  projection: Pick<ArchitectureProjection, 'nodes' | 'edges'>,
+): string {
   const nodes = projection.nodes
     .map((node) => `${node.id}<${node.parentId ?? ''}>${node.width}x${node.height}`)
     .join('|')

--- a/frontend/src/canvas/nodeActions.ts
+++ b/frontend/src/canvas/nodeActions.ts
@@ -1,0 +1,24 @@
+import { createContext } from 'react'
+
+import type { ComponentId } from '@/api/types'
+
+/**
+ * How a rendered node reaches back into the canvas.
+ *
+ * React Flow compares `nodeTypes` by identity and re-renders a node when its
+ * `data` changes, so a callback can travel through neither: putting the
+ * expand/collapse handler on the node data would re-render every node whenever
+ * anything about the disclosure changed, and would make the node data something
+ * other than a pure function of the model.
+ *
+ * A context provided inside the canvas keeps the graph pure and gives the two
+ * node renderers exactly the one action they need.
+ */
+export interface CanvasNodeActions {
+  /** Opens or closes one container. */
+  toggleCollapsed: (componentId: ComponentId, collapsed: boolean) => void
+}
+
+export const CanvasNodeActionsContext = createContext<CanvasNodeActions>({
+  toggleCollapsed: () => {},
+})

--- a/frontend/src/canvas/useArchitectureGraph.ts
+++ b/frontend/src/canvas/useArchitectureGraph.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 import type { ComponentId } from '@/api/types'
 
+import { ancestorIds, collapseGraph, initialCollapsedIds } from './collapse'
 import { layoutArchitecture, type EdgeRoutes } from './elkLayout'
 import {
   EMPTY_DIAGNOSTICS,
@@ -37,9 +38,40 @@ export interface ArchitectureGraph {
   appliedEdgeCount: number
   /** Edges drawn only because a change was reported. */
   overlayEdgeCount: number
+  /** Containers that are currently collapsed, in canonical order. */
+  collapsedIds: ComponentId[]
+  /**
+   * The collapsed set this model opens with. Kept here rather than recomputed
+   * by the canvas because it needs the *full* hierarchy, which only the
+   * projection still has once containers are closed.
+   */
+  initialCollapsedIds: ComponentId[]
+  /** Components hidden inside a collapsed container. */
+  hiddenComponentIds: Set<ComponentId>
+  /** Components of the model that are drawn right now. */
+  visibleNodeCount: number
+  /** The containers that have to be opened for a component to be on screen. */
+  ancestorsOf: (componentId: ComponentId) => ComponentId[]
 }
 
 const EMPTY_MODEL: ArchitectureModel = { components: [], relationships: [] }
+
+/** Not a legal character in a `ComponentId`, so it cannot collide. */
+const KEY_SEPARATOR = '\u0000'
+
+export interface ArchitectureGraphOptions {
+  /**
+   * Containers the user has collapsed, or `null` while the project is still on
+   * its initial disclosure — the canvas then uses `initialCollapsedIds`.
+   */
+  collapsedComponentIds: readonly ComponentId[] | null
+  /**
+   * A component that must be on screen. Its ancestors are opened regardless of
+   * the collapsed set, which is what makes a deep link into a component four
+   * levels down actually arrive.
+   */
+  revealComponentId?: ComponentId | null
+}
 
 /**
  * Projects an architecture snapshot and lays it out with ELK.
@@ -56,12 +88,43 @@ const EMPTY_MODEL: ArchitectureModel = { components: [], relationships: [] }
  */
 export function useArchitectureGraph(
   model: ArchitectureModel | undefined,
+  options: ArchitectureGraphOptions = { collapsedComponentIds: [] },
 ): ArchitectureGraph {
+  const { collapsedComponentIds, revealComponentId } = options
+
   const projection = useMemo(
     () => projectArchitecture(model ?? EMPTY_MODEL),
     [model],
   )
-  const signature = useMemo(() => projectionSignature(projection), [projection])
+
+  /**
+   * The collapsed set as a stable string.
+   *
+   * Keying the reduction on the content rather than on the array identity is
+   * what keeps a re-render that produced an equal set from re-running ELK — the
+   * same reason `projectionSignature` exists.
+   */
+  const collapsedKey = useMemo(() => {
+    const base = collapsedComponentIds ?? initialCollapsedIds(projection.nodes)
+    if (!revealComponentId) return [...base].sort().join(KEY_SEPARATOR)
+    const revealed = new Set(ancestorIds(projection.nodes, revealComponentId))
+    return base
+      .filter((componentId) => !revealed.has(componentId))
+      .sort()
+      .join(KEY_SEPARATOR)
+  }, [collapsedComponentIds, revealComponentId, projection.nodes])
+
+  const visible = useMemo(
+    () =>
+      collapseGraph(
+        projection.nodes,
+        projection.edges,
+        collapsedKey === '' ? [] : collapsedKey.split(KEY_SEPARATOR),
+      ),
+    [projection, collapsedKey],
+  )
+
+  const signature = useMemo(() => projectionSignature(visible), [visible])
 
   const [laidOut, setLaidOut] = useState<LayoutState | null>(null)
   const [error, setError] = useState<unknown>(null)
@@ -71,13 +134,13 @@ export function useArchitectureGraph(
     // An empty model needs no solver run; the derived result below already
     // describes it. Returning here also keeps this effect free of a synchronous
     // `setState`, which would cost a cascading render on every refetch.
-    if (projection.nodes.length === 0) return
+    if (visible.nodes.length === 0) return
 
     const runId = runIdRef.current + 1
     runIdRef.current = runId
 
     let cancelled = false
-    void layoutArchitecture(projection.nodes, projection.edges)
+    void layoutArchitecture(visible.nodes, visible.edges)
       .then((layout) => {
         if (cancelled || runIdRef.current !== runId) return
         setLaidOut({ signature, nodes: layout.nodes, routes: layout.routes })
@@ -91,36 +154,44 @@ export function useArchitectureGraph(
     return () => {
       cancelled = true
     }
-    // `signature` is derived from `projection`; both are listed so a projection
-    // that is structurally identical after a refetch does not re-run ELK.
-  }, [projection, signature])
+    // `signature` is derived from `visible`; both are listed so a graph that is
+    // structurally identical after a refetch does not re-run ELK.
+  }, [visible, signature])
 
   // The edges always come from the current projection — an incoming update must
   // show up immediately, even if its layout is still being computed. Only the
   // node positions wait for ELK.
   return useMemo<ArchitectureGraph>(() => {
-    const isEmpty = projection.nodes.length === 0
+    const isEmpty = visible.nodes.length === 0
     const isCurrent = laidOut !== null && laidOut.signature === signature
 
     return {
       nodes: isEmpty
         ? []
         : isCurrent
-          ? withCurrentData(laidOut.nodes, projection.nodes)
+          ? withCurrentData(laidOut.nodes, visible.nodes)
           : (laidOut?.nodes ?? []),
-      edges: projection.edges,
+      edges: visible.edges,
       routes: isCurrent ? laidOut.routes : {},
       diagnostics: projection.diagnostics ?? EMPTY_DIAGNOSTICS,
       isInitialLayout: !isEmpty && laidOut === null,
       isRelayouting: !isEmpty && !isCurrent,
       error,
       signature,
+      // Counted on the *reported* model, not on what is open: a collapsed
+      // container hides components, it does not remove them, and the pane's
+      // "28 Komponenten" must keep saying 28.
       appliedNodeCount: projection.appliedNodeCount,
       overlayNodeCount: projection.overlayNodeCount,
       appliedEdgeCount: projection.appliedEdgeCount,
       overlayEdgeCount: projection.overlayEdgeCount,
+      collapsedIds: [...visible.collapsedComponentIds].sort(),
+      initialCollapsedIds: initialCollapsedIds(projection.nodes),
+      hiddenComponentIds: visible.hiddenComponentIds,
+      visibleNodeCount: visible.nodes.length,
+      ancestorsOf: (componentId) => ancestorIds(projection.nodes, componentId),
     }
-  }, [laidOut, projection, signature, error])
+  }, [laidOut, projection, visible, signature, error])
 }
 
 /**

--- a/frontend/src/state/uiStore.ts
+++ b/frontend/src/state/uiStore.ts
@@ -162,6 +162,20 @@ export interface UiState {
    * looking at the graph — the bundle itself is a rendering, never a merge.
    */
   expandedEdgeIds: string[]
+  /**
+   * Architecture containers whose children are not drawn.
+   *
+   * `null` means "the canvas has not disclosed this project yet" and makes it
+   * apply its initial rule (`initialCollapsedIds`). From the first user action
+   * on it the array is authoritative, including the empty array — "the user
+   * opened everything" is a different statement from "nothing was decided yet".
+   *
+   * Transient like the camera and the selection, and for the same reason: it
+   * describes a concrete architecture snapshot, and restoring it into a model
+   * whose hierarchy has meanwhile changed would hide components the user never
+   * chose to hide.
+   */
+  collapsedComponentIds: string[] | null
   /** `false` hides the canvas minimap. */
   minimapVisible: boolean
   deepFocus: DeepFocusTarget | null
@@ -187,6 +201,8 @@ export interface UiState {
 
   toggleEdgeExpanded: (edgeId: string) => void
   clearExpandedEdges: () => void
+  setCollapsedComponentIds: (componentIds: string[] | null) => void
+  setComponentCollapsed: (componentId: string, collapsed: boolean) => void
   setMinimapVisible: (visible: boolean) => void
 
   setAgentCollapsed: (agentId: string, collapsed: boolean) => void
@@ -203,6 +219,7 @@ const transientDefaults = {
   selectedRelationshipId: null,
   hoveredComponentId: null,
   expandedEdgeIds: [],
+  collapsedComponentIds: null,
   deepFocus: null,
   paneStateBeforeDeepFocus: null,
 } satisfies Partial<UiState>
@@ -243,6 +260,18 @@ export const useUiStore = create<UiState>()(
             : [...s.expandedEdgeIds, edgeId],
         })),
       clearExpandedEdges: () => set({ expandedEdgeIds: [] }),
+      setCollapsedComponentIds: (collapsedComponentIds) =>
+        set({
+          collapsedComponentIds:
+            collapsedComponentIds === null ? null : [...collapsedComponentIds].sort(),
+        }),
+      setComponentCollapsed: (componentId, collapsed) =>
+        set((s) => {
+          const current = new Set(s.collapsedComponentIds ?? [])
+          if (collapsed) current.add(componentId)
+          else current.delete(componentId)
+          return { collapsedComponentIds: [...current].sort() }
+        }),
       setMinimapVisible: (minimapVisible) => set({ minimapVisible }),
 
       setAgentCollapsed: (agentId, collapsed) =>

--- a/frontend/src/test/architectureFixtures.ts
+++ b/frontend/src/test/architectureFixtures.ts
@@ -315,6 +315,137 @@ export const grownArchitectureResponse: ArchitectureResponse = {
 }
 
 // ---------------------------------------------------------------------------
+// A model that does not fit on a screen
+// ---------------------------------------------------------------------------
+
+/**
+ * A deliberately large snapshot: **32 components over four hierarchy levels**.
+ *
+ * The acceptance criterion of #34 asks for at least 30 nodes, because that is
+ * the size at which fitting everything into the centre pane drops the zoom far
+ * below anything readable. The shape is generated rather than written out so
+ * the intent stays visible: one system, four services, two modules each, two
+ * leaves per module, plus two shared stores and one external client.
+ *
+ * Generated deterministically — same ids, same order, same relationships on
+ * every run — so it can be used in the determinism assertions too.
+ */
+function buildLargeModel(): { components: Component[]; relationships: Relationship[] } {
+  const components: Component[] = [
+    { componentId: 'mesh', name: 'Mesh Platform', kind: 'system', parentComponentId: null },
+    { componentId: 'edge.client', name: 'Edge Client', kind: 'external', parentComponentId: null },
+    { componentId: 'mesh.db', name: 'Mesh Store', kind: 'datastore', parentComponentId: 'mesh' },
+    { componentId: 'mesh.queue', name: 'Mesh Queue', kind: 'queue', parentComponentId: 'mesh' },
+  ]
+  const relationships: Relationship[] = [
+    {
+      relationshipId: 'lr-000',
+      sourceComponentId: 'edge.client',
+      targetComponentId: 'mesh',
+      kind: 'http',
+      protocol: 'HTTP/2',
+      operation: 'GET /',
+    },
+  ]
+
+  for (let service = 1; service <= 4; service += 1) {
+    const serviceId = `mesh.s${service}`
+    components.push({
+      componentId: serviceId,
+      name: `Service ${service}`,
+      kind: 'service',
+      parentComponentId: 'mesh',
+      technology: { language: 'Go' },
+    })
+    for (const module of ['a', 'b']) {
+      const moduleId = `${serviceId}.${module}`
+      components.push({
+        componentId: moduleId,
+        name: `Modul ${service}${module.toUpperCase()}`,
+        kind: 'module',
+        parentComponentId: serviceId,
+      })
+      for (let leaf = 1; leaf <= 2; leaf += 1) {
+        const leafId = `${moduleId}.l${leaf}`
+        components.push({
+          componentId: leafId,
+          name: `Baustein ${service}${module.toUpperCase()}${leaf}`,
+          kind: 'module',
+          parentComponentId: moduleId,
+          technology: { language: 'Go' },
+        })
+        relationships.push({
+          relationshipId: `lr-${service}${module}${leaf}`,
+          sourceComponentId: leafId,
+          targetComponentId: leaf === 1 ? 'mesh.db' : 'mesh.queue',
+          kind: leaf === 1 ? 'data' : 'async',
+          protocol: leaf === 1 ? 'SQL' : 'NATS',
+          ...(leaf === 1 ? { operation: 'SELECT' } : { channel: `mesh.s${service}` }),
+        })
+      }
+    }
+  }
+
+  return { components, relationships }
+}
+
+const LARGE_MODEL = buildLargeModel()
+
+/** A component of the large model four levels down; used for deep-link tests. */
+export const LARGE_DEEP_COMPONENT_ID = 'mesh.s1.a.l1'
+/** Its ancestors, root first — the containers a deep link has to open. */
+export const LARGE_DEEP_ANCESTORS = ['mesh', 'mesh.s1', 'mesh.s1.a'] as const
+
+export const LARGE_COMPONENTS: AppliedComponent[] = LARGE_MODEL.components.map(
+  (component, index) => appliedComponent(component, { position: index + 1 }),
+)
+
+export const LARGE_RELATIONSHIPS: AppliedRelationship[] = LARGE_MODEL.relationships.map(
+  (relationship, index) =>
+    appliedRelationship(relationship, {
+      position: LARGE_MODEL.components.length + index + 1,
+    }),
+)
+
+export const largeArchitectureResponse: ArchitectureResponse = {
+  projectPosition: 90,
+  components: LARGE_COMPONENTS,
+  relationships: LARGE_RELATIONSHIPS,
+  activeChanges: [],
+}
+
+/** The large model with one more leaf — a real structural live update. */
+export const largeGrownArchitectureResponse: ArchitectureResponse = {
+  projectPosition: 91,
+  components: [
+    ...LARGE_COMPONENTS,
+    appliedComponent(
+      {
+        componentId: 'mesh.s1.a.l3',
+        name: 'Baustein 1A3',
+        kind: 'module',
+        parentComponentId: 'mesh.s1.a',
+      },
+      { position: 200 },
+    ),
+  ],
+  relationships: [
+    ...LARGE_RELATIONSHIPS,
+    appliedRelationship(
+      {
+        relationshipId: 'lr-1a3',
+        sourceComponentId: 'mesh.s1.a.l3',
+        targetComponentId: 'mesh.db',
+        kind: 'data',
+        protocol: 'SQL',
+      },
+      { position: 201 },
+    ),
+  ],
+  activeChanges: [],
+}
+
+// ---------------------------------------------------------------------------
 // Change proposals
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/test/renderApp.tsx
+++ b/frontend/src/test/renderApp.tsx
@@ -7,6 +7,7 @@ import { vi } from 'vitest'
 
 import { DEFAULT_LANGUAGE, type Language, createI18n } from '@/i18n'
 import { createAppRouter } from '@/routes/router'
+import { useUiStore } from '@/state/uiStore'
 
 import { createFakeFetch } from './fixtures'
 
@@ -17,6 +18,17 @@ export interface RenderAppOptions {
   language?: Language
   /** A prepared instance, for tests that need to observe its events. */
   i18n?: I18n
+  /**
+   * Starts with every architecture container open, i.e. in the state the user
+   * reaches with "Gesamtes Modell einpassen".
+   *
+   * A project otherwise opens on its top levels with deeper containers
+   * collapsed (ADR 0017), which is the right default but the wrong starting
+   * point for a test about edge bundling, overlays or selection on a component
+   * four levels down. Those tests set this and keep asserting exactly what they
+   * asserted before the progressive disclosure existed.
+   */
+  expandAllComponents?: boolean
 }
 
 /**
@@ -27,6 +39,10 @@ export interface RenderAppOptions {
  */
 export function renderApp(initialPath: string, options: RenderAppOptions = {}) {
   vi.stubGlobal('fetch', options.fetchImpl ?? createFakeFetch())
+
+  if (options.expandAllComponents) {
+    useUiStore.getState().setCollapsedComponentIds([])
+  }
 
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },


### PR DESCRIPTION
Der Architekturcanvas passte beim Öffnen das gesamte Modell in die Fläche ein. Das ist genau so lange richtig, wie das Modell klein ist — und `visualise-ai-self` ist es nicht mehr.

## Das Problem, gemessen

Chromium, 1920 × 1080, Centre-Pane 1035,7 × 932,5 CSS px, `localStorage` vor jeder Messung geleert:

| Modell | Zoom | Knoten | Name × Zoom | Detailstufe |
| --- | --- | --- | --- | --- |
| `visualise-ai-self` — 28 Komponenten / 4 Ebenen | **0,203** | 46,3 × 19,5 px | **2,64 px** | `overview` |
| synthetisch — 32 Komponenten / 4 Ebenen | **0,282** | 64,3 × 27,1 px | **3,66 px** | `overview` |

2,6 px ist keine kleine Schrift, das ist keine Schrift. Die wichtigste Fläche des Produkts war beim Einstieg nicht lesbar — und mit jeder Komponente, die ein Agent meldet, wird es schlechter.

## Nachher

| Modell | Zoom | Knoten | Name × Zoom | Detailstufe | gezeichnet |
| --- | --- | --- | --- | --- | --- |
| `visualise-ai-self` (28) | **0,770** | **175,6 × 73,9 px** | **10,01 px** | `standard` | 10 von 28 |
| synthetisch (32) | **1,000** | **228 × 96 px** | **13,00 px** | `standard` | 8 von 32 |

`data-fit-view-count` ist in beiden Fällen `1`.

---

## Wie der Mindestzoom hergeleitet ist

Keine geratene Zahl, sondern eine Division zweier Konstanten, die es im Produkt schon gibt:

* der identifizierende Text eines Knotens ist `text-[13px]` (`NODE_LABEL_FONT_SIZE_PX`),
* die kleinste Schrift, die das Designsystem bei Zoom 1 überhaupt rendert, ist `text-[10px]` (`MIN_LEGIBLE_FONT_SIZE_PX`) — Art-Badge, Technologiezeile, Tags, beide Legenden.

Der Canvas zeichnet seine Knoten in einem CSS-Transform, jede Glyphe wird also mit dem Zoom skaliert. Damit der Komponentenname nicht unter die produkteigene Lesbarkeitsgrenze fällt:

```
13 px × zoom ≥ 10 px   ⇒   zoom ≥ 10 / 13 ≈ 0,7692   ⇒   0,77
```

**aufgerundet**, damit die Rundung den Boden nie unterschreitet. `detailLevel.test.ts` prüft die Herleitung, nicht das Ergebnis: ändert sich die Schriftgröße des Knotennamens, wandert der Boden mit.

Der Boden ist **keine** Funktion der Canvasbreite — er ist eine Aussage über Glyphen, nicht darüber, wie viel hineinpasst. *Wie viel hineinpasst* ist sehr wohl eine Funktion der Fläche, deshalb liest die Kamera die tatsächlich gemessene Breite (`storeApi.getState().width`) statt einer Konstante. **#41** verkleinert die Centre-Pane bei 1280 px Fensterbreite auf ~660 px; an dieser Herleitung ändert das nichts, und die Tests hängen an keiner 1036.

## Der Boden gilt nur für die automatische Kamera

`viewportForBounds` in `cameraPolicy.ts` nimmt ein `minZoom` entgegen. Es gibt genau zwei Aufrufer:

* der **initiale** Fit — die eine Bewegung, die der Nutzer nicht angefordert hat — übergibt `MIN_READABLE_ZOOM`,
* ein explizites **„Gesamtes Modell einpassen"** übergibt das Canvas-Minimum und darf auf 0,20 gehen, wenn das Zeigen des Ganzen so viel kostet.

Der Nutzer darf jederzeit wählen, ein Modell zu klein zu sehen. Der Canvas darf es nie für ihn wählen.

`viewportForBounds` verankert ein Modell, das beim lesbaren Zoom nicht hineinpasst, außerdem an seiner **oberen linken Ecke** statt es zu zentrieren: das ELK-Layout läuft nach rechts, Aufrufer zuerst (ADR 0008) — sein Anfang ist die Stelle, an der man eine Architektur zu lesen beginnt.

## Die Kamerapolicy selbst ist unverändert

**Es kam keine neue Ausnahme hinzu.** `onLayoutReady` liefert weiterhin höchstens einmal pro Projekt einen Grund, plus solange sich die Fläche noch einmisst. Der lesbare Boden ändert, *wohin* die Kamera fährt, nie *ob* sie fährt.

Belegt gegen einen echten Simulatorlauf (`--scenario self --speed 1 --project i34-live-proof`, 122 Ereignisse), 100 s lang alle 10 s abgetastet, nachdem der Nutzer eine Komponente ausgewählt hatte:

```
samples                 : 9
node count 0 -> end     : 27 -> 28        <- das Modell ist waehrend des Laufs gewachsen
edge count 0 -> end     : 33 -> 34
overlay nodes at end    : 1
data-fit-view-count     : 1
viewport transform      : translate(27.8409px, 281.7px) scale(0.77)
   unchanged in all     : true
selection unchanged     : true
disclosure unchanged    : true
DRIFTING SAMPLES        : 0
```

Ein eintreffendes Ereignis ändert weder Zoom noch Pan noch Auswahl — und auch nicht, was der Nutzer aufgeklappt hat.

## Progressive Detailstufen: Expand/Collapse, nicht zoomgesteuert

`canvas/collapse.ts` reduziert den projizierten Graphen auf das, was ein Satz eingeklappter Container übrig lässt. Ein Projekt öffnet mit `initialCollapsedIds`: jeder Container tiefer als `INITIAL_EXPANDED_DEPTH` (= 1). Wurzeln und ihre direkten Kinder werden gezeichnet, alles darunter wartet hinter seinem Container. Die Regel ist eine Eigenschaft der gemeldeten Hierarchie, nicht der Knotenzahl — ein Modell mit 300 Komponenten öffnet mit derselben Handvoll Kästen.

**Warum nicht zoomgesteuert.** Kinder ein- oder auszublenden ändert die ELK-Eingabe und damit das Layout. An den Zoom gebunden würde das jeden Kasten unter der Kamera verschieben, während der Nutzer scrollt — genau die Bewegung, die ADR 0008 verhindert, und der Grund, warum die Knotengröße schon heute nicht von der Detailstufe abhängt. Aufklappen ist stattdessen ein ausdrücklicher Akt: die Kamera bleibt stehen, die Kästen ordnen sich neu — dieselbe Regel, die ADR 0010 für ein eintreffendes Proposal festgehalten hat.

Die vorhandenen Detailstufen bleiben unangetastet und behalten ihre Aufgabe — *wie viel ein gezeichneter Knoten sagt*. Dieser PR ergänzt die orthogonale Frage, *welche* Knoten gezeichnet werden. Nebeneffekt: 0,77 liegt in `standard`, das Projekt öffnet jetzt mit Namen, Art **und** Technologie statt in `overview`.

## Eingeklappt heißt nicht verschwunden

* **Eine Beziehung wird gehoben, nicht verworfen.** Eine Kante mit verstecktem Endpunkt wird an den nächsten sichtbaren Vorfahren gehängt und dort gebündelt. Vier Bausteine, die in den Store schreiben, werden zu einer `Service → Store`-Kante, die weiterhin alle vier gemeldeten Beziehungen trägt; `resolveEdgeBundle` löst sie genau so auf, wie ADR 0008 es von jedem Bündel verlangt. Eine Beziehung, deren beide Enden in dieselbe Box fallen, ist deren Interna und wird nicht gezeichnet — eine Schlinge am Container sagt nichts — und kommt beim Aufklappen zurück.
* **Ein Arbeitszustand wird hochgezogen.** Ein geschlossener Container trägt den dominanten Zustand von allem dahinter (`dominantOverlay`, ADR 0010), mit allen Beiträgen, sodass der `title` der Marke sie weiterhin einzeln auflistet. Eine Komponente zu verstecken darf nicht verstecken, was ein Agent mit ihr *tut*. Die **Operation** wird bewusst nicht hochgezogen — `geplant · entfernen` am Container würde behaupten, der Container werde entfernt — und die Presence auch nicht, damit ein Proposal darin den Container nicht ausgraut.
* **Die gemeldeten Zahlen bewegen sich nicht.** `data-node-count` bleibt die Zahl der angewandten Komponenten, der Pane-Header sagt weiter „28 Komponenten". Neu sind `data-visible-node-count`, `data-hidden-node-count` und `data-collapsed-count`.

`collapseGraph` gibt seine Eingabearrays unverändert zurück, wenn nichts eingeklappt ist — ein offener Canvas ist beweisbar der Graph, den `projectArchitecture` erzeugt hat.

## Determinismus

Der eingeklappte Satz wird normalisiert und sortiert, die Reduktion erhält die kanonische Reihenfolge der Projektion (Eltern vor Kindern, Geschwister nach Id, Kanten nach Id), und die Knotengrößen bleiben deklarierte Konstanten — ein geschlossener Container schrumpft auf `LEAF_NODE_SIZE`, eine Konstante, keine Messung. ELK sieht also unverändert kanonisch geordnete Eingaben mit deklarierten Größen und gepinntem Seed; die Determinismustests aus #9 sind unberührt. `collapse.test.ts` prüft es direkt: dasselbe Modell mit durchgeschüttelten Eingabelisten und umgedrehtem Collapse-Satz erzeugt eine identische `projectionSignature`.

Ein Detail ist tragend genug, um es zu benennen: ein eingeklappter Container behält seinen React-Flow-**Knotentyp**. React Flow remountet einen Knoten mit geändertem Typ, und ein remounteter Knoten wird aus dem DOM vermessen — das würde eine gerenderte Box zurück in den Layoutpfad holen, den dieser Canvas gerade freihält. (Beim ersten Versuch hat genau das zugeschlagen: `window.DOMMatrixReadOnly is not a constructor` aus `updateNodeInternals`.)

## Deep Links auf tiefe Komponenten

Ein Link auf eine Komponente vier Ebenen tief klappt ihre Vorfahren auf. Die Alternative — auf einem Canvas landen, auf dem die verlinkte Komponente nicht gezeichnet ist — würde den Deep Link zu einem gebrochenen Versprechen machen, und es gibt keinen Weg, eine Komponente zu zeigen, ohne zu öffnen, was sie enthält.

Aufgelöst wird das **zusammen mit** dem initialen Satz, vor dem ersten Layout, also kostet ein Deep Link weiterhin genau einen ELK-Lauf und genau eine Kamerabewegung. Und er ändert nur die Sichtbarkeit — Zoom und Pan werden nicht angefasst, der Deep Link ist damit auch keine Kameraausnahme.

Der umgekehrte Fall ist ausdrücklich behandelt: wer einen Container schließt, der die aktuelle Auswahl enthält, bekommt die Auswahl **nach oben** auf diesen Container gesetzt. Die URL zeigt so nie auf etwas, das nicht auf dem Bildschirm ist, und der Inspector beschreibt nie eine unsichtbare Komponente.

Im Browser gegen das laufende Backend (`visualise-ai-self`, Deep Link auf `visualise-ai.frontend.api.generated`, Ebene 3):

```
visible 17, hidden 12, zoom 0.77, fit 1
deep node drawn   : 1
deep node selected: 1
inspector shows it: true
ancestors opened  : visualise-ai > visualise-ai.frontend > visualise-ai.frontend.api
```

## Der Deep-Link-Knoten ist auch wirklich im Bild

> Nachgezogen nach der Orchestrator-Verifikation — Boden und Verankerung hatten zusammen eine Regression erzeugt.

Gezeichnet zu sein ist nicht dasselbe wie sichtbar zu sein. Der lesbare Zoom schob den verlinkten Knoten **732 px über die rechte Kante**: der Inspector beschrieb eine Komponente, die die Architekturfläche nirgends zeigte. Das vorherige Einpassen des ganzen Modells war unlesbar, hatte den Knoten aber wenigstens im Bild — eine echte Regression gegen „Deep Links und Auswahl einer Komponente weiterhin unterstützen".

`viewportForBounds` nimmt jetzt ein optionales `focus`-Rechteck; die initiale Kamera übergibt die Box der Komponente, auf die die URL zeigt. Hereingeholt wird sie **ausschließlich durch Pan**, um den kleinsten Betrag, der reicht — nie durch Herauszoomen. Der Boden ist nicht der Preis dafür, einem Link zu folgen, und beide stehen nicht in Konkurrenz: ein Blattknoten misst beim lesbaren Zoom 176 × 74 px und passt auf jede unterstützte Fläche mehrfach.

**Das ist bewusst kein vierter `fitView`-Grund.** Es gibt weiterhin genau eine automatische Bewegung, und in dem Moment hat noch niemand die Kamera übernommen; sie zusätzlich die URL lesen zu lassen gibt ihr eine weitere *Eingabe*, nicht einen weiteren *Anlass*. Die Alternative — den Deep Link als explizite Nutzeraktion und damit als zweite Bewegung zu behandeln — habe ich verworfen und im ADR begründet.

Die Grenze liegt dort, wo sie liegen muss: `selectedComponentId` steht in der Dependency-Liste des Layout-Effekts, ein *späterer* Auswahlwechsel lässt die Policy also erneut laufen — und sie antwortet `null`.

Nachgemessen im Browser, `visualise-ai-self`, Deep Link auf `visualise-ai.frontend.api.generated` (Ebene 4):

```
knotenGerendert      true
ausgewaehlt          true
inspector            visualise-ai.frontend.api.generated
zoom                 0.77            <- Boden gehalten, nicht herausgezoomt
fitViewCount         1
Knoten               {"left":1160,"right":1335,"top":606,"bottom":680}
Canvas               {"left":346,"right":1382,"top":84,"bottom":1017}
sichtbarerAnteil     100 %           <- vorher 0 %
vollstaendig drin    true

=== Gegentest: Klick auf einen anderen Knoten ===
url                  ?component=visualise-ai.postgres
transform vorher     translate(-751.291px, 135.4px) scale(0.77)
transform nachher    translate(-751.291px, 135.4px) scale(0.77)
Kamera unbewegt      true
fitViewCount         1 -> 1
```

„Systemebene" reproduziert das Einstiegsbild und berücksichtigt die Auswahl genauso. „Gesamtes Modell einpassen" nicht — das ist eine Aussage über das Modell, nicht über eine seiner Komponenten.

Der Test dazu ist nachweislich nicht vakuum: mit deaktiviertem `focus` schlägt er fehl (`expected 508.59727272727275 to be less than or equal to 500`).

## Alle Komponenten bleiben erreichbar

Drei Wege, alle im Browser durchgespielt:

```
--- 1. initial disclosure ---
10 of 28 visible; 19 hidden; 2 containers collapsed; zoom 0.77; fit 1

--- 2. expand visualise-ai.backend (Dreieck am Container) ---
visible 20, hidden 9, fit-view-count 1 (must stay 1)
   camera unmoved: true

--- 3. collapse it again ---
visible 10, hidden 19, fit 1

--- 4. "Gesamtes Modell einpassen" ---
visible 29 of 28, hidden 0, zoom 0.2032, fit 2
   every reported component drawn: true

--- 5. back to "Systemebene" ---
visible 10, hidden 19, zoom 0.77, fit 3

--- 6. click a node: URL + inspector ---
url       : ?component=visualise-ai.postgres
inspector : present
selected  : 1
```

(29 statt 28 in Schritt 4, weil ein offenes Proposal — `repository-provider` — als Overlay-Knoten mitgezeichnet wird; `data-node-count` bleibt korrekt bei 28.)

Dasselbe für das synthetische 32-Komponenten-Modell:

```
--- 1. initial disclosure ---
8 of 32 visible; 24 hidden; 4 containers collapsed; zoom 1; fit 1
--- 2. expand grid.s1 ---   visible 14, hidden 18, fit 1, camera unmoved: true
--- 4. "Gesamtes Modell einpassen" ---  visible 32 of 32, hidden 0, zoom 0.2816, fit 2
--- 7. deep link grid.s1.a.l1 ---  fit 1, drawn 1, selected 1, inspector true
       ancestors opened: grid > grid.s1 > grid.s1.a
```

## Ein Modell mit mindestens 30 Knoten

Zweifach belegt:

1. **Im Browser**, gegen ein eigenes Projekt (`i34-large`, 32 Komponenten über vier Ebenen, per Ingest-API veröffentlicht): 0,282 → **1,000**, Knoten 64,3 × 27,1 → **228 × 96 px**, Name 3,66 → **13,00 px**.
2. **Als Eigenschaft, unabhängig von der Knotenzahl**: `cameraPolicy.test.ts` prüft den Boden für Layout-Bounds von 2 000, 20 000 und 200 000 px Breite — der Zoom bleibt `MIN_READABLE_ZOOM`. Der Boden ist eine Klemmung, keine Heuristik; er kann von keiner Modellgröße unterlaufen werden.

Zusätzlich läuft die gesamte neue Integrationssuite `ArchitectureZoom.test.tsx` gegen ein Fixture mit 32 Komponenten über vier Ebenen.

---

## Tests

```
$ npm run lint                       # frontend — sauber
$ npx tsc --build --force            # frontend — sauber
$ npm run build                      # ✓ built in 14.73s
$ npx vitest run
   Test Files  30 passed (30)
        Tests  262 passed (262)      # 224 vorher + 38 neu
```

Verpflichtender End-to-End-Abnahmelauf (#14), auf einem eigenen Stack, damit 8080–8083 unberührt bleiben:

```
$ FRONTEND_HTTP_PORT=8105 E2E_COMPOSE_PROJECT=vai-issue34 npm test
  ok  1 … 1 · a refused event occupies no position, a retry repeats it, a conflict is rejected
  ok  4 … 3 · every live change state is observed while the run is happening (30.6s)
  ok  6 … 2 · the canvas draws the reported hierarchy across four nesting levels
  ok  7 … 2 · every relationship kind is drawn, and every reported NATS topic stays individually identifiable
  ok 10 … 5 · clicking a component shows its agent, task, markdown feedback and grouped diffs
  ok 15 … 6 · deep focus enlarges the inspector while the architecture stays on screen
  ok 18 … 8 · the page has no horizontal scrollbar and every primary control is operable
  20 passed (1.9m)
```

### Neue Tests

* `collapse.test.ts` (12) — initiale Offenlegung, Vorfahrenpfad, Identität bei nichts eingeklappt, gehobene Beziehungen, Selbstschlingen, Determinismus gegen durchgeschüttelte Eingaben.
* `ArchitectureZoom.test.tsx` (12) — initiale Kamera bei großem Modell, System-/Container-Ebene mit einem Klick zum Rest, gehobene Beziehung, hochgezogener Arbeitszustand, „Gesamtes Modell einpassen", „Systemebene", Deep Link auf tiefe Komponente (aufgeklappt **und** vollständig im Canvas-Rechteck), Klick bewegt die Kamera nicht, Auswahl beim Einklappen, Nutzerkamera bleibt nach eintreffendem Ereignis unberührt, Offenlegung bleibt beim Ereignis unberührt.
* `cameraPolicy.test.ts` (+9) — Zentrierung, Boden, Bodenhaltung über drei Größenordnungen, Verankerung links oben, explizites Herauszoomen, Klemmung, Fokus heranpannen, No-op bei sichtbarem Fokus, übergroßer Fokus.
* `detailLevel.test.ts` (+5) — die Herleitung selbst.

### Zwei bestehende Testdateien starten vom offenen Modell

`ArchitectureCanvas.test.tsx` und `ChangeOverlays.test.tsx` prüfen Bündelung, Overlays und Auswahl an Komponenten drei und vier Ebenen tief. Sie übergeben jetzt `expandAllComponents` an `renderApp` — genau der Zustand, den der Button „Gesamtes Modell einpassen" erzeugt, also ein echter, erreichbarer Zustand. **Jede Assertion darin ist unverändert.** Die Abnahmesuite macht dasselbe über den Button selbst (`e2e/src/canvas.ts`), damit der E2E-Lauf das echte Bedienelement benutzt statt eine Testnaht.

---

## Bei anderen Issues aufgefallen — nicht behoben

* **Deep Link ohne Auswahl in der Fläche:** nur die *erste* Darstellung pannt zur ausgewählten Komponente. Eine später von außerhalb gesetzte Auswahl (Inspector-Link, Browser-Zurück auf einen anderen `component=`-Wert) bewegt die Kamera nicht — bewusst, weil die Kamera ab dann dem Nutzer gehört. Falls sich zeigt, dass das doch gebraucht wird, ist es eine neue, ausdrückliche Aktion neben „Einpassen" und keine Änderung an der Policy.
* **#35 (A11y):** ein eingeklappter Container ist eine weitere Sache, die einen zugänglichen Namen braucht. Sein Aufklapp-Steuerelement hat einen (`aria-label`, `aria-expanded`), der Knoten selbst nicht — das war vorher auch schon so. Die Forderung „ein ausgeblendeter Knoten darf kein Tab-Stop sein" ist hier geschenkt: ein ausgeblendeter Knoten wird gar nicht gerendert. Neu für #35: `aria-expanded` am Container und der zugängliche Name der Steuerung sollten mit dem Knotennamen zusammenpassen, statt „Aufklappen (9 Komponenten)" isoliert vorzulesen.
* **#41 (Viewport/Panes):** die Toolbar hat einen Button dazubekommen und bricht jetzt um (`flex-wrap`, `max-w`), statt über den Rand der Pane zu laufen. Bei der in #41 vorgesehenen Mindestbreite von 500 px wird sie zweizeilig. Wenn #41 hier etwas anderes will, ist die eine Zeile in `ArchitectureCanvas.tsx` die Stelle.
* **#42 (i18n):** alle neuen Texte liegen gesammelt in `DISCLOSURE_LABELS` in `canvas/detailLevel.ts`, hart kodiert, an einer Stelle abholbar.
* Nicht angefasst und nicht stillschweigend repariert: das Bundle des Entry-Chunks liegt weiter über der 500-kB-Warnung (bekannt aus ADR 0003), und `e2e` hat kein `lint`-Script, obwohl `frontend` und `simulator` eines haben.

## Offene Risiken

* `INITIAL_EXPANDED_DEPTH` ist eine Produktentscheidung im Gewand einer Konstante, wie `RECENT_APPLIED_LIMIT` in ADR 0010. Eine Ebene unter den Wurzeln ist für eine gemeldete Architektur richtig, in der Tiefe 0 das System und Tiefe 1 seine Teile sind. Ein Modell, das alles Interessante auf Ebene 3 legt, öffnet mit einer Seite voller Container; die Antwort wäre dann Offenlegung nach Teilbaumgröße statt nach Tiefe, und sie gehört allein in `initialCollapsedIds`.
* Das Einstiegsbild zeigt nicht mehr das ganze Modell. 28 Komponenten auf ihrer obersten Ebene layouten zu 1944 × 518, also 69 % einer 1036 px breiten Fläche bei 0,77. Die Übersichtskarte (ADR 0008) und die Verankerung links oben sind das, was das navigierbar statt desorientierend macht.
* Der hochgezogene Arbeitszustand sagt die Phase, nicht die Operation. Wer wissen will, *was* im Container passiert, muss ihn öffnen. Das ist bewusst so — die Alternative wäre eine Marke, die über den falschen Knoten spricht.

Siehe [ADR 0017](docs/decisions/0017-readable-entry-zoom-and-progressive-disclosure.md).

Closes #34
