### PR TITLE
Architekturkomponenten mit zugänglichen Namen und Zuständen versehen (#35)

### DIFF
--- a/docs/decisions/0018-accessible-architecture-nodes.md
+++ b/docs/decisions/0018-accessible-architecture-nodes.md
@@ -1,0 +1,289 @@
+# 18. Accessible architecture nodes: a name, a state and a focus ring that survives the zoom
+
+- **Status:** accepted
+- **Date:** 2026-08-04
+- **Context issue:** #35 (part of the v0 epic #1)
+- **Builds on:** [0003 — Frontend state split and live updates](./0003-frontend-state-split-and-live-updates.md),
+  [0008 — Architecture canvas](./0008-architecture-canvas-layout-and-edge-bundling.md),
+  [0010 — Live change overlays](./0010-live-change-overlays.md),
+  [0012 — Component inspector](./0012-component-inspector-and-markdown-safety.md),
+  [0014 — Localisation architecture and translation contract](./0014-localisation-architecture-and-translation-contract.md),
+  [0017 — Readable entry zoom and progressive disclosure](./0017-readable-entry-zoom-and-progressive-disclosure.md),
+  [0019 — Locale-aware formatting and the UTC rule](./0019-locale-aware-formatting-and-the-utc-rule.md)
+
+## Context
+
+The architecture canvas is the product (ADR 0008). React Flow makes every node
+and every edge a tab stop, which reads like accessibility and is not: measured
+against the running cockpit (`visualise-ai-self`, 28 components over four
+levels, one open proposal), the accessibility tree contained
+
+- **29 focusable nodes, 0 of them named** — each one a `group` with the
+  roledescription `node` and no `aria-label` at all,
+- **34 focusable edges**, named `Edge from <componentId> to <componentId>` in
+  English and built from ids rather than from the reported names,
+- **no focus indicator anywhere**: React Flow's own stylesheet sets
+  `outline: none` on `.react-flow__node.selectable:focus-visible` and on
+  `.react-flow__edge:focus-visible`, so the ring the design system defines never
+  applied,
+- **a node description that offered actions the cockpit does not have** —
+  "Press delete to remove it" and "use the arrow keys to move the node around",
+  in a read-only observation tool with `deleteKeyCode={null}`,
+- **Enter and Space that did nothing.** React Flow's built-in handler sets its
+  *internal* selection; the graph here is fully controlled and has no
+  `onNodesChange`, so the change was dropped. Selection was mouse-only.
+
+(Those counts are the model fully expanded — the picture before ADR 0017 landed.
+With the progressive disclosure a project now opens on 10 drawn nodes and 24
+drawn edges, and every one of the defects above applied to each of them.)
+
+Component name, kind, change state and selection — everything the box shows —
+were unavailable to a screen reader. Two further properties made a naive fix
+insufficient: the canvas draws inside a CSS transform, so any ring is multiplied
+by the zoom, and the camera belongs to the user (ADR 0008), so nothing about
+focus may move it.
+
+## Decision
+
+### One module owns everything the canvas says
+
+`src/canvas/canvasAccessibility.ts` builds every accessible name, role and
+description; `ArchitectureCanvas` only wires it up. The module reads the same
+sources the drawing code reads — `componentKinds` for the kind label,
+`overlayLabel` for the work state, `DISCLOSURE_LABELS` for the disclosure verbs
+— so a state cannot be worded one way on the box and another way in the
+accessibility tree. It never invents a second vocabulary and never adds a
+judgement: the four states of `src/state/workStates.ts` describe a *phase of
+work*, and `entfernt` means "is being removed", not "bad" (ADR 0003).
+
+Every German string it speaks sits in one exported object, `CANVAS_A11Y_TEXT`,
+so the i18n migration (#42) has a single place to pull from.
+
+**Counted nouns are the one exception, and they are passed in.** "10 Komponenten"
+is already localised (ADR 0019), and this module is pure and free of React by
+design — the same discipline `graphProjection.ts` follows, and the reason its
+rules can be tested without rendering anything. It therefore cannot hold a `t`
+of its own, and it must not build one: a module-local plural table would be a
+second one next to the catalogues, which is exactly what #40 removed. So the
+module takes a `CountText` — `(noun, count) => string` over the three nouns it
+speaks — and `useCanvasCountText` is the single seam that resolves it against
+`common:count.*` for the two React callers. `count.relationship` was added to
+both catalogues for it; #40 had left it out for want of a caller.
+
+The consequence is worth stating plainly: until #42 migrates the `canvas`
+namespace, an English reader hears a **German frame around an English count** —
+`Container mit 10 components`. That is the same half-migrated state the visible
+canvas is already in (`10 components eingeklappt` on a closed box, from #34),
+and it is the correct intermediate: the count was the part that was actually
+*wrong* before, because a German plural table cannot say "1 component".
+
+### A node stays a `group` — what was missing was never the role
+
+React Flow already gives a focusable node `role="group"`. The obvious fix was to
+make it `role="button"` with `aria-pressed`, and that would have been wrong:
+a container renders a real disclosure `<button>` inside itself (ADR 0017), and
+`button` is one of the roles whose children are **presentational**. A node
+marked up as a button takes that toggle out of the accessibility tree — trading
+one unreachable thing for another. What was missing was never the role. It was
+the name.
+
+So the role stays `group`, and the two things a group cannot say are said
+otherwise:
+
+- **Selection travels as `aria-current`.** It is a *global* ARIA state, valid on
+  any role, and it means exactly what a canvas selection is: the current item
+  among a set of related ones. It is set only on the selected node —
+  `aria-current="false"` on the other 27 boxes is noise, not information.
+- **Container against leaf travels as `aria-roledescription`** —
+  `Architekturcontainer` against `Architekturkomponente` — plus the child count
+  in the name. The two are told apart by words rather than by the size of a box.
+
+**`aria-expanded` stays on the disclosure control, not on the node.** It belongs
+to the element that performs the disclosure, it is already there (ADR 0017), and
+`group` does not support it — duplicating it onto the node would be invalid ARIA
+that `aria-allowed-attr` flags. What the node carries instead is the *state* in
+words: a closed container announces that it is closed and how many components
+are behind it, the same number the closed box prints.
+
+The name is built as *identity* + *disclosure* + *state*:
+
+```
+Router, Modul, in HTTP Layer, geplant · hinzufügen
+└─ reported name  └─ kind   └─ container path   └─ work state, from overlayLabel
+```
+
+**Identity is qualified only as far as it has to be.** An agent may report the
+same name twice — a `Router` in the HTTP layer and a `Router` in the gRPC layer
+are two components with two ids. The name therefore starts as "name, kind",
+gains one container level at a time while it still collides with another, and
+falls back to the reported component id when even the full path is ambiguous
+(two identically named siblings of the same kind). A component whose name is
+already unambiguous does not drag its hierarchy along.
+
+The **work state and the disclosure are deliberately not part of the identity**.
+Both change while the user watches; an identity that moved with them would not
+be an identity. They are appended afterwards, and when nothing was reported the
+name says so explicitly — `kein Änderungsstatus gemeldet`. A screen reader must
+be able to tell "no state" from "state not conveyed", which is exactly the
+distinction the drawn box makes by carrying no mark.
+
+Two things the closed containers of ADR 0017 add to that:
+
+- a closed container says `eingeklappt, 3 Komponenten verborgen`, the same
+  number its box prints, so the picture and the announcement agree on what is
+  missing;
+- when the state on a closed container was rolled up from something *inside* it
+  (`rollUpOverlay`), the name says so. Without that the announcement would claim
+  the container is the element an agent is working on — which is the same class
+  of error the roll-up itself already avoids by dropping the operation.
+
+Edges are named from the same reported data the line is drawn from: the two
+endpoint names, every relationship the edge carries with its discriminator, and
+the count when it is a bundle. A bundle stays a rendering and never a merge
+(ADR 0008), so all three NATS topics are named individually in one label. Past
+six relationships — which a closed container can produce, because `collapse.ts`
+lifts hidden endpoints onto their nearest visible ancestor — the name switches
+to a count. That is a limit on the *name*, not on the data: unfolding the bundle
+still gives every single relationship its own label.
+
+The endpoint names come from `graph.nodes`, the nodes that are actually drawn.
+Because a lifted edge always ends on a *visible* ancestor, every endpoint of
+every drawn edge has a name and none can fall back to an id.
+
+### The focus ring is divided by the live zoom
+
+The canvas publishes its zoom as a CSS custom property on the drawing surface
+(`--vai-canvas-zoom`), written imperatively on every camera move — the wrapper
+carries no `style` prop, so React never overwrites it, and publishing costs no
+render. The stylesheet then declares
+
+```css
+outline-width: calc(var(--vai-focus-ring-width) / var(--vai-canvas-zoom));
+```
+
+which makes the **rendered** ring a constant number of CSS pixels instead of a
+constant number of model units. Measured in Chromium at 1920 × 1080 against
+`visualise-ai-self`:
+
+| zoom | declared `outline-width` | rendered ring |
+| --- | --- | --- |
+| 0.124 (canvas minimum) | 24 px | **2.99 px** |
+| 0.309 | 9 px | **2.79 px** |
+| 0.770 (entry zoom, ADR 0017) | 3 px | **2.31 px** |
+| 1.109 | 2 px | **2.22 px** |
+| 2.500 (canvas maximum) | 1 px | **2.50 px** |
+
+Before, at every one of those zoom levels: no outline at all. The remaining
+spread comes from Chromium snapping `outline-width` down to whole device pixels;
+it never approaches invisibility.
+
+The rules sit **outside every cascade layer** and carry one class more than
+React Flow's. Tailwind v4 uses real `@layer`, and unlayered CSS beats layered
+CSS regardless of specificity — a ring written inside `@layer components` would
+have lost to React Flow's unlayered `outline: none` no matter how specific it
+was, and no matter which stylesheet the bundler emitted first.
+
+### Keyboard activation is intercepted above React Flow
+
+One `onKeyDownCapture` on the canvas surface handles Enter, Space, Escape and
+the arrow keys for the focused node or edge. The capture phase is the only place
+that runs *before* React Flow's own handlers, and stopping the event there is
+the point:
+
+- **Enter and Space** write the `component` search parameter — the same path a
+  click takes, so URL, selection and inspector cannot drift apart (ADR 0008).
+  React Flow's internal, dropped selection never runs.
+- **Escape** clears the selection and, unlike React Flow's handler, does not
+  blur the node: a keyboard user must not lose their place.
+- **Arrow keys are swallowed.** React Flow would announce "Moved selected node
+  right. New position, x: …, y: …" over its aria-live region while nothing
+  moves, because the controlled graph drops the position change. Announcing a
+  change that did not happen is the same defect as not announcing one that did.
+- **A real control inside a node is left alone.** When the key comes from the
+  disclosure `<button>` of a container, the handler returns immediately: opening
+  a container and selecting one are two different intents (ADR 0017), and the
+  button is its own tab stop with its own action.
+
+Activating an edge unfolds a bundle or selects the single relationship — the two
+actions its badges already offer to the mouse, so a tab stop stops being a
+dead end.
+
+### The camera: one deliberate exception, and it is not a fit
+
+`autoPanOnNodeFocus` stays **on**, and is now written out explicitly rather than
+inherited as a default. Focusing a node that lies outside the viewport brings it
+into view at the same zoom.
+
+This is a decision, not an oversight. It is requested by the user's own Tab
+press, not by arriving data; it is the difference between a visible focus
+indicator and an invisible one (WCAG 2.4.7 and 2.4.11 are unsatisfiable
+otherwise); and it is **not a `fitView`**. The camera policy of ADR 0008 is
+untouched and no new automatic movement was added.
+
+**It became visible only after ADR 0017.** At the old entry zoom of 0.20 the
+whole model was inside the viewport, so the pan never fired and the viewport
+transform stayed byte-identical through a full keyboard walk. At the readable
+entry zoom of 0.77 a large model no longer fits, and tabbing to a node outside
+the viewport now really pans — measured against `visualise-ai-self`:
+`translate(27.8409px, 213.362px) scale(0.77)` →
+`translate(410.97px, 15.665px) scale(0.77)`.
+
+So the guarantee has to be stated precisely, and it is the one the tests assert:
+
+| | keyboard focus / selection |
+| --- | --- |
+| `data-fit-view-count` | never moves |
+| zoom | never changes |
+| pan | follows the focus, and only the focus |
+
+The alternative — switching `autoPanOnNodeFocus` off — would put the focus ring
+on a node nobody can see, which is a worse answer to the same question this ADR
+exists for.
+
+### Automated coverage, and where it stops
+
+`axe-core` runs over the architecture pane and the inspector pane after a
+keyboard selection, so the graph, the selection and the hand-over to the
+inspector are audited in one pass. Two boundaries are explicit:
+
+- **Colour rules are disabled**, because jsdom has neither layout nor rendering
+  and `color-contrast` would be undecidable rather than passing. That colour is
+  never the only channel is asserted where it is decided — `workStates.test.ts`
+  requires a label, an icon and a line style next to every hue.
+- **The audit is scoped to the two panes.** Over the whole page axe additionally
+  reports the two resize handles of the workspace layout under `region` ("all
+  page content should be contained by landmarks"): they sit *between* the panes
+  and therefore inside none of them. That is a best-practice finding about the
+  workspace shell (#7, touched again by #41), not about the architecture graph,
+  and disabling the rule globally here would have hidden it for the panes too.
+
+## Consequences
+
+- The node label is the only place a component's identity is spelled out for
+  assistive technology. A future change to what a node *shows* has to change
+  what it *says* in the same commit; `ArchitectureAccessibility.test.tsx`
+  compares the two channels node by node and fails when they diverge.
+- Names get longer in deep hierarchies with repeated component names. That is
+  the price of uniqueness, and it is paid only where a collision exists.
+- Only what is **drawn** is named. `graph.nodes` is already the collapsed graph
+  (ADR 0017), so a component behind a closed container is neither a tab stop nor
+  an accessible name — the accessibility tree and the picture contain the same
+  set of things. Tests that need every component say so with
+  `renderApp(path, { expandAllComponents: true })`.
+- The disclosure control's accessible name is built here
+  (`nodeDisclosureLabel`) from the verbs `DISCLOSURE_LABELS` already owns, so the
+  button, its tooltip and its accessible name cannot drift into three different
+  words — at the cost of a dependency from `ComponentNode` onto this module.
+- `axe-core` is a new dev dependency. It does not enter the bundle.
+- The German strings stay hard-coded, in `CANVAS_A11Y_TEXT` and
+  `DISCLOSURE_LABELS`. ADR 0014 puts accessible names squarely in the
+  *translated* half of the contract; migrating the `canvas` namespace is #42,
+  and both collections exist so that migration is a move, not a hunt.
+- A name is now built from two sources with different lifetimes — the German
+  scaffolding here and the counted nouns in the catalogues. Adding a counted
+  noun means adding it to `de` and `en`; `check:locales` fails otherwise, which
+  is the intended way to find out.
+- The React Flow strings that are *not* replaced (`aria-roledescription="node"`
+  is overridden per element, the aria-live message is unreachable) remain
+  English in the library. If a future version starts using them, the config in
+  `CANVAS_ARIA_LABEL_CONFIG` is where they get German text.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^5.0.0",
+        "axe-core": "^4.12.1",
         "eslint": "^9.39.0",
         "eslint-plugin-react-hooks": "^7.0.0",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -4678,6 +4679,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/bail": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "axe-core": "^4.12.1",
     "eslint": "^9.39.0",
     "eslint-plugin-react-hooks": "^7.0.0",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/frontend/src/canvas/ArchitectureAccessibility.test.tsx
+++ b/frontend/src/canvas/ArchitectureAccessibility.test.tsx
@@ -1,0 +1,611 @@
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import axe from 'axe-core'
+import { describe, expect, it } from 'vitest'
+
+import type { ArchitectureResponse, ComponentId } from '@/api/types'
+import { useUiStore } from '@/state/uiStore'
+import {
+  NESTED_COMPONENTS,
+  activeChange,
+  architectureWithChanges,
+  nestedArchitectureResponse,
+} from '@/test/architectureFixtures'
+import {
+  PROJECT_ID,
+  RUN_ID,
+  agent,
+  createFakeFetch,
+  historyResponse,
+  inspectorResponse,
+} from '@/test/fixtures'
+import { renderApp } from '@/test/renderApp'
+
+import { CANVAS_A11Y_TEXT } from './canvasAccessibility'
+
+/**
+ * The accessible architecture graph, exercised through the real application.
+ *
+ * `canvasAccessibility.test.ts` covers how a name is built. This file covers
+ * what a keyboard and a screen reader actually get out of the rendered
+ * cockpit — the graph, the selection and the hand-over to the inspector, which
+ * is the acceptance criterion of #35.
+ */
+
+const WORKSPACE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}`
+const ARCHITECTURE_PATH = `/api/v1/projects/${PROJECT_ID}/architecture`
+
+/** ELK runs for real in these tests; it needs a moment on a nested model. */
+const CANVAS_TIMEOUT = 15_000
+
+/**
+ * A read-API double whose inspector answers for the component that was asked
+ * for, so "the inspector shows what the keyboard selected" is a real assertion
+ * rather than a canned body.
+ */
+function accessibleFetch(architecture: ArchitectureResponse = nestedArchitectureResponse) {
+  return createFakeFetch({
+    [ARCHITECTURE_PATH]: architecture,
+    ...Object.fromEntries(
+      NESTED_COMPONENTS.map((component) => [
+        `/api/v1/projects/${PROJECT_ID}/components/${component.componentId}`,
+        {
+          ...inspectorResponse,
+          component,
+          responsibleAgent: agent(),
+        },
+      ]),
+    ),
+    ...Object.fromEntries(
+      NESTED_COMPONENTS.map((component) => [
+        `/api/v1/projects/${PROJECT_ID}/components/${component.componentId}/history`,
+        historyResponse,
+      ]),
+    ),
+  })
+}
+
+/**
+ * Renders the workspace with **every** container open.
+ *
+ * A project otherwise opens on its top levels with deeper containers collapsed
+ * (ADR 0017), and a component behind a closed container is deliberately not in
+ * the DOM and not a tab stop. These tests are about what a screen reader gets
+ * from a *drawn* node, so they draw all of them; the closed case has its own
+ * block below.
+ */
+function renderGraph(url = WORKSPACE_URL, architecture = nestedArchitectureResponse) {
+  return renderApp(url, {
+    fetchImpl: accessibleFetch(architecture),
+    expandAllComponents: true,
+  })
+}
+
+/** Renders the workspace on the disclosure a project actually opens with. */
+function renderCollapsedGraph(
+  url = WORKSPACE_URL,
+  architecture = nestedArchitectureResponse,
+) {
+  return renderApp(url, { fetchImpl: accessibleFetch(architecture) })
+}
+
+async function waitForCanvas(): Promise<HTMLElement> {
+  const canvas = await screen.findByTestId('architecture-canvas', undefined, {
+    timeout: CANVAS_TIMEOUT,
+  })
+  await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'), {
+    timeout: CANVAS_TIMEOUT,
+  })
+  // ELK is loaded through a dynamic import and runs off the render pass, so
+  // "not laying out" is reached one tick before the first node is in the DOM.
+  await waitFor(
+    () => expect(document.querySelectorAll('.react-flow__node').length).toBeGreaterThan(0),
+    { timeout: CANVAS_TIMEOUT },
+  )
+  return canvas
+}
+
+/** Every node React Flow made a tab stop, as the accessibility tree sees it. */
+function nodeElements(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>('.react-flow__node')]
+}
+
+function nodeElement(componentId: ComponentId): HTMLElement {
+  const element = document.querySelector<HTMLElement>(
+    `.react-flow__node[data-id="${componentId}"]`,
+  )
+  if (!element) throw new Error(`no node rendered for ${componentId}`)
+  return element
+}
+
+function viewportTransform(): string {
+  return document.querySelector<HTMLElement>('.react-flow__viewport')?.style.transform ?? ''
+}
+
+describe('accessible architecture graph — every node arrives named', () => {
+  it(
+    'gives every focusable node a role, a role description and a unique name',
+    async () => {
+      renderGraph()
+      await waitForCanvas()
+
+      const nodes = nodeElements()
+      expect(nodes.length).toBe(NESTED_COMPONENTS.length)
+
+      const names: string[] = []
+      for (const node of nodes) {
+        // Before this change every one of these was an *unnamed* group. The
+        // role stays `group` — a container holds a real disclosure button, and
+        // a widget role would make that child presentational.
+        expect(node).toHaveAttribute('tabindex', '0')
+        expect(node).toHaveAttribute('role', 'group')
+        const name = node.getAttribute('aria-label')
+        expect(name).toBeTruthy()
+        names.push(name as string)
+      }
+      expect(new Set(names).size).toBe(nodes.length)
+
+      // A container and a leaf are told apart by words, not by box size.
+      expect(nodeElement('platform.core')).toHaveAttribute(
+        'aria-roledescription',
+        CANVAS_A11Y_TEXT.containerRoleDescription,
+      )
+      expect(nodeElement('platform.db')).toHaveAttribute(
+        'aria-roledescription',
+        CANVAS_A11Y_TEXT.componentRoleDescription,
+      )
+      expect(nodeElement('platform.core').getAttribute('aria-label')).toContain(
+        'Container mit 2 Komponenten',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'is reachable by its accessible name and names the whole surface',
+    async () => {
+      renderGraph()
+      await waitForCanvas()
+
+      expect(
+        screen.getByRole('group', { name: /^Orders DB, Datenspeicher/ }),
+      ).toBe(nodeElement('platform.db'))
+
+      const flow = document.querySelector('.react-flow')
+      expect(flow).toHaveAttribute('aria-label', CANVAS_A11Y_TEXT.graphLabel)
+      const describedBy = flow?.getAttribute('aria-describedby') ?? ''
+      expect(document.getElementById(describedBy)?.textContent).toBe(
+        CANVAS_A11Y_TEXT.graphInstructions,
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'replaces React Flow’s English node description, which offered deleting',
+    async () => {
+      renderGraph()
+      await waitForCanvas()
+
+      const node = nodeElement('platform.db')
+      const description = document.getElementById(
+        node.getAttribute('aria-describedby') ?? '',
+      )
+      expect(description?.textContent).toBe(CANVAS_A11Y_TEXT.nodeInstructions)
+      expect(description?.textContent).not.toMatch(/delete|remove/i)
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'names every edge from the reported relationship instead of from its ids',
+    async () => {
+      renderGraph()
+      await waitForCanvas()
+
+      const edges = [...document.querySelectorAll('.react-flow__edge')]
+      expect(edges.length).toBeGreaterThan(0)
+      for (const edge of edges) {
+        const name = edge.getAttribute('aria-label') ?? ''
+        expect(name).not.toMatch(/^Edge from /)
+        expect(name).toContain('Beziehung von ')
+        expect(edge).toHaveAttribute(
+          'aria-roledescription',
+          CANVAS_A11Y_TEXT.relationshipRoleDescription,
+        )
+      }
+
+      // The bundle says how many relationships it carries and lists all three.
+      const bundle = document.querySelector(
+        '.react-flow__edge[data-id="rel:platform.core.orders~>platform.bus"]',
+      )
+      const bundleName = bundle?.getAttribute('aria-label') ?? ''
+      expect(bundleName).toContain('Sammelkante mit 3 Beziehungen')
+      for (const channel of ['orders.created', 'orders.cancelled', 'orders.shipped']) {
+        expect(bundleName).toContain(channel)
+      }
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('accessible architecture graph — selection by keyboard alone', () => {
+  it(
+    'selects with Enter, writes the URL and hands the component to the inspector',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderGraph()
+      await waitForCanvas()
+
+      const node = nodeElement('platform.db')
+      expect(node).not.toHaveAttribute('aria-current')
+
+      node.focus()
+      expect(document.activeElement).toBe(node)
+      await user.keyboard('{Enter}')
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ component: 'platform.db' }),
+      )
+      await waitFor(() =>
+        expect(nodeElement('platform.db')).toHaveAttribute('aria-current', 'true'),
+      )
+      // Visual and accessible state stay one thing, not two.
+      expect(
+        within(nodeElement('platform.db')).getByTestId('canvas-node-platform.db'),
+      ).toHaveAttribute('data-selected', 'true')
+
+      // The inspector really followed the keyboard.
+      const inspector = screen.getByTestId('pane-inspector')
+      await waitFor(() => expect(inspector).toHaveTextContent('Orders DB'))
+
+      // Focus stayed where the user put it.
+      expect(document.activeElement).toBe(nodeElement('platform.db'))
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'selects with the space bar and toggles the selection off again',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderGraph()
+      await waitForCanvas()
+
+      nodeElement('platform.bus').focus()
+      await user.keyboard('[Space]')
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ component: 'platform.bus' }),
+      )
+
+      nodeElement('platform.bus').focus()
+      await user.keyboard('[Space]')
+      await waitFor(() => expect(router.state.location.search).toEqual({}))
+      expect(nodeElement('platform.bus')).not.toHaveAttribute('aria-current')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'clears the selection with Escape without throwing the focus away',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderGraph(`${WORKSPACE_URL}?component=platform.db`)
+      await waitForCanvas()
+
+      await waitFor(() =>
+        expect(nodeElement('platform.db')).toHaveAttribute('aria-current', 'true'),
+      )
+
+      nodeElement('platform.db').focus()
+      await user.keyboard('{Escape}')
+
+      await waitFor(() => expect(router.state.location.search).toEqual({}))
+      expect(document.activeElement).toBe(nodeElement('platform.db'))
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'lets Escape travel on when there is nothing to deselect',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderGraph(`${WORKSPACE_URL}?focus=feedback`)
+      await waitForCanvas()
+      await waitFor(() => expect(router.state.location.search).toEqual({ focus: 'feedback' }))
+
+      // Nothing is selected, so the canvas must not swallow the key — deep
+      // focus is the layer that owns Escape here.
+      nodeElement('platform.db').focus()
+      await user.keyboard('{Escape}')
+
+      await waitFor(() => expect(router.state.location.search).toEqual({}))
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'never announces a node movement that a read-only canvas does not perform',
+    async () => {
+      const user = userEvent.setup()
+      renderGraph(`${WORKSPACE_URL}?component=platform.db`)
+      await waitForCanvas()
+
+      const node = nodeElement('platform.db')
+      node.focus()
+      await user.keyboard('{ArrowRight}{ArrowDown}{ArrowLeft}{ArrowUp}')
+
+      const live = [...document.querySelectorAll('[aria-live]')]
+      expect(live.length).toBeGreaterThan(0)
+      for (const region of live) expect(region.textContent).toBe('')
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+/**
+ * The progressive disclosure of #34 (ADR 0017), from the accessibility side.
+ *
+ * A collapsed container is a different picture — fewer boxes, a stacked edge,
+ * a count of what is behind it — and it has to be a different announcement.
+ */
+describe('accessible architecture graph — a closed container says so', () => {
+  it(
+    'draws only the open levels and names each of them',
+    async () => {
+      renderCollapsedGraph()
+      await waitForCanvas()
+
+      const nodes = nodeElements()
+      // Deeper containers start closed, so this is deliberately *not* all 10.
+      expect(nodes.length).toBeLessThan(NESTED_COMPONENTS.length)
+      for (const node of nodes) {
+        expect(node.getAttribute('aria-label')).toBeTruthy()
+      }
+      // What is behind a closed container is not drawn and is not a tab stop.
+      expect(
+        document.querySelector('.react-flow__node[data-id="platform.api.http.router"]'),
+      ).toBeNull()
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'says that it is closed, how much is behind it, and offers a named control',
+    async () => {
+      renderCollapsedGraph()
+      await waitForCanvas()
+
+      const container = nodeElement('platform.api')
+      const name = container.getAttribute('aria-label') ?? ''
+      expect(name).toContain('API Gateway')
+      expect(name).toContain('eingeklappt')
+
+      // The visible count and the announced count are the same number.
+      const hidden = within(container).getByTestId('node-hidden-count').textContent ?? ''
+      const hiddenCount = Number(/(\d+)/.exec(hidden)?.[1])
+      expect(hiddenCount).toBeGreaterThan(0)
+      expect(name).toContain(`${hiddenCount} Komponenten verborgen`)
+
+      // The disclosure control is a real, separately reachable button, and it
+      // names the container it belongs to rather than only its action.
+      const toggle = screen.getByTestId('node-disclosure-platform.api')
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      expect(toggle.getAttribute('aria-label')).toBe(
+        `Aufklappen: API Gateway (${hiddenCount} Komponenten)`,
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'opens a container from the keyboard without selecting it or moving the camera',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCollapsedGraph()
+      const canvas = await waitForCanvas()
+
+      const transformBefore = viewportTransform()
+      const toggle = screen.getByTestId('node-disclosure-platform.api')
+      toggle.focus()
+      expect(document.activeElement).toBe(toggle)
+
+      // Enter on the toggle must open the container — not select the node it
+      // sits in. The canvas keyboard handler leaves real controls alone.
+      await user.keyboard('{Enter}')
+
+      await waitFor(
+        () =>
+          expect(
+            document.querySelector('.react-flow__node[data-id="platform.api.http"]'),
+          ).not.toBeNull(),
+        { timeout: CANVAS_TIMEOUT },
+      )
+      await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'), {
+        timeout: CANVAS_TIMEOUT,
+      })
+
+      expect(router.state.location.search).toEqual({})
+      expect(screen.getByTestId('node-disclosure-platform.api')).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      )
+      expect(nodeElement('platform.api').getAttribute('aria-label')).not.toContain(
+        'eingeklappt',
+      )
+      // Opening rearranges the boxes; it does not move the camera (ADR 0008).
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+      expect(viewportTransform()).toBe(transformBefore)
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('accessible architecture graph — the state a screen reader hears is the state on screen', () => {
+  it(
+    'announces the reported work state with the same words the mark carries',
+    async () => {
+      renderGraph(WORKSPACE_URL, architectureWithChanges([activeChange()]))
+      await waitForCanvas()
+
+      const proposal = await screen.findByTestId(
+        'canvas-node-platform.core.shipping',
+        undefined,
+        { timeout: CANVAS_TIMEOUT },
+      )
+      // What the box says…
+      expect(proposal).toHaveAttribute('data-work-state', 'planned')
+      expect(proposal).toHaveAttribute('data-presence', 'proposal')
+
+      // …is what the accessible name says.
+      const name = nodeElement('platform.core.shipping').getAttribute('aria-label') ?? ''
+      expect(name).toContain('Shipping')
+      expect(name).toContain('geplant · hinzufügen')
+      expect(name).toContain(CANVAS_A11Y_TEXT.proposalNote)
+      // …and it is a phase of work, never a verdict.
+      expect(name).not.toMatch(/gut|schlecht|Fehler|riskant/i)
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'says explicitly when an agent reported nothing about a component',
+    async () => {
+      renderGraph()
+      await waitForCanvas()
+
+      for (const node of nodeElements()) {
+        const inner = node.querySelector('[data-component-id]')
+        const label = node.getAttribute('aria-label') ?? ''
+        if (inner?.getAttribute('data-work-state') === null) {
+          expect(label).toContain(CANVAS_A11Y_TEXT.noWorkState)
+        }
+      }
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+/**
+ * What the keyboard may and may not do to the camera.
+ *
+ * Two different guarantees, and they are worth keeping apart:
+ *
+ * * **No fit, ever.** `data-fit-view-count` counts the one automatic movement
+ *   of the first model plus explicit user requests. Focusing, selecting and
+ *   deselecting never touch it.
+ * * **No zoom change, ever.** The scale the user is reading at is theirs.
+ *
+ * A **pan** is a different matter. React Flow's `autoPanOnNodeFocus` brings a
+ * node that lies outside the viewport into view at the same zoom, and it is
+ * deliberately left on (ADR 0018): since ADR 0017 the entry zoom is 0.77 rather
+ * than 0.20, so a large model no longer fits on screen and a focus ring on an
+ * off-screen node would be a ring nobody can see. That pan is requested by the
+ * user's own Tab press — never by arriving data.
+ */
+describe('accessible architecture graph — the camera stays where the user left it', () => {
+  it(
+    'never fits and never changes the zoom while the keyboard walks the graph',
+    async () => {
+      const user = userEvent.setup()
+      const canvas = await (async () => {
+        renderGraph()
+        return waitForCanvas()
+      })()
+
+      await waitFor(() => expect(canvas.getAttribute('data-fit-view-count')).toBe('1'))
+      const zoomBefore = useUiStore.getState().camera.zoom
+
+      for (const node of nodeElements()) node.focus()
+      nodeElement('platform.core.orders').focus()
+      await user.keyboard('{Enter}')
+
+      await waitFor(() =>
+        expect(nodeElement('platform.core.orders')).toHaveAttribute(
+          'aria-current',
+          'true',
+        ),
+      )
+
+      // The one automatic fit of the first model, and nothing on top of it.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+      expect(useUiStore.getState().camera.zoom).toBe(zoomBefore)
+      expect(viewportTransform()).toContain(`scale(${zoomBefore})`)
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'publishes the live zoom so the focus ring can stay a constant width',
+    async () => {
+      renderGraph()
+      const canvas = await waitForCanvas()
+
+      const published = canvas.style.getPropertyValue('--vai-canvas-zoom')
+      expect(Number(published)).toBeGreaterThan(0)
+      expect(Number(published)).toBeCloseTo(useUiStore.getState().camera.zoom, 5)
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('accessible architecture graph — automated audit', () => {
+  /**
+   * axe-core over the two panes this issue is about, run against the rendered
+   * DOM after a keyboard selection — the graph, the selection and the
+   * hand-over to the inspector in one pass.
+   *
+   * Two deliberate boundaries:
+   *
+   * * **Colour rules are off.** jsdom has neither layout nor rendering, so
+   *   `color-contrast` is undecidable there rather than passing. That colour is
+   *   never the only channel is asserted where it is decided —
+   *   `workStates.test.ts` requires a label, an icon and a line style next to
+   *   every hue.
+   * * **The audit is scoped to the two panes.** Run over the whole page, axe
+   *   additionally reports the two resize handles of the workspace layout under
+   *   `region` ("all page content should be contained by landmarks"): they sit
+   *   *between* the panes and therefore inside none of them. That is a
+   *   best-practice finding about the workspace shell (#7/#41), not about the
+   *   architecture graph, and silently disabling the rule here would hide it
+   *   for the panes too.
+   */
+  it(
+    'reports no violations for the graph, a selection and the inspector',
+    async () => {
+      const user = userEvent.setup()
+      renderGraph()
+      await waitForCanvas()
+
+      nodeElement('platform.db').focus()
+      await user.keyboard('{Enter}')
+      await waitFor(() =>
+        expect(screen.getByTestId('pane-inspector')).toHaveTextContent('Orders DB'),
+      )
+
+      const results = await axe.run(
+        {
+          include: [
+            ['[data-testid="pane-architecture"]'],
+            ['[data-testid="pane-inspector"]'],
+          ],
+        },
+        {
+          resultTypes: ['violations'],
+          rules: { 'color-contrast': { enabled: false } },
+        },
+      )
+
+      const summary = results.violations.map(
+        (violation) =>
+          `${violation.id}: ${violation.help} (${violation.nodes.length}×) — ` +
+          violation.nodes
+            .map((node) => node.target.join(' '))
+            .slice(0, 3)
+            .join(' | '),
+      )
+      expect(summary).toEqual([])
+    },
+    CANVAS_TIMEOUT,
+  )
+})

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -15,7 +15,16 @@ import {
   type Viewport,
 } from '@xyflow/react'
 import { Layers2, Map, MapPinOff, Maximize2, RotateCcw, TriangleAlert } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
 
 import '@xyflow/react/dist/style.css'
 
@@ -33,6 +42,13 @@ import {
   viewportForBounds,
   type CameraPolicyState,
 } from './cameraPolicy'
+import {
+  CANVAS_A11Y_TEXT,
+  CANVAS_ARIA_LABEL_CONFIG,
+  componentNamesById,
+  withEdgeAccessibility,
+  withNodeAccessibility,
+} from './canvasAccessibility'
 import {
   DETAIL_LEVEL_DESCRIPTIONS,
   DETAIL_LEVEL_LABELS,
@@ -53,6 +69,7 @@ import {
   routesInvalidatedByDrag,
   useArchitectureGraph,
 } from './useArchitectureGraph'
+import { useCanvasCountText } from './useCanvasCountText'
 
 /**
  * The interactive architecture canvas.
@@ -75,6 +92,11 @@ import {
  *    `MIN_READABLE_ZOOM`, and a project opens on its top levels with deeper
  *    containers collapsed (`collapse.ts`). Both are undone by an explicit
  *    "Gesamtes Modell einpassen", never by anything the data does.
+ *
+ * The accessible surface — names, roles and states of the nodes and edges —
+ * lives in `./canvasAccessibility`; this component only wires it up, owns the
+ * keyboard activation and publishes the live zoom so the focus ring can stay a
+ * constant width inside the CSS transform (see `--vai-canvas-zoom`).
  */
 
 const MIN_ZOOM = 0.12
@@ -82,6 +104,18 @@ const MAX_ZOOM = 2.5
 
 const NODE_TYPES = ARCHITECTURE_NODE_TYPES
 const EDGE_TYPES = ARCHITECTURE_EDGE_TYPES
+
+/**
+ * Arrow keys reach React Flow's node handler, which announces "Moved selected
+ * node …" over an aria-live region. Nothing moves: the graph is fully
+ * controlled and has no `onNodesChange`, so the position change is dropped. The
+ * canvas therefore stops the keys before that announcement can be made — a
+ * screen reader must never be told about a change that did not happen.
+ */
+const ARROW_KEYS = new Set(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'])
+
+/** Keys that activate the focused node or edge. */
+const ACTIVATION_KEYS = new Set(['Enter', ' '])
 
 /**
  * Why the camera is being moved.
@@ -113,6 +147,9 @@ function ArchitectureCanvasInner({
   selectedComponentId,
   onSelectComponent,
 }: ArchitectureCanvasProps) {
+  // Counts the nouns the accessible names carry, in the reader's language
+  // (#40). Stable per language, so it does not invalidate the label memos.
+  const countText = useCanvasCountText()
   const collapsedComponentIds = useUiStore((state) => state.collapsedComponentIds)
   const setCollapsedComponentIds = useUiStore((state) => state.setCollapsedComponentIds)
   const setComponentCollapsed = useUiStore((state) => state.setComponentCollapsed)
@@ -136,6 +173,9 @@ function ArchitectureCanvasInner({
   const minimapVisible = useUiStore((state) => state.minimapVisible)
   const setMinimapVisible = useUiStore((state) => state.setMinimapVisible)
   const clearExpandedEdges = useUiStore((state) => state.clearExpandedEdges)
+  const toggleEdgeExpanded = useUiStore((state) => state.toggleEdgeExpanded)
+  const selectedRelationshipId = useUiStore((state) => state.selectedRelationshipId)
+  const setSelectedRelationshipId = useUiStore((state) => state.setSelectedRelationshipId)
 
   // The size of the drawing surface, as React Flow measures it. Subscribing
   // here is what lets the initial fit wait for the three panes to settle
@@ -146,6 +186,12 @@ function ArchitectureCanvasInner({
   const [detailLevel, setDetailLevel] = useState(() => detailLevelForZoom(camera.zoom))
   const [fitViewCount, setFitViewCount] = useState(0)
   const policyRef = useRef<CameraPolicyState>(INITIAL_CAMERA_POLICY)
+  // The drawing surface itself. Used to publish the live zoom to CSS, nothing
+  // else — the camera stays React Flow's.
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
+  // Id of the visually hidden description every screen reader gets when it
+  // enters the graph.
+  const instructionsId = `architecture-graph-instructions-${useId()}`
   // Flipped by the first pan or zoom that came from a real input event. From
   // then on the camera is the user's and nothing but "Einpassen" touches it.
   const userMovedCameraRef = useRef(false)
@@ -153,11 +199,42 @@ function ArchitectureCanvasInner({
   // camera change never re-mounts the flow.
   const [initialViewport] = useState<Viewport>(() => useUiStore.getState().camera)
 
+  // `graph.nodes` is already what `collapse.ts` left visible, so the accessible
+  // names describe exactly the boxes that are drawn — a component behind a
+  // closed container is not a tab stop and is not named as one.
   const nodes = useMemo(
     () =>
-      applyTemporaryPositions(graph.nodes, nodePositions, selectedComponentId ?? null),
-    [graph.nodes, nodePositions, selectedComponentId],
+      withNodeAccessibility(
+        applyTemporaryPositions(graph.nodes, nodePositions, selectedComponentId ?? null),
+        countText,
+      ),
+    [graph.nodes, nodePositions, selectedComponentId, countText],
   )
+
+  /**
+   * Publishes the live zoom as a CSS custom property on the surface.
+   *
+   * The canvas draws inside a CSS transform, so every length inside it is
+   * multiplied by the zoom: a 2 px focus ring is 0.4 px at zoom 0.2, which is
+   * no ring at all. The stylesheet divides the ring width by this value, which
+   * makes the rendered ring the same number of CSS pixels at every zoom level.
+   *
+   * Written imperatively on purpose. The wrapper carries no `style` prop, so
+   * React never overwrites the property, and publishing it does not cost a
+   * render on every frame of a pan.
+   */
+  const publishZoom = useCallback((zoom: number) => {
+    const surface = surfaceRef.current
+    if (!surface) return
+    const safe = Number.isFinite(zoom) && zoom > 0 ? zoom : 1
+    surface.style.setProperty('--vai-canvas-zoom', String(safe))
+    surface.setAttribute('data-canvas-zoom', safe.toFixed(4))
+  }, [])
+
+  useLayoutEffect(() => {
+    publishZoom(useUiStore.getState().camera.zoom)
+  }, [publishZoom])
+
   /**
    * Puts the currently drawn graph under the camera.
    *
@@ -198,8 +275,9 @@ function ArchitectureCanvasInner({
       void flow.setViewport(viewport)
       setCamera(viewport)
       setDetailLevel(detailLevelForZoom(viewport.zoom))
+      publishZoom(viewport.zoom)
     },
-    [flow, storeApi, setCamera],
+    [flow, storeApi, setCamera, publishZoom],
   )
 
   /**
@@ -301,14 +379,22 @@ function ArchitectureCanvasInner({
     fitView(pending.mode, pending.focusComponentId)
   }, [graph.isRelayouting, graph.nodes.length, graph.signature, fitView])
 
+  // Endpoint names for the edge labels. Derived from the laid-out graph rather
+  // than from `nodes`, so a selection — which changes nothing an edge says —
+  // does not rebuild every edge. `collapse.ts` lifts a hidden endpoint onto its
+  // nearest *visible* ancestor, so every endpoint of every drawn edge is a node
+  // of `graph.nodes` and no name can fall back to an id.
+  const nodeNames = useMemo(() => componentNamesById(graph.nodes), [graph.nodes])
+
   const edges = useMemo<ArchitectureEdge[]>(() => {
     const invalidated = routesInvalidatedByDrag(graph.edges, nodePositions)
-    return graph.edges.map((edge) => {
+    const routed = graph.edges.map((edge) => {
       const route = invalidated.has(edge.id) ? undefined : graph.routes[edge.id]
       if (!edge.data) return edge
       return { ...edge, data: { ...edge.data, ...(route ? { route } : {}) } }
     })
-  }, [graph.edges, graph.routes, nodePositions])
+    return withEdgeAccessibility(routed, nodeNames, countText)
+  }, [graph.edges, graph.routes, nodePositions, nodeNames, countText])
 
   const onNodeClick = useCallback<NodeMouseHandler>(
     (_event, node) => {
@@ -334,16 +420,107 @@ function ArchitectureCanvasInner({
   const onMove = useCallback(
     (_event: unknown, viewport: Viewport) => {
       setDetailLevel(detailLevelForZoom(viewport.zoom))
+      publishZoom(viewport.zoom)
     },
-    [],
+    [publishZoom],
   )
 
   const onMoveEnd = useCallback(
     (_event: unknown, viewport: Viewport) => {
       setCamera(viewport)
       setDetailLevel(detailLevelForZoom(viewport.zoom))
+      publishZoom(viewport.zoom)
     },
-    [setCamera],
+    [setCamera, publishZoom],
+  )
+
+  /**
+   * Keyboard activation of the focused node or edge.
+   *
+   * Handled in the **capture** phase, one level above React Flow, for two
+   * reasons: it is the only place that runs before React Flow's own node and
+   * edge key handling, and stopping the event there keeps the built-in
+   * behaviour — an internal selection this fully controlled graph drops on the
+   * floor, and an aria-live message about a move that never happens — from
+   * running at all.
+   *
+   * What is left is exactly what the canvas really does: activating a component
+   * writes the `component` search parameter, which is the same path a click
+   * takes, so the URL, the selection and the inspector cannot drift apart.
+   * Activating an edge unfolds a bundle or selects the single relationship —
+   * the same two actions its badges offer to the mouse.
+   *
+   * A real control *inside* a node — the disclosure toggle of a container — is
+   * left alone: it is its own tab stop with its own action, and a container
+   * that could not be opened from the keyboard would be worse than an unnamed
+   * one.
+   */
+  const onSurfaceKeyDownCapture = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const target = event.target
+      if (!(target instanceof Element)) return
+
+      const nodeElement = target.closest('.react-flow__node')
+      if (nodeElement) {
+        const control = target.closest('button, a[href], input, select, textarea')
+        if (control !== null && nodeElement.contains(control)) return
+
+        const componentId = nodeElement.getAttribute('data-id')
+        if (componentId === null) return
+        if (ACTIVATION_KEYS.has(event.key)) {
+          event.preventDefault()
+          event.stopPropagation()
+          onSelectComponent(componentId === selectedComponentId ? null : componentId)
+          return
+        }
+        if (event.key === 'Escape') {
+          // Only the *selection* is taken back here. With nothing selected the
+          // key travels on, so an Escape from a focused node can still leave
+          // deep focus — one Escape per layer, none of them swallowed.
+          if (selectedComponentId === undefined) return
+          event.preventDefault()
+          event.stopPropagation()
+          onSelectComponent(null)
+          return
+        }
+        // Swallowed, never announced. See ARROW_KEYS.
+        if (ARROW_KEYS.has(event.key)) event.stopPropagation()
+        return
+      }
+
+      const edgeElement = target.closest('.react-flow__edge')
+      if (!edgeElement) return
+      const edgeId = edgeElement.getAttribute('data-id')
+      if (edgeId === null) return
+      if (!ACTIVATION_KEYS.has(event.key) && event.key !== 'Escape') return
+      if (event.key === 'Escape' && selectedRelationshipId === null) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      if (event.key === 'Escape') {
+        setSelectedRelationshipId(null)
+        return
+      }
+      const edge = edges.find((candidate) => candidate.id === edgeId)
+      const relationships = edge?.data?.relationships ?? []
+      if (relationships.length > 1) {
+        toggleEdgeExpanded(edgeId)
+        return
+      }
+      const only = relationships[0]
+      if (!only) return
+      setSelectedRelationshipId(
+        only.relationshipId === selectedRelationshipId ? null : only.relationshipId,
+      )
+    },
+    [
+      edges,
+      onSelectComponent,
+      selectedComponentId,
+      selectedRelationshipId,
+      setSelectedRelationshipId,
+      toggleEdgeExpanded,
+    ],
   )
 
   /**
@@ -402,7 +579,9 @@ function ArchitectureCanvasInner({
   // checkable from the outside.
   return (
     <div
+      ref={surfaceRef}
       className="relative h-full w-full min-w-0"
+      onKeyDownCapture={onSurfaceKeyDownCapture}
       data-testid="architecture-canvas"
       data-fit-view-count={fitViewCount}
       data-detail-level={detailLevel}
@@ -420,6 +599,11 @@ function ArchitectureCanvasInner({
       data-layouting={graph.isRelayouting ? 'true' : 'false'}
     >
       <EdgeMarkerDefs />
+      {/* Read out when a screen reader enters the graph: what is drawn here and
+          how it is operated — including that it cannot be edited. */}
+      <p id={instructionsId} className="sr-only" data-testid="canvas-instructions">
+        {CANVAS_A11Y_TEXT.graphInstructions}
+      </p>
       <CanvasNodeActionsContext value={nodeActions}>
         <ReactFlow
           nodes={nodes}
@@ -445,7 +629,14 @@ function ArchitectureCanvasInner({
           proOptions={{ hideAttribution: false }}
           attributionPosition="bottom-left"
           className="bg-canvas"
-          aria-label="Interaktiver Architekturgraph"
+          // Keyboard focus may bring a node that sits outside the viewport into
+          // view. That is a deliberate exception and the only one: it is
+          // requested by the user's own Tab press, it keeps the zoom, and it is
+          // not a `fitView` — `data-fit-view-count` does not move (ADR 0018).
+          autoPanOnNodeFocus
+          ariaLabelConfig={CANVAS_ARIA_LABEL_CONFIG}
+          aria-label={CANVAS_A11Y_TEXT.graphLabel}
+          aria-describedby={instructionsId}
         >
           <Background
             variant={BackgroundVariant.Dots}

--- a/frontend/src/canvas/ComponentNode.tsx
+++ b/frontend/src/canvas/ComponentNode.tsx
@@ -8,11 +8,13 @@ import { cn } from '@/lib/utils'
 import { WORK_STATE_BY_ID } from '@/state/workStates'
 
 import { ChangeOverlayMark } from './ChangeOverlayMark'
+import { nodeDisclosureLabel } from './canvasAccessibility'
 import type { ChangeOverlay } from './changeOverlays'
 import { componentKindStyle, componentTags, technologyParts } from './componentKinds'
 import { DISCLOSURE_LABELS, showsTags, showsTechnology } from './detailLevel'
 import { HANDLE_IDS, type ArchitectureNode } from './graphProjection'
 import { CanvasNodeActionsContext } from './nodeActions'
+import { useCanvasCountText } from './useCanvasCountText'
 import { useDetailLevel } from './useDetailLevel'
 
 /**
@@ -61,6 +63,8 @@ function overlayBoxProps(overlay: ChangeOverlay | null, applied: boolean) {
 
 interface DisclosureToggleProps {
   componentId: ComponentId
+  /** Reported name of the container this toggle belongs to. */
+  componentName: string
   collapsed: boolean
   /** Components hidden behind this container right now. */
   hiddenCount: number
@@ -72,20 +76,39 @@ interface DisclosureToggleProps {
  * `nodrag`/`nopan` stop React Flow from turning the press into a node drag or a
  * canvas pan, and `stopPropagation` keeps it from also selecting the node —
  * opening a container and choosing one are two different intents.
+ *
+ * The visible `title` stays the short action; the **accessible** name names the
+ * container as well (`nodeDisclosureLabel`, #35). A screen reader reaches this
+ * button out of context — a canvas full of controls that all announce
+ * "Aufklappen" says what would happen but never to what.
  */
-function DisclosureToggle({ componentId, collapsed, hiddenCount }: DisclosureToggleProps) {
+function DisclosureToggle({
+  componentId,
+  componentName,
+  collapsed,
+  hiddenCount,
+}: DisclosureToggleProps) {
   const { t } = useTranslation('common')
+  const countText = useCanvasCountText()
   const { toggleCollapsed } = use(CanvasNodeActionsContext)
   const Icon = collapsed ? ChevronRight : ChevronDown
-  const label = collapsed
+  // The visible title counts through the locale-aware formatter (#40); the
+  // accessible name additionally says *which* container (#35).
+  const title = collapsed
     ? `${DISCLOSURE_LABELS.expand} (${t('count.component', { count: hiddenCount })})`
     : DISCLOSURE_LABELS.collapse
+  const label = nodeDisclosureLabel(
+    componentName,
+    !collapsed,
+    countText,
+    collapsed ? hiddenCount : undefined,
+  )
 
   return (
     <button
       type="button"
       className="nodrag nopan text-muted-foreground hover:text-foreground hover:bg-secondary/70 focus-visible:ring-ring -m-0.5 flex shrink-0 items-center gap-0.5 rounded-sm p-0.5 focus-visible:ring-2 focus-visible:outline-none"
-      title={label}
+      title={title}
       aria-label={label}
       aria-expanded={!collapsed}
       data-testid={`node-disclosure-${componentId}`}
@@ -273,6 +296,7 @@ export const CompoundNode = memo(function CompoundNode({
       >
         <DisclosureToggle
           componentId={component.componentId}
+          componentName={component.name}
           collapsed={collapsed === true}
           hiddenCount={collapsed ? hiddenCount : childCount}
         />

--- a/frontend/src/canvas/canvasAccessibility.test.ts
+++ b/frontend/src/canvas/canvasAccessibility.test.ts
@@ -1,0 +1,514 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AppliedComponent, Component } from '@/api/types'
+import { createI18n, type Language } from '@/i18n'
+import { WORK_STATES } from '@/state/workStates'
+import { appliedComponent, NESTED_COMPONENTS } from '@/test/architectureFixtures'
+
+import type { ChangeOverlay } from './changeOverlays'
+import { DISCLOSURE_LABELS } from './detailLevel'
+import {
+  CANVAS_A11Y_TEXT,
+  CANVAS_ARIA_LABEL_CONFIG,
+  edgeAccessibleName,
+  identifyingNames,
+  nodeAccessibleName,
+  nodeDisclosureLabel,
+  withEdgeAccessibility,
+  withNodeAccessibility,
+  componentNamesById,
+  workStatePhrase,
+  type CountText,
+} from './canvasAccessibility'
+import { projectArchitecture, type ArchitectureNode } from './graphProjection'
+
+/**
+ * The accessible surface of the canvas, tested where it is decided.
+ *
+ * These are the properties a screen reader depends on and a screenshot cannot
+ * show: that every node has a name, that no two names are the same, that the
+ * name says what the box says, and that nothing is announced which the agent
+ * did not report.
+ */
+
+/**
+ * The counting function the canvas passes in, built from the **real**
+ * catalogues.
+ *
+ * Not a stub: counted nouns are the one part of an accessible name that is
+ * already localised (#40), and a hand-written double here would prove that the
+ * plumbing works while saying nothing about whether `count.relationship`
+ * exists or whether German and English pluralise the same number the same way.
+ */
+function countTextFor(language: Language): CountText {
+  const instance = createI18n({ language })
+  return (noun, count) => instance.t(`count.${noun}`, { count, ns: 'common' })
+}
+
+const countText = countTextFor('de')
+
+function nodesOf(components: readonly AppliedComponent[]): ArchitectureNode[] {
+  return projectArchitecture({ components, relationships: [] }).nodes
+}
+
+function overlay(partial: Partial<ChangeOverlay> = {}): ChangeOverlay {
+  return {
+    targetKind: 'component',
+    targetId: 'platform.db',
+    state: 'planned',
+    presence: 'applied',
+    operation: 'add',
+    contributions: [],
+    agentIds: ['subagent-architecture-mapper'],
+    descriptor: null,
+    ...partial,
+  }
+}
+
+describe('canvas accessibility — every node is named', () => {
+  it('names a node after the reported component name and its kind', () => {
+    const nodes = nodesOf(NESTED_COMPONENTS)
+    const names = identifyingNames(nodes, countText)
+
+    expect(names.get('platform.db')).toBe('Orders DB, Datenspeicher')
+    expect(names.get('external.payments')).toBe('Payment Provider, Extern')
+  })
+
+  it('tells a container apart from a leaf, with the number of components in it', () => {
+    const names = identifyingNames(nodesOf(NESTED_COMPONENTS), countText)
+
+    // `platform.core` holds `orders` and `billing`.
+    expect(names.get('platform.core')).toBe('Core Services, Service, Container mit 2 Komponenten')
+    // A container with exactly one child says "Komponente", not "Komponenten".
+    expect(names.get('platform.api.http')).toBe('HTTP Layer, Modul, Container mit 1 Komponente')
+    expect(names.get('platform.api.http.router')).toBe('Router, Modul')
+  })
+
+  it('leaves the reported name, id and kind exactly as the agent reported them', () => {
+    const names = identifyingNames(nodesOf(NESTED_COMPONENTS), countText)
+    for (const component of NESTED_COMPONENTS) {
+      expect(names.get(component.componentId)).toContain(component.name)
+    }
+  })
+})
+
+describe('canvas accessibility — names stay unique', () => {
+  /**
+   * Nothing forbids an agent from reporting the same component name twice: a
+   * `Router` in the HTTP layer and a `Router` in the gRPC layer are two
+   * different components with two different ids. The picture tells them apart
+   * by where they sit; the accessible name has to do the same.
+   */
+  const SAME_NAME_IN_TWO_CONTAINERS: Component[] = [
+    { componentId: 'a', name: 'API Gateway', kind: 'service', parentComponentId: null },
+    { componentId: 'b', name: 'Worker Pool', kind: 'service', parentComponentId: null },
+    { componentId: 'a.router', name: 'Router', kind: 'module', parentComponentId: 'a' },
+    { componentId: 'b.router', name: 'Router', kind: 'module', parentComponentId: 'b' },
+  ]
+
+  it('qualifies two identically named components with their containers', () => {
+    const names = identifyingNames(
+      nodesOf(SAME_NAME_IN_TWO_CONTAINERS.map((one) => appliedComponent(one))),
+      countText,
+    )
+
+    expect(names.get('a.router')).toBe('Router, Modul, in API Gateway')
+    expect(names.get('b.router')).toBe('Router, Modul, in Worker Pool')
+    expect(names.get('a.router')).not.toBe(names.get('b.router'))
+  })
+
+  it('only qualifies the names that would otherwise collide', () => {
+    const withCache: Component[] = [
+      ...SAME_NAME_IN_TWO_CONTAINERS,
+      { componentId: 'a.cache', name: 'Cache', kind: 'datastore', parentComponentId: 'a' },
+    ]
+    const names = identifyingNames(
+      nodesOf(withCache.map((one) => appliedComponent(one))),
+      countText,
+    )
+
+    // `Cache` is unambiguous on its own and does not drag its container along.
+    expect(names.get('a.cache')).toBe('Cache, Datenspeicher')
+  })
+
+  it('walks further up when the direct container is not enough', () => {
+    const deep: Component[] = [
+      { componentId: 'eu', name: 'EU', kind: 'system', parentComponentId: null },
+      { componentId: 'us', name: 'US', kind: 'system', parentComponentId: null },
+      { componentId: 'eu.edge', name: 'Edge', kind: 'service', parentComponentId: 'eu' },
+      { componentId: 'us.edge', name: 'Edge', kind: 'service', parentComponentId: 'us' },
+      { componentId: 'eu.edge.router', name: 'Router', kind: 'module', parentComponentId: 'eu.edge' },
+      { componentId: 'us.edge.router', name: 'Router', kind: 'module', parentComponentId: 'us.edge' },
+    ]
+    const names = identifyingNames(
+      nodesOf(deep.map((one) => appliedComponent(one))),
+      countText,
+    )
+
+    expect(names.get('eu.edge.router')).toBe('Router, Modul, in Edge, in EU')
+    expect(names.get('us.edge.router')).toBe('Router, Modul, in Edge, in US')
+  })
+
+  it('falls back to the reported component id when even the path collides', () => {
+    const siblings: Component[] = [
+      { componentId: 'root', name: 'Platform', kind: 'system', parentComponentId: null },
+      { componentId: 'root.one', name: 'Worker', kind: 'module', parentComponentId: 'root' },
+      { componentId: 'root.two', name: 'Worker', kind: 'module', parentComponentId: 'root' },
+    ]
+    const names = identifyingNames(
+      nodesOf(siblings.map((one) => appliedComponent(one))),
+      countText,
+    )
+
+    expect(names.get('root.one')).toBe(
+      'Worker, Modul, in Platform, Komponenten-ID root.one',
+    )
+    expect(names.get('root.two')).toBe(
+      'Worker, Modul, in Platform, Komponenten-ID root.two',
+    )
+  })
+
+  it('gives every node of the nested snapshot a distinct name', () => {
+    const nodes = nodesOf(NESTED_COMPONENTS)
+    const names = [...identifyingNames(nodes, countText).values()]
+
+    expect(names).toHaveLength(nodes.length)
+    expect(new Set(names).size).toBe(nodes.length)
+  })
+})
+
+describe('canvas accessibility — the reported work state, in words', () => {
+  it('uses the one central definition and never a second vocabulary', () => {
+    for (const definition of WORK_STATES) {
+      const phrase = workStatePhrase(overlay({ state: definition.id, operation: null }), countText)
+      expect(phrase[0]).toBe(definition.label)
+    }
+  })
+
+  it('spells out the operation, so two states of the same colour differ in words', () => {
+    expect(workStatePhrase(overlay({ state: 'planned', operation: 'add' }), countText)).toEqual([
+      'geplant · hinzufügen',
+    ])
+    expect(workStatePhrase(overlay({ state: 'planned', operation: 'remove' }), countText)).toEqual([
+      'geplant · entfernen',
+    ])
+  })
+
+  it('says explicitly when nothing was reported', () => {
+    expect(workStatePhrase(null, countText)).toEqual([CANVAS_A11Y_TEXT.noWorkState])
+  })
+
+  it('marks a proposal and a ghost as not being part of the applied model', () => {
+    expect(workStatePhrase(overlay({ presence: 'proposal' }), countText)).toContain(
+      CANVAS_A11Y_TEXT.proposalNote,
+    )
+    expect(
+      workStatePhrase(overlay({ state: 'removed', operation: 'remove', presence: 'ghost' }), countText),
+    ).toContain(CANVAS_A11Y_TEXT.ghostNote)
+  })
+
+  it('counts the agents instead of dropping one of them', () => {
+    expect(workStatePhrase(overlay({ agentIds: ['a', 'b'] }), countText)).toContain(
+      '2 Agents melden dazu',
+    )
+  })
+
+  it('never adds a judgement of its own', () => {
+    const forbidden = /gut|schlecht|falsch|richtig|riskant|Fehler|Problem/i
+    const spoken = [
+      ...WORK_STATES.flatMap((definition) =>
+        workStatePhrase(overlay({ state: definition.id, operation: 'remove' }), countText),
+      ),
+      CANVAS_A11Y_TEXT.graphInstructions,
+      CANVAS_A11Y_TEXT.nodeInstructions,
+      CANVAS_A11Y_TEXT.edgeInstructions,
+    ]
+    for (const text of spoken) expect(text).not.toMatch(forbidden)
+  })
+})
+
+describe('canvas accessibility — the full node name', () => {
+  it('appends the reported state to the identity', () => {
+    const nodes = nodesOf(NESTED_COMPONENTS)
+    const node = nodes.find((one) => one.id === 'platform.db') as ArchitectureNode
+    const withState: ArchitectureNode = {
+      ...node,
+      data: { ...node.data, overlay: overlay({ state: 'active', operation: null }) },
+    }
+
+    expect(nodeAccessibleName(withState, 'Orders DB, Datenspeicher', countText)).toBe(
+      'Orders DB, Datenspeicher, aktiv',
+    )
+    expect(nodeAccessibleName(node, 'Orders DB, Datenspeicher', countText)).toBe(
+      'Orders DB, Datenspeicher, kein Änderungsstatus gemeldet',
+    )
+  })
+
+  it('says that a container is closed and how much is behind it', () => {
+    const nodes = nodesOf(NESTED_COMPONENTS)
+    const node = nodes.find((one) => one.id === 'platform.api') as ArchitectureNode
+    const closed: ArchitectureNode = {
+      ...node,
+      data: { ...node.data, collapsed: true, hiddenDescendantCount: 3 },
+    }
+
+    expect(nodeAccessibleName(closed, 'API Gateway, Service, Container mit 2 Komponenten', countText)).toBe(
+      'API Gateway, Service, Container mit 2 Komponenten, eingeklappt, 3 Komponenten verborgen, kein Änderungsstatus gemeldet',
+    )
+  })
+
+  it('does not claim a container is what an agent is working on inside it', () => {
+    const nodes = nodesOf(NESTED_COMPONENTS)
+    const node = nodes.find((one) => one.id === 'platform.api') as ArchitectureNode
+    const rolledUp: ArchitectureNode = {
+      ...node,
+      data: {
+        ...node.data,
+        collapsed: true,
+        hiddenDescendantCount: 3,
+        overlay: overlay({ state: 'active', operation: null }),
+        overlayRolledUp: true,
+      },
+    }
+
+    const name = nodeAccessibleName(rolledUp, 'API Gateway, Service', countText)
+    expect(name).toContain('aktiv')
+    expect(name).toContain(CANVAS_A11Y_TEXT.rolledUpNote)
+  })
+
+  it('keeps the group role, a role description and the current-item state', () => {
+    const nodes = withNodeAccessibility(
+      nodesOf(NESTED_COMPONENTS).map((node) =>
+        node.id === 'platform.db' ? { ...node, selected: true } : node,
+      ),
+      countText,
+    )
+
+    for (const node of nodes) {
+      // Not `button`: a container renders a real disclosure control inside it,
+      // and a widget role would make that child presentational.
+      expect(node.ariaRole).toBe('group')
+      expect(node.ariaLabel).toBeTruthy()
+      expect(node.domAttributes?.['aria-roledescription']).toBe(
+        node.data.isCompound
+          ? CANVAS_A11Y_TEXT.containerRoleDescription
+          : CANVAS_A11Y_TEXT.componentRoleDescription,
+      )
+    }
+
+    const selected = nodes.find((node) => node.id === 'platform.db')
+    expect(selected?.domAttributes?.['aria-current']).toBe(true)
+    // Absent rather than `false`: `aria-current="false"` means "not the current
+    // item" and is noise on 27 of 28 boxes.
+    expect(
+      nodes.find((node) => node.id === 'platform.bus')?.domAttributes,
+    ).not.toHaveProperty('aria-current')
+  })
+
+  it('names the disclosure control after the container it opens', () => {
+    expect(nodeDisclosureLabel('API Gateway', false, countText, 3)).toBe(
+      'Aufklappen: API Gateway (3 Komponenten)',
+    )
+    expect(nodeDisclosureLabel('API Gateway', false, countText)).toBe('Aufklappen: API Gateway')
+    expect(nodeDisclosureLabel('API Gateway', true, countText)).toBe('Einklappen: API Gateway')
+  })
+
+  it('takes the disclosure verbs from the collection #34 already owns', () => {
+    expect(nodeDisclosureLabel('X', false, countText)).toContain(DISCLOSURE_LABELS.expand)
+    expect(nodeDisclosureLabel('X', true, countText)).toContain(DISCLOSURE_LABELS.collapse)
+  })
+})
+
+describe('canvas accessibility — edges are named from what they carry', () => {
+  const projection = projectArchitecture({
+    components: NESTED_COMPONENTS,
+    relationships: [],
+  })
+  const names = componentNamesById(projection.nodes)
+
+  it('names a single relationship with its endpoints and its kind', () => {
+    const model = projectArchitecture({
+      components: NESTED_COMPONENTS,
+      relationships: [
+        {
+          relationshipId: 'r-03',
+          sourceComponentId: 'platform.core.orders',
+          targetComponentId: 'platform.db',
+          kind: 'data',
+          label: '',
+          protocol: 'SQL',
+          operation: 'SELECT/INSERT',
+          channel: '',
+          appliedAt: '2026-08-04T09:05:00Z',
+          appliedByAgentId: 'orchestrator-root',
+          appliedRunId: 'run-2026-08-04-0001',
+          position: 1,
+        },
+      ],
+    })
+    const edge = model.edges[0]
+    expect(edge).toBeDefined()
+    expect(edgeAccessibleName(edge!, names, countText)).toBe(
+      'Beziehung von Orders zu Orders DB, Datenzugriff SELECT/INSERT, kein Änderungsstatus gemeldet',
+    )
+  })
+
+  it('says how many relationships a bundle carries and lists every one of them', () => {
+    const topics = ['orders.created', 'orders.cancelled'].map((channel, index) => ({
+      relationshipId: `r-1${index}`,
+      sourceComponentId: 'platform.core.orders' as const,
+      targetComponentId: 'platform.bus' as const,
+      kind: 'nats_topic' as const,
+      label: '',
+      protocol: 'NATS',
+      operation: 'publish',
+      channel,
+      appliedAt: '2026-08-04T09:05:00Z',
+      appliedByAgentId: 'orchestrator-root',
+      appliedRunId: 'run-2026-08-04-0001',
+      position: index + 1,
+    }))
+    const model = projectArchitecture({
+      components: NESTED_COMPONENTS,
+      relationships: topics,
+    })
+    const edge = model.edges[0]
+    expect(edge).toBeDefined()
+
+    const label = edgeAccessibleName(edge!, names, countText)
+    expect(label).toContain('Sammelkante mit 2 Beziehungen')
+    // Both topics stay individually announced — a bundle is a rendering, not a
+    // merge (ADR 0008).
+    expect(label).toContain('orders.created')
+    expect(label).toContain('orders.cancelled')
+  })
+
+  it('marks every edge as a relationship and gives it a name', () => {
+    const model = projectArchitecture({
+      components: NESTED_COMPONENTS,
+      relationships: [],
+    })
+    for (const edge of withEdgeAccessibility(model.edges, names, countText)) {
+      expect(edge.ariaLabel).toBeTruthy()
+      expect(edge.domAttributes?.['aria-roledescription']).toBe(
+        CANVAS_A11Y_TEXT.relationshipRoleDescription,
+      )
+    }
+  })
+})
+
+describe('canvas accessibility — the instructions describe what is really there', () => {
+  it('replaces React Flow’s English defaults on both node description keys', () => {
+    expect(CANVAS_ARIA_LABEL_CONFIG['node.a11yDescription.default']).toBe(
+      CANVAS_A11Y_TEXT.nodeInstructions,
+    )
+    expect(CANVAS_ARIA_LABEL_CONFIG['node.a11yDescription.keyboardDisabled']).toBe(
+      CANVAS_A11Y_TEXT.nodeInstructions,
+    )
+  })
+
+  it('never offers deleting or moving — the cockpit only observes', () => {
+    const spoken = [
+      CANVAS_A11Y_TEXT.graphInstructions,
+      CANVAS_A11Y_TEXT.nodeInstructions,
+      CANVAS_A11Y_TEXT.edgeInstructions,
+    ]
+    for (const text of spoken) {
+      expect(text.toLowerCase()).not.toContain('löschen')
+      expect(text.toLowerCase()).not.toContain('verschieben')
+    }
+    expect(CANVAS_A11Y_TEXT.nodeInstructions).toContain('Enter oder Leertaste')
+    expect(CANVAS_A11Y_TEXT.graphInstructions).toContain('Tabulatortaste')
+  })
+})
+
+/**
+ * Counted nouns come from the catalogues, in the reader's language.
+ *
+ * This is the one part of an accessible name that is already localised (#40 /
+ * ADR 0019). The surrounding scaffolding is still German until #42 migrates the
+ * `canvas` namespace — but a screen reader reading English must not hear
+ * "1 Komponenten", and it must not hear a German plural either.
+ */
+describe('canvas accessibility — the counting follows the language', () => {
+  const containerOf = (language: Language, childCount: number): string => {
+    const nodes = nodesOf(NESTED_COMPONENTS)
+    const node = nodes.find((one) => one.id === 'platform.core') as ArchitectureNode
+    const sized: ArchitectureNode = { ...node, data: { ...node.data, childCount } }
+    return identifyingNames([sized], countTextFor(language)).get('platform.core') ?? ''
+  }
+
+  it('counts components in German and in English', () => {
+    expect(containerOf('de', 2)).toBe('Core Services, Service, Container mit 2 Komponenten')
+    expect(containerOf('en', 2)).toBe('Core Services, Service, Container mit 2 components')
+  })
+
+  it('uses the singular form of each language for exactly one', () => {
+    expect(containerOf('de', 1)).toContain('1 Komponente')
+    expect(containerOf('de', 1)).not.toContain('1 Komponenten')
+    expect(containerOf('en', 1)).toContain('1 component')
+    expect(containerOf('en', 1)).not.toContain('1 components')
+  })
+
+  it('counts the components a closed container hides, in both languages', () => {
+    const nodes = nodesOf(NESTED_COMPONENTS)
+    const node = nodes.find((one) => one.id === 'platform.api') as ArchitectureNode
+    const closed: ArchitectureNode = {
+      ...node,
+      data: { ...node.data, collapsed: true, hiddenDescendantCount: 3 },
+    }
+
+    expect(nodeAccessibleName(closed, 'API Gateway', countTextFor('de'))).toContain(
+      'eingeklappt, 3 Komponenten verborgen',
+    )
+    expect(nodeAccessibleName(closed, 'API Gateway', countTextFor('en'))).toContain(
+      'eingeklappt, 3 components verborgen',
+    )
+  })
+
+  it('counts the relationships of a bundle — the key #40 had no caller for', () => {
+    const topics = ['a', 'b'].map((channel, index) => ({
+      relationshipId: `r-2${index}`,
+      sourceComponentId: 'platform.core.orders' as const,
+      targetComponentId: 'platform.bus' as const,
+      kind: 'nats_topic' as const,
+      label: '',
+      protocol: 'NATS',
+      operation: 'publish',
+      channel,
+      appliedAt: '2026-08-04T09:05:00Z',
+      appliedByAgentId: 'orchestrator-root',
+      appliedRunId: 'run-2026-08-04-0001',
+      position: index + 1,
+    }))
+    const model = projectArchitecture({
+      components: NESTED_COMPONENTS,
+      relationships: topics,
+    })
+    const edge = model.edges[0]
+    expect(edge).toBeDefined()
+    const names = componentNamesById(model.nodes)
+
+    expect(edgeAccessibleName(edge!, names, countTextFor('de'))).toContain(
+      'Sammelkante mit 2 Beziehungen',
+    )
+    expect(edgeAccessibleName(edge!, names, countTextFor('en'))).toContain(
+      'Sammelkante mit 2 relationships',
+    )
+  })
+
+  it('counts the agents behind one element, in both languages', () => {
+    const twoAgents = overlay({ agentIds: ['a', 'b'] })
+    expect(workStatePhrase(twoAgents, countTextFor('de'))).toContain('2 Agents melden dazu')
+    expect(workStatePhrase(twoAgents, countTextFor('en'))).toContain('2 agents melden dazu')
+  })
+
+  it('names the disclosure control with a localised count', () => {
+    expect(nodeDisclosureLabel('Backend', false, countTextFor('de'), 10)).toBe(
+      'Aufklappen: Backend (10 Komponenten)',
+    )
+    expect(nodeDisclosureLabel('Backend', false, countTextFor('en'), 10)).toBe(
+      'Aufklappen: Backend (10 components)',
+    )
+  })
+})

--- a/frontend/src/canvas/canvasAccessibility.ts
+++ b/frontend/src/canvas/canvasAccessibility.ts
@@ -1,0 +1,487 @@
+import type { ComponentId } from '@/api/types'
+
+import { dominantOverlay, overlayLabel, type ChangeOverlay } from './changeOverlays'
+import { componentKindStyle } from './componentKinds'
+import { DISCLOSURE_LABELS } from './detailLevel'
+import type { ArchitectureEdge, ArchitectureNode } from './graphProjection'
+import { RELATIONSHIP_KIND_STYLE_BY_ID, relationshipDiscriminator } from './relationshipKinds'
+
+/**
+ * The accessible surface of the architecture canvas.
+ *
+ * React Flow makes every node and every edge a tab stop, but it names neither:
+ * a node arrives in the accessibility tree as an unnamed `group` with the
+ * roledescription `node`, and an edge as `Edge from <id> to <id>`. What the
+ * canvas draws — the component's name, its kind, whether it contains other
+ * components, and the work state an agent reported for it — is invisible to a
+ * screen reader. This module is the counterpart of the drawing code: it turns
+ * exactly the same facts into an accessible name.
+ *
+ * Four rules hold here and are covered by tests:
+ *
+ * 1. **Everything visible is announced, and nothing else is.** The work state
+ *    comes from `overlayLabel`, the single definition the boxes, the marks, the
+ *    legend and the inspector already use (`src/state/workStates.ts`). This
+ *    module never invents a second vocabulary and never adds a judgement: a
+ *    state is a phase of work, `entfernt` means "is being removed", not "bad".
+ * 2. **Reported data is passed through verbatim.** Component names,
+ *    component ids and technology strings are what an agent reported. They are
+ *    never translated, shortened or reworded — only the surrounding German
+ *    scaffolding is this module's own.
+ * 3. **Every accessible name is unique.** Two components may legitimately carry
+ *    the same reported name in two different containers. The name is therefore
+ *    qualified with as much of the container path as it takes to tell them
+ *    apart, and with the component id when even that is not enough.
+ * 4. **Colour is not a channel at all here.** A screen reader receives the
+ *    state as words, which is the same information the visible label, icon and
+ *    border style carry (ADR 0003).
+ *
+ * All German strings the canvas speaks live in `CANVAS_A11Y_TEXT` so the
+ * translation work of #42 has a single place to pull from. Counted nouns are
+ * the exception and deliberately so: they are already localised, and this
+ * module takes them as a `CountText` from its caller rather than owning a
+ * second plural table (ADR 0019).
+ */
+
+// ---------------------------------------------------------------------------
+// Counting
+// ---------------------------------------------------------------------------
+
+/** The counted nouns this module speaks. */
+export type CanvasCountNoun = 'component' | 'relationship' | 'agent'
+
+/**
+ * Turns a count into text in the reader's language — `10 Komponenten`,
+ * `10 components`, `1 Komponente`.
+ *
+ * Passed in rather than looked up. This module is pure and free of React by
+ * design (it is the counterpart of `graphProjection`), so it cannot hold a
+ * `t` of its own; and building one here would mean a second plural table,
+ * which is exactly what #40 removed. The two React callers —
+ * `ArchitectureCanvas` and `ComponentNode` — get theirs from
+ * `useCanvasCountText`, which resolves against the catalogues.
+ */
+export type CountText = (noun: CanvasCountNoun, count: number) => string
+
+// ---------------------------------------------------------------------------
+// The texts
+// ---------------------------------------------------------------------------
+
+/**
+ * Every accessible string of the canvas, in one object.
+ *
+ * Hard-coded German for now — the i18n migration is #42, and the translation
+ * contract of #38 already records that accessible names have to travel with it.
+ */
+export const CANVAS_A11Y_TEXT = {
+  /** Accessible name of the whole drawing surface. */
+  graphLabel: 'Interaktiver Architekturgraph',
+
+  /**
+   * Read out when the graph is entered. It describes what is there and how to
+   * operate it — and it stops at what the cockpit can actually do: v0 observes,
+   * it does not let anyone edit the reported architecture.
+   */
+  graphInstructions:
+    'Architekturgraph des Projekts. Mit der Tabulatortaste zwischen den Komponenten ' +
+    'und Beziehungen wechseln. Enter oder Leertaste wählt die fokussierte Komponente ' +
+    'aus und zeigt sie im Inspector; eine erneute Aktivierung hebt die Auswahl auf, ' +
+    'Escape ebenfalls. Jede Komponente nennt ihren gemeldeten Namen, ihre Art, ob sie ' +
+    'weitere Komponenten enthält, in welchem Container sie liegt und welchen ' +
+    'Änderungsstatus ein Agent für sie gemeldet hat. Der Graph ist eine Beobachtung: ' +
+    'das gemeldete Architekturmodell lässt sich hier nicht bearbeiten.',
+
+  /** Description attached to every node by React Flow. */
+  nodeInstructions:
+    'Enter oder Leertaste wählt diese Komponente aus und zeigt sie im Inspector. ' +
+    'Escape hebt die Auswahl auf. Die Komponente lässt sich nicht bearbeiten oder ' +
+    'entfernen — das Cockpit beobachtet nur.',
+
+  /** Description attached to every edge by React Flow. */
+  edgeInstructions:
+    'Enter oder Leertaste wählt diese Beziehung aus; bei einer Sammelkante klappt sie ' +
+    'die enthaltenen Beziehungen auf und wieder zu. Escape hebt die Auswahl auf.',
+
+  /** `aria-roledescription` of a component that contains other components. */
+  containerRoleDescription: 'Architekturcontainer',
+  /** `aria-roledescription` of a component without children. */
+  componentRoleDescription: 'Architekturkomponente',
+  /** `aria-roledescription` of a drawn relationship. */
+  relationshipRoleDescription: 'Architekturbeziehung',
+
+  /** Container part of a node name. Takes the already-counted noun. */
+  contains: (components: string) => `Container mit ${components}`,
+  /**
+   * Said by a container whose children are not drawn right now. Mirrors the
+   * "… eingeklappt" line the closed box shows, so the two channels say the same
+   * thing (#34 / ADR 0017).
+   */
+  collapsedNote: (components: string) => `eingeklappt, ${components} verborgen`,
+  /** One step of the container path. */
+  inContainer: (containerName: string) => `in ${containerName}`,
+  /** Last-resort qualifier when name, kind and container path still collide. */
+  identifiedBy: (componentId: ComponentId) => `Komponenten-ID ${componentId}`,
+
+  /** Said when an agent reported nothing about this element. */
+  noWorkState: 'kein Änderungsstatus gemeldet',
+  /** Said for an announced element that the applied model does not contain. */
+  proposalNote: 'angekündigt, noch nicht Teil des angewandten Architekturmodells',
+  /** Said for an element an applied change removed. */
+  ghostNote: 'nicht mehr Teil des angewandten Architekturmodells',
+  /**
+   * Said when the state on a closed container was reported for something
+   * *inside* it. Without this the name would claim the container itself is the
+   * element an agent is working on (`rollUpOverlay` in `collapse.ts`).
+   */
+  rolledUpNote: 'gemeldet für eine eingeklappte Komponente darin',
+
+  /** Direction part of an edge name. */
+  fromTo: (sourceName: string, targetName: string) =>
+    `Beziehung von ${sourceName} zu ${targetName}`,
+  /** Said for an edge that renders more than one reported relationship. */
+  bundleOf: (relationships: string) => `Sammelkante mit ${relationships}`,
+  /** Tail of a bundle name that is too long to read out in full. */
+  furtherRelationships: (relationships: string) => `und ${relationships} weitere`,
+  /** Said when more than one agent reported for the same element. */
+  agentsReporting: (agents: string) => `${agents} melden dazu`,
+} as const
+
+/**
+ * German replacements for React Flow's built-in English a11y strings.
+ *
+ * This is not only a translation. React Flow's default node description offers
+ * "press delete to remove it" and "use the arrow keys to move the node around",
+ * and neither is true here: `deleteKeyCode` is `null`, and the canvas is a
+ * read-only view of what an agent reported. Announcing an action that does not
+ * exist is the same defect as not announcing one that does.
+ */
+export const CANVAS_ARIA_LABEL_CONFIG = {
+  // React Flow renders the `keyboardDisabled` variant while keyboard a11y is
+  // *enabled*; both keys carry the same text so the rendered one is right
+  // either way.
+  'node.a11yDescription.default': CANVAS_A11Y_TEXT.nodeInstructions,
+  'node.a11yDescription.keyboardDisabled': CANVAS_A11Y_TEXT.nodeInstructions,
+  'edge.a11yDescription.default': CANVAS_A11Y_TEXT.edgeInstructions,
+  'controls.ariaLabel': 'Zoomsteuerung des Architekturgraphen',
+  'controls.zoomIn.ariaLabel': 'Hineinzoomen',
+  'controls.zoomOut.ariaLabel': 'Herauszoomen',
+  'controls.fitView.ariaLabel': 'Ansicht einpassen',
+  'controls.interactive.ariaLabel': 'Interaktivität umschalten',
+  'minimap.ariaLabel': 'Übersichtskarte der Architektur',
+  'handle.ariaLabel': 'Verbindungspunkt',
+} as const
+
+// ---------------------------------------------------------------------------
+// Work state as words
+// ---------------------------------------------------------------------------
+
+/**
+ * The reported work state of an element, spelled out.
+ *
+ * `null` produces the explicit "nothing was reported" — the visible node is
+ * equally explicit about it by carrying no mark at all, and a screen reader
+ * must be able to tell "no state" from "state not conveyed".
+ */
+export function workStatePhrase(
+  overlay: ChangeOverlay | null,
+  countText: CountText,
+  rolledUp = false,
+): string[] {
+  if (!overlay) return [CANVAS_A11Y_TEXT.noWorkState]
+  const parts = [overlayLabel(overlay)]
+  if (rolledUp) parts.push(CANVAS_A11Y_TEXT.rolledUpNote)
+  if (overlay.presence === 'proposal') parts.push(CANVAS_A11Y_TEXT.proposalNote)
+  if (overlay.presence === 'ghost') parts.push(CANVAS_A11Y_TEXT.ghostNote)
+  if (overlay.agentIds.length > 1) {
+    parts.push(
+      CANVAS_A11Y_TEXT.agentsReporting(countText('agent', overlay.agentIds.length)),
+    )
+  }
+  return parts
+}
+
+// ---------------------------------------------------------------------------
+// Node names
+// ---------------------------------------------------------------------------
+
+/** Maximum number of container levels a name is qualified with. */
+const MAX_QUALIFIER_DEPTH = 16
+
+interface NameCandidate {
+  id: ComponentId
+  /** Name, kind and — for a container — how many components it holds. */
+  base: string
+  /** Names of the ancestors, nearest container first. */
+  ancestors: string[]
+}
+
+function baseName(node: ArchitectureNode, countText: CountText): string {
+  const { component, isCompound, childCount } = node.data
+  const parts = [component.name, componentKindStyle(component.kind).label]
+  if (isCompound) {
+    parts.push(CANVAS_A11Y_TEXT.contains(countText('component', childCount)))
+  }
+  return parts.join(', ')
+}
+
+function qualified(candidate: NameCandidate, depth: number): string {
+  if (depth === 0) return candidate.base
+  const path = candidate.ancestors
+    .slice(0, depth)
+    .map((name) => CANVAS_A11Y_TEXT.inContainer(name))
+  return [candidate.base, ...path].join(', ')
+}
+
+/**
+ * The identifying part of every node's accessible name, guaranteed unique.
+ *
+ * The name starts as "name, kind" (plus the child count for a container) and is
+ * qualified with the container path only as far as it has to be: a component
+ * whose name is already unambiguous does not drag its whole hierarchy along.
+ * When even the full path collides — two identically named siblings of the same
+ * kind in the same container — the reported component id decides, because it is
+ * unique by contract.
+ *
+ * The work state is deliberately *not* part of this: it changes while the user
+ * watches, and an identity that moves with it would not be an identity.
+ */
+export function identifyingNames(
+  nodes: readonly ArchitectureNode[],
+  countText: CountText,
+): Map<ComponentId, string> {
+  const nameById = new Map<ComponentId, string>()
+  const parentById = new Map<ComponentId, ComponentId | undefined>()
+  for (const node of nodes) {
+    nameById.set(node.id, node.data.component.name)
+    parentById.set(node.id, node.parentId)
+  }
+
+  const candidates: NameCandidate[] = nodes.map((node) => {
+    const ancestors: string[] = []
+    let current = node.parentId
+    const seen = new Set<ComponentId>([node.id])
+    while (current !== undefined && !seen.has(current) && ancestors.length < MAX_QUALIFIER_DEPTH) {
+      seen.add(current)
+      ancestors.push(nameById.get(current) ?? current)
+      current = parentById.get(current)
+    }
+    return { id: node.id, base: baseName(node, countText), ancestors }
+  })
+
+  const result = new Map<ComponentId, string>()
+  let pending = candidates
+  let depth = 0
+
+  while (pending.length > 0) {
+    const groups = new Map<string, NameCandidate[]>()
+    for (const candidate of pending) {
+      const label = qualified(candidate, depth)
+      const group = groups.get(label)
+      if (group) group.push(candidate)
+      else groups.set(label, [candidate])
+    }
+
+    const next: NameCandidate[] = []
+    for (const [label, group] of groups) {
+      const first = group[0]
+      if (group.length === 1 && first) {
+        result.set(first.id, label)
+        continue
+      }
+      // Only go one container level deeper when every member of the collision
+      // still has one; otherwise the reported id settles it right away.
+      const canGoDeeper =
+        depth < MAX_QUALIFIER_DEPTH &&
+        group.every((candidate) => candidate.ancestors.length > depth)
+      if (canGoDeeper) {
+        next.push(...group)
+        continue
+      }
+      for (const candidate of group) {
+        result.set(
+          candidate.id,
+          `${qualified(candidate, depth)}, ${CANVAS_A11Y_TEXT.identifiedBy(candidate.id)}`,
+        )
+      }
+    }
+
+    pending = next
+    depth += 1
+  }
+
+  return result
+}
+
+/**
+ * The full accessible name of one node: identity, disclosure, reported state.
+ *
+ * The two things after the identity are the ones that move while the user
+ * watches — whether the container is open, and what an agent reported — and
+ * they are deliberately *outside* the identity for exactly that reason.
+ */
+export function nodeAccessibleName(
+  node: ArchitectureNode,
+  identity: string,
+  countText: CountText,
+): string {
+  const { collapsed, hiddenDescendantCount, childCount, overlay, overlayRolledUp } =
+    node.data
+  const parts = [identity]
+  // A closed container looks different and has to sound different: what is
+  // behind it is not on screen and is not a tab stop either.
+  if (collapsed === true) {
+    parts.push(
+      CANVAS_A11Y_TEXT.collapsedNote(
+        countText('component', hiddenDescendantCount ?? childCount),
+      ),
+    )
+  }
+  parts.push(...workStatePhrase(overlay, countText, overlayRolledUp === true))
+  return parts.join(', ')
+}
+
+/**
+ * The accessible name of the control that expands or collapses a container.
+ *
+ * The verbs come from `DISCLOSURE_LABELS`, the collection #34 created for the
+ * same reason this module exists — one place per vocabulary, so the button, its
+ * tooltip and its accessible name cannot drift into three different words. What
+ * this function adds is the *component*: a canvas full of buttons that all say
+ * "Aufklappen" tells a screen reader which action is available and not which
+ * box it belongs to.
+ */
+export function nodeDisclosureLabel(
+  componentName: string,
+  expanded: boolean,
+  countText: CountText,
+  hiddenCount?: number,
+): string {
+  if (expanded) return `${DISCLOSURE_LABELS.collapse}: ${componentName}`
+  const suffix =
+    hiddenCount === undefined ? '' : ` (${countText('component', hiddenCount)})`
+  return `${DISCLOSURE_LABELS.expand}: ${componentName}${suffix}`
+}
+
+/**
+ * Puts role, name and state on every node.
+ *
+ * `role="group"` is what React Flow already gives a focusable node, and it is
+ * kept on purpose. A node is not a leaf widget: a container renders a real
+ * disclosure `<button>` inside it (#34), and `button`, `option` and the other
+ * widget roles make their children *presentational* — a node marked up as a
+ * button would take that toggle out of the accessibility tree entirely. What
+ * was missing was never the role, it was the name.
+ *
+ * The selection therefore travels as `aria-current`, which is a **global**
+ * ARIA state and valid on `group`, and which says precisely what a canvas
+ * selection is: the current item among a set of related ones.
+ * `aria-roledescription` carries the distinction the role cannot — a container
+ * that holds other components against a single component — so the two are told
+ * apart by words rather than by the size of a box.
+ */
+export function withNodeAccessibility(
+  nodes: readonly ArchitectureNode[],
+  countText: CountText,
+): ArchitectureNode[] {
+  const identities = identifyingNames(nodes, countText)
+  return nodes.map((node) => ({
+    ...node,
+    ariaRole: 'group',
+    ariaLabel: nodeAccessibleName(node, identities.get(node.id) ?? node.id, countText),
+    domAttributes: {
+      'aria-roledescription': node.data.isCompound
+        ? CANVAS_A11Y_TEXT.containerRoleDescription
+        : CANVAS_A11Y_TEXT.componentRoleDescription,
+      ...(node.selected === true ? { 'aria-current': true as const } : {}),
+    },
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Edge names
+// ---------------------------------------------------------------------------
+
+/** Reported component names by id, for naming the endpoints of an edge. */
+export function componentNamesById(
+  nodes: readonly ArchitectureNode[],
+): Map<ComponentId, string> {
+  return new Map(nodes.map((node) => [node.id, node.data.component.name]))
+}
+
+/**
+ * How many relationships of a bundle are spelled out before the name switches
+ * to a count. A closed container can lift a dozen relationships onto one line
+ * (`collapse.ts`); reading all of them out is not a name any more. The bundle
+ * stays fully resolvable — unfolding it gives every single one its own label,
+ * which is what ADR 0008 requires of a bundle.
+ */
+const MAX_NAMED_RELATIONSHIPS = 6
+
+/** The accessible name of one drawn edge. */
+export function edgeAccessibleName(
+  edge: ArchitectureEdge,
+  names: ReadonlyMap<ComponentId, string>,
+  countText: CountText,
+): string {
+  const relationships = edge.data?.relationships ?? []
+  const parts = [
+    CANVAS_A11Y_TEXT.fromTo(
+      names.get(edge.source) ?? edge.source,
+      names.get(edge.target) ?? edge.target,
+    ),
+  ]
+
+  if (relationships.length > 1) {
+    parts.push(
+      CANVAS_A11Y_TEXT.bundleOf(countText('relationship', relationships.length)),
+    )
+  }
+  for (const relationship of relationships.slice(0, MAX_NAMED_RELATIONSHIPS)) {
+    const kind = RELATIONSHIP_KIND_STYLE_BY_ID[relationship.kind]
+    const discriminator = relationshipDiscriminator(relationship)
+    parts.push(
+      discriminator
+        ? `${kind?.label ?? relationship.kind} ${discriminator}`
+        : (kind?.label ?? relationship.kind),
+    )
+  }
+  if (relationships.length > MAX_NAMED_RELATIONSHIPS) {
+    parts.push(
+      CANVAS_A11Y_TEXT.furtherRelationships(
+        countText('relationship', relationships.length - MAX_NAMED_RELATIONSHIPS),
+      ),
+    )
+  }
+
+  parts.push(
+    ...workStatePhrase(
+      dominantOverlay(Object.values(edge.data?.overlays ?? {})),
+      countText,
+    ),
+  )
+  return parts.join(', ')
+}
+
+/**
+ * Names every edge and marks it as a relationship.
+ *
+ * React Flow makes edges focusable and labels them `Edge from <id> to <id>` —
+ * English, built from ids rather than from the reported names, and identical
+ * for a single call and for a bundle of three NATS topics. A tab stop that
+ * announces neither what it connects nor what it carries is the same defect as
+ * an unnamed node, so the edges are named from the same reported data the line
+ * is drawn from.
+ */
+export function withEdgeAccessibility(
+  edges: readonly ArchitectureEdge[],
+  names: ReadonlyMap<ComponentId, string>,
+  countText: CountText,
+): ArchitectureEdge[] {
+  return edges.map((edge) => ({
+    ...edge,
+    ariaLabel: edgeAccessibleName(edge, names, countText),
+    domAttributes: {
+      'aria-roledescription': CANVAS_A11Y_TEXT.relationshipRoleDescription,
+    },
+  }))
+}

--- a/frontend/src/canvas/useCanvasCountText.ts
+++ b/frontend/src/canvas/useCanvasCountText.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { CountText } from './canvasAccessibility'
+
+/**
+ * The counting function the accessible names of the canvas are built with.
+ *
+ * `canvasAccessibility.ts` is pure and free of React — the same discipline
+ * `graphProjection.ts` follows, and the reason its rules can be tested without
+ * rendering anything. It therefore cannot hold a `t` of its own, and it must
+ * not: counted nouns are localised, and a module-local plural table would be a
+ * second one next to the catalogues (`src/i18n`, ADR 0019). This hook is the
+ * one seam between the two.
+ *
+ * The identity is stable per language, so the memo that builds the node and
+ * edge labels is not invalidated on every render — and it *does* change when
+ * the language does, which is exactly what makes the accessible names follow a
+ * language switch.
+ */
+export function useCanvasCountText(): CountText {
+  const { t } = useTranslation('common')
+  return useCallback<CountText>((noun, count) => t(`count.${noun}`, { count }), [t])
+}

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -19,6 +19,8 @@
     "plan_other": "{{count, number}} Pläne",
     "problem_one": "{{count, number}} Problem",
     "problem_other": "{{count, number}} Probleme",
+    "relationship_one": "{{count, number}} Beziehung",
+    "relationship_other": "{{count, number}} Beziehungen",
     "revision_one": "{{count, number}} Revision",
     "revision_other": "{{count, number}} Revisionen",
     "risk_one": "{{count, number}} Risiko",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -19,6 +19,8 @@
     "plan_other": "{{count, number}} plans",
     "problem_one": "{{count, number}} problem",
     "problem_other": "{{count, number}} problems",
+    "relationship_one": "{{count, number}} relationship",
+    "relationship_other": "{{count, number}} relationships",
     "revision_one": "{{count, number}} revision",
     "revision_other": "{{count, number}} revisions",
     "risk_one": "{{count, number}} risk",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,6 +53,13 @@
   /* ---- canvas ----------------------------------------------------------- */
   --canvas: oklch(0.2 0.004 265);
   --canvas-grid: oklch(0.26 0.005 265);
+  /* Rendered width and offset of the focus ring inside the canvas, in CSS
+     pixels *on screen* — the rules below divide them by the live zoom. */
+  --vai-focus-ring-width: 3px;
+  --vai-focus-ring-offset: 2px;
+  /* Live zoom of the architecture canvas. Published by `ArchitectureCanvas`
+     on the drawing surface; 1 is the honest fallback everywhere else. */
+  --vai-canvas-zoom: 1;
 
   /* ---- v0 work states --------------------------------------------------- */
   /* Phases of work, never a quality judgement. Always paired with a label and
@@ -145,6 +152,38 @@
     outline-style: solid;
     outline-offset: 2px;
   }
+}
+
+/*
+ * Focus indicator inside the architecture canvas.
+ *
+ * Two problems, one rule. First, React Flow's own stylesheet removes the focus
+ * outline of every node and every edge outright
+ * (`.react-flow__node.selectable:focus-visible { outline: none }`), so the tab
+ * stops it creates have no visible focus at all. Second, the canvas draws
+ * inside a CSS transform: whatever ring is put back is multiplied by the zoom,
+ * and at the 0.2 an unzoomed large model opens at, a 2 px ring renders as
+ * 0.4 px — a line that is not there.
+ *
+ * Dividing by `--vai-canvas-zoom`, which the canvas publishes on its surface on
+ * every camera move, makes the *rendered* ring `--vai-focus-ring-width` CSS
+ * pixels wide at every zoom level. The rules sit outside every cascade layer
+ * and carry one class more than React Flow's, so neither layer order nor bundle
+ * order can put the outline back to `none`.
+ */
+.react-flow .react-flow__node:focus-visible,
+.react-flow .react-flow__node.selectable:focus-visible,
+.react-flow .react-flow__edge:focus-visible,
+.react-flow .react-flow__edge.selectable:focus-visible {
+  outline: calc(var(--vai-focus-ring-width) / var(--vai-canvas-zoom, 1)) solid
+    var(--ring);
+  outline-offset: calc(var(--vai-focus-ring-offset) / var(--vai-canvas-zoom, 1));
+}
+
+.react-flow .react-flow__node:focus-visible,
+.react-flow .react-flow__node.selectable:focus-visible {
+  /* Follows the rounded box the node itself draws. */
+  border-radius: calc(var(--radius) - 2px);
 }
 
 @layer components {


### PR DESCRIPTION
> **Rebased auf `develop` nach #38, #41, #39, #34 und #40.** Zwei Integrationen mit Folgen, beide unten ausgeführt:
>
> * **#34** — `role="button"` am Knoten hätte die neue Aufklapp-Steuerung aus dem Accessibility Tree entfernt. Der Knoten bleibt eine `group`, die Auswahl reist als `aria-current`. Siehe „Was der Rebase geändert hat".
> * **#40** — `src/lib/plural.ts` ist gelöscht. Die Zählung in den zugänglichen Namen läuft jetzt über die Kataloge und stimmt damit in **beiden** Sprachen. Siehe „Die Zählung kommt aus den Katalogen".

Die Architekturfläche war per Tastatur erreichbar und für einen Screenreader trotzdem stumm. Gemessen am laufenden Cockpit (`visualise-ai-self`, 28 Komponenten über vier Ebenen, ein offener `planned`-Vorschlag), Chromium 1920 × 1080, `localStorage` vor jeder Messung geleert.

## Vorher

```
nodes:        role=group  aria-roledescription="node"  aria-label=null
description:  "Press enter or space to select a node. You can then use the arrow
               keys to move the node around. Press delete to remove it and
               escape to cancel."
edges:        role=group  aria-label="Edge from browser to visualise-ai.nginx"
Fokusring:    outline-style: none   — bei jeder Zoomstufe
Enter/Space:  ohne Wirkung
```

| gemessen (Modell vollständig aufgeklappt) | Wert |
| --- | --- |
| fokussierbare Knoten | **29** |
| davon mit zugänglichem Namen | **0** |
| fokussierbare Kanten | **34**, englisch, aus Ids gebaut |
| gerenderter Fokusring | **0 px** (`outline: none`) bei jeder Zoomstufe |

Drei Befunde, die über „unbenannt" hinausgehen:

1. React Flows Stylesheet setzt `outline: none` auf `.react-flow__node.selectable:focus-visible` **und** `.react-flow__edge:focus-visible`. Es gab also nicht einen zu dünnen Ring, sondern gar keinen — das ist zugleich Befund 3 aus #41 (Kanten sind Tab-Stopps ohne Fokusindikator).
2. Die Knotenbeschreibung bot **Löschen und Verschieben an** — in einem read-only Beobachtungswerkzeug mit `deleteKeyCode={null}`.
3. **Enter und Leertaste taten nichts.** React Flows eingebauter Handler setzt seine *interne* Auswahl; der Graph hier ist vollständig kontrolliert und hat kein `onNodesChange`, die Änderung fiel auf den Boden. Auswahl war ausschließlich mit der Maus möglich.

Zusätzlich: die Pfeiltasten meldeten über die aria-live-Region „Moved selected node right. New position, x: …, y: …", während sich nichts bewegte — eine Ansage für etwas, das nicht stattfand.

## Nachher

Beim Einstieg (Zoom 0,77, obere Ebenen offen — ADR 0017), Accessibility Tree aus dem echten Browser:

```
group | Architekturkomponente | Operator Browser, Extern, kein Änderungsstatus gemeldet
group | Architekturcontainer  | Visualise AI, System, Container mit 7 Komponenten,
                                kein Änderungsstatus gemeldet
group | Architekturcontainer  | Backend, Service, Container mit 10 Komponenten,
                                eingeklappt, 10 Komponenten verborgen,
                                kein Änderungsstatus gemeldet
group | Architekturcontainer  | Cockpit SPA, UI, Container mit 6 Komponenten,
                                eingeklappt, 9 Komponenten verborgen,
                                kein Änderungsstatus gemeldet
group | Architekturkomponente | PostgreSQL, Datenspeicher, kein Änderungsstatus gemeldet
group | Architekturkomponente | Repository Provider, Extern, geplant · hinzufügen,
                                angekündigt, noch nicht Teil des angewandten
                                Architekturmodells
```

und die Aufklapp-Steuerungen daneben:

```
aria-expanded=true   Einklappen: Visualise AI
aria-expanded=false  Aufklappen: Backend (10 Komponenten)
aria-expanded=false  Aufklappen: Cockpit SPA (9 Komponenten)
```

| gemessen | Einstieg (10 gezeichnet) | nach dem Aufklappen (20 gezeichnet) |
| --- | --- | --- |
| Knoten mit zugänglichem Namen | **10 / 10** | **20 / 20** |
| davon eindeutig | **10** | **20** |
| Knoten mit abweichendem visuellem/zugänglichem Zustand | **0** | **0** |
| Kanten mit deutschem Namen aus gemeldeten Daten | 24 / 24, eindeutig | 24 / 24, eindeutig |
| englische `Edge from …`-Namen | **0** | **0** |

Eine gehobene Sammelkante nennt jede Beziehung, die sie trägt:

```
"Beziehung von Nginx Entry Point zu HTTP Surface, Sammelkante mit 3 Beziehungen,
 HTTP-Aufruf proxy_pass http://backend:8080, HTTP-Aufruf GET /healthz, GET /readyz,
 HTTP-Aufruf location ~ ^/api/v1/projects/[^/]+/stream$, kein Änderungsstatus gemeldet"
```

Ab sieben Beziehungen wechselt der Name auf eine Zahl (`und N weitere Beziehungen`) — eine Grenze für den *Namen*, nicht für die Daten: aufgeklappt bekommt jede Beziehung wieder ihr eigenes Label (ADR 0008).

## Was der Rebase geändert hat

### `role="button"` war falsch — der Knoten bleibt eine `group`

Mein ursprünglicher Entwurf gab jedem Knoten `role="button"` mit `aria-pressed`. Auf `develop` rendert ein Container seit #34 eine echte Aufklapp-`<button>` **in sich**, und `button` gehört zu den Rollen, deren Kinder *presentational* sind: der Knoten als Schaltfläche hätte genau die Steuerung aus dem Accessibility Tree genommen, die #34 gerade eingebaut hat. Ein unerreichbares Element gegen ein anderes zu tauschen ist keine Lösung.

Also bleibt die Rolle `group` — was gefehlt hat, war nie die Rolle, sondern der Name. Die beiden Dinge, die eine `group` nicht sagen kann, sagen jetzt andere Kanäle:

* **Auswahl → `aria-current`.** Ein *globaler* ARIA-Zustand, auf jeder Rolle gültig, und inhaltlich genau das, was eine Canvas-Auswahl ist: das aktuelle Element unter verwandten. Gesetzt nur am ausgewählten Knoten — `aria-current="false"` auf allen anderen ist Rauschen.
* **Container gegen Blatt → `aria-roledescription`**, plus die Kinderzahl im Namen.

`nested-interactive` und `aria-allowed-attr` sind im axe-Lauf beide sauber.

### `aria-expanded` bleibt an der Steuerung, nicht am Knoten

#34 setzt es bereits dort, und dort gehört es hin: an das Element, das das Aufklappen ausführt. `group` unterstützt `aria-expanded` nicht; es zusätzlich an den Knoten zu hängen wäre ungültiges ARIA, das `aria-allowed-attr` meldet. Was der Knoten stattdessen trägt, ist der Zustand **in Worten** — `eingeklappt, 10 Komponenten verborgen`, dieselbe Zahl, die die geschlossene Box druckt.

Ergänzt habe ich den **Namen** der Steuerung: `nodeDisclosureLabel()` baut ihn aus den Verben, die `DISCLOSURE_LABELS` (#34) schon besitzt, plus dem Container. Eine Fläche voller Schaltflächen, die alle „Aufklappen" heißen, sagt welche Aktion es gibt, aber nie zu welcher Box. Der sichtbare `title` bleibt kurz, der zugängliche Name nennt den Container.

### Meine drei Merge-Hinweise, nachgeprüft

1. ✅ `withNodeAccessibility(...)` liegt außen um die Collapse-Projektion. `graph.nodes` ist bereits das, was `collapse.ts` sichtbar gelassen hat — benannt wird also genau das, was gezeichnet ist.
2. ✅ `nodeNames` kommt aus `graph.nodes`. `collapse.ts` hebt eine versteckte Kantenendung auf den nächsten **sichtbaren** Vorfahren, also ist jeder Endpunkt jeder gezeichneten Kante ein Knoten daraus — **0** Namen fallen auf eine Id zurück.
3. ⚠️ `nodeDisclosureLabel` ist angeschlossen, `aria-expanded` steht bewusst weiterhin nur an der Steuerung (Begründung oben).

### Der Fokus schwenkt jetzt sichtbar die Kamera — und das ist beabsichtigt

Vor dem Rebase lag das ganze Modell bei Zoom 0,20 im Viewport, `autoPanOnNodeFocus` feuerte nie, und der Viewport-Transform blieb über einen vollen Tastaturdurchlauf zeichengleich. Beim lesbaren Einstiegszoom 0,77 passt ein großes Modell nicht mehr hinein, und ein Tab auf einen Knoten außerhalb des Viewports **schwenkt jetzt wirklich**:

```
vor  : translate(27.8409px, 213.362px) scale(0.77)
nach : translate(410.97px,  15.665px)  scale(0.77)     <- alle 10 Knoten fokussiert
```

Die Zusage muss deshalb genauer formuliert werden — und genau das prüfen die Tests:

| | Tastaturfokus / Auswahl |
| --- | --- |
| `data-fit-view-count` | bewegt sich **nie** (bleibt `1`) |
| Zoom | ändert sich **nie** |
| Pan | folgt dem Fokus, und nur ihm |

`autoPanOnNodeFocus` abzuschalten würde den Fokusring auf einen Knoten legen, den niemand sieht (WCAG 2.4.7 / 2.4.11) — die schlechtere Antwort auf dieselbe Frage.

## Die Zählung kommt aus den Katalogen

#40 hat `src/lib/plural.ts` gelöscht — die rein deutsche Tabelle, aus der die Namen bisher „10 Komponenten" holten. Git meldete das nicht als Konflikt, weil mein Modul neu ist und die Löschung anderswo geschah; sechs Aufrufstellen brachen.

Aufgelöst ohne zweite Plural-Tabelle:

* `canvasAccessibility.ts` bleibt **pur und React-frei** — dieselbe Disziplin wie `graphProjection.ts`, und der Grund, warum seine Regeln ohne Rendern prüfbar sind. Es kann also kein eigenes `t` halten und soll auch keins bauen.
* Es nimmt stattdessen ein `CountText` entgegen: `(noun, count) => string` über die drei Nomen, die es spricht (`component`, `relationship`, `agent`).
* `useCanvasCountText()` ist die eine Naht: ein `useCallback` über `t('count.<noun>')`, stabil pro Sprache, benutzt von `ArchitectureCanvas` und `ComponentNode`.
* `CANVAS_A11Y_TEXT` behält das deutsche Gerüst und nimmt das bereits gezählte Nomen: `contains: (components) => \`Container mit ${components}\``.

**`count.relationship` neu in beiden Katalogen.** #40 hatte es weggelassen, weil es keine Aufrufstelle gab — jetzt gibt es eine. `check:locales`: `Translation catalogues agree: 36 keys, de, en, reference de.`

Am laufenden Modell gemessen, `localStorage` geleert, einmal `de` und einmal `en`:

| | Deutsch | Englisch |
| --- | --- | --- |
| Container | `Visualise AI, System, Container mit 7 Komponenten, …` | `Visualise AI, System, Container mit 7 components, …` |
| geschlossener Container | `Backend, Service, Container mit 10 Komponenten, eingeklappt, 10 Komponenten verborgen, …` | `Backend, Service, Container mit 10 components, eingeklappt, 10 components verborgen, …` |
| Singular | `API Client, Modul, Container mit 1 Komponente, …` | `API Client, Modul, Container mit 1 component, …` |
| Aufklapp-Steuerung | `Aufklappen: Backend (10 Komponenten)` | `Aufklappen: Backend (10 components)` |
| Sammelkante | `Sammelkante mit 2 Beziehungen` | `Sammelkante mit 2 relationships` |

Der Singular ist der Punkt: die gelöschte Tabelle konnte „1 component" nicht sagen, sie hätte „1 Komponente" in beide Sprachen geschrieben.

**Was im Englischen noch schief klingt — und warum es so bleibt.** Das Gerüst ist weiter deutsch, also hört ein englischer Screenreader `Container mit 10 components, eingeklappt, 10 components verborgen`. Das ist derselbe halbmigrierte Zustand, in dem der *sichtbare* Canvas seit #34/#40 schon ist (die geschlossene Box druckt `10 components eingeklappt`, der Tooltip sagt `Aufklappen (10 components)`). Die vollständige Textmigration ist #42 und läuft parallel; die `canvas`-Strings jetzt zu ziehen, würde direkt mit ihr kollidieren. Der Zwischenstand ist trotzdem der richtige: falsch war die **Zählung**, und die stimmt jetzt.

Zwei Tests halten das fest — sie bauen ihr `CountText` aus den **echten** Katalogen über `createI18n({ language })`, nicht aus einem Stub, damit ein fehlender Schlüssel oder eine falsche Pluralform auffällt statt durchzurutschen.

## Wie der zugängliche Name aufgebaut ist

```
Router, Modul, in HTTP Layer, eingeklappt, 3 Komponenten verborgen, geplant · hinzufügen
└ Name  └ Art  └ Containerpfad   └ Aufklappzustand              └ Arbeitszustand
└──────────── Identität ────────┘ └──────── ändert sich, während man zusieht ────────┘
```

* **Identität zuerst, Veränderliches danach.** Aufklappzustand und Arbeitszustand ändern sich unter dem Nutzer; eine Identität, die mitwandert, wäre keine.
* **Qualifiziert wird nur, was kollidiert.** Ein eindeutiger Name schleppt seine Hierarchie nicht mit. Erst bei einer Kollision kommt eine Containerebene dazu, dann die nächste, zuletzt die gemeldete Komponenten-ID.
* **Farbe ist kein Kanal.** Der Zustand kommt als Wort aus `overlayLabel` — derselben Definition, aus der Marke, Legende und Inspector lesen (`state/workStates.ts`, ADR 0003). Keine zweite Benennung, keine Bewertung: `entfernt` heißt „wird entfernt".
* **Gemeldete Daten bleiben unverändert.** Komponentennamen, Ids und Technologieangaben werden weder übersetzt noch umformuliert.
* **„Nichts gemeldet" wird gesagt.** `kein Änderungsstatus gemeldet` — ein Screenreader muss „kein Zustand" von „Zustand nicht übermittelt" unterscheiden können.
* **Ein hochgezogener Zustand wird als solcher gesagt.** Trägt ein geschlossener Container den Zustand von etwas *darin* (`rollUpOverlay`, #34), sagt der Name `gemeldet für eine eingeklappte Komponente darin` — sonst würde er behaupten, der Container sei das Element, an dem gearbeitet wird.

Zwei gleichnamige Komponenten in verschiedenen Containern: das Modell hat den Fall nicht, der Test konstruiert ihn.

```
Router, Modul, in API Gateway
Router, Modul, in Worker Pool
```

Reicht der direkte Container nicht, wandert der Pfad weiter hoch (`Router, Modul, in Edge, in EU` gegen `… in Edge, in US`); bei zwei gleichnamigen Geschwistern derselben Art entscheidet die gemeldete Id (`…, Komponenten-ID root.one`).

## Fokusindikator über die Zoomstufen

Der Canvas zeichnet in einem CSS-Transform, jede Länge darin wird mit dem Zoom multipliziert. Der Canvas veröffentlicht seinen Zoom deshalb als `--vai-canvas-zoom` auf der Zeichenfläche, und die Regel teilt durch ihn:

```css
outline-width: calc(var(--vai-focus-ring-width) / var(--vai-canvas-zoom));
```

Gemessen wurde nicht die Klasse, sondern die tatsächlich gerenderte Breite: `getComputedStyle(node).outlineWidth × (getBoundingClientRect().width / offsetWidth)`.

| Zoom | deklarierte `outline-width` | **gerenderter Ring** | vorher |
| --- | --- | --- | --- |
| 0,124 (Canvas-Minimum) | 24 px | **2,99 px** | 0 px |
| 0,309 | 9 px | **2,79 px** | 0 px |
| 0,770 (Einstiegszoom) | 3 px | **2,31 px** | 0 px |
| 1,109 | 2 px | **2,22 px** | 0 px |
| 2,500 (Canvas-Maximum) | 1 px | **2,50 px** | 0 px |

Die Restspanne kommt daher, dass Chromium `outline-width` auf ganze Gerätepixel abrundet; sie nähert sich nirgends der Unsichtbarkeit. Dieselbe Regel gilt für die Kanten, die vorher ebenfalls ohne Ring fokussierbar waren.

Die Regeln stehen **außerhalb jeder Cascade Layer** und tragen eine Klasse mehr als React Flows. Tailwind v4 benutzt echte `@layer`, und ungelayertes CSS schlägt gelayertes unabhängig von der Spezifität — ein Ring in `@layer components` hätte gegen React Flows ungelayertes `outline: none` verloren.

## Tastaturbedienung

Ein `onKeyDownCapture` auf der Zeichenfläche, eine Ebene über React Flow — die einzige Stelle, die *vor* dessen Handlern läuft.

* **Enter und Leertaste** schreiben den `component`-Suchparameter — denselben Weg, den ein Klick nimmt. URL, Auswahl und Inspector können nicht auseinanderlaufen.
* **Escape** nimmt die Auswahl zurück und lässt den Fokus stehen. Ist nichts ausgewählt, reist die Taste weiter, damit Deep Focus weiterhin mit Escape verlassen werden kann — eine Escape-Taste pro Ebene, keine davon verschluckt.
* **Pfeiltasten werden geschluckt**, damit die aria-live-Region keine Bewegung meldet, die nicht stattfindet. Nach vier Pfeiltasten ist sie leer.
* **Eine echte Steuerung *innerhalb* eines Knotens bleibt unangetastet.** Kommt die Taste von der Aufklapp-Schaltfläche eines Containers, kehrt der Handler sofort zurück: einen Container öffnen und einen auswählen sind zwei verschiedene Absichten.
* **Eine Kante aktivieren** klappt eine Sammelkante auf oder wählt die einzelne Beziehung aus — dieselben zwei Aktionen, die ihre Badges der Maus anbieten.

Am Modell gemessen:

```
Fokus auf "PostgreSQL, Datenspeicher, …"  → Enter
   location.search  : ?component=visualise-ai.postgres
   aria-current     : true          data-selected (Box): true
   Inspector        : "PostgreSQL · visualise-ai.postgres · Datenspeicher"
   Fokus            : bleibt auf dem Knoten
                                          → Escape
   location.search  : ""            aria-current: (weg)   data-selected: false
   Inspector        : "Keine Komponente ausgewählt"
   Fokus            : bleibt auf dem Knoten
                                          → 4 × Pfeiltaste
   aria-live        : ""            fit=1   zoom=0.77

Fokus auf "Aufklappen: Backend (10 Komponenten)"  → Enter
   sichtbare Knoten : 10 → 20       aria-expanded: false → true
   Steuerung heißt  : "Einklappen: Backend"
   Knotenname       : ohne "eingeklappt"
   Auswahl          : ""            <- der Container wurde geöffnet, nicht ausgewählt
   Kamera           : translate(-571.55px, 389.5px) scale(0.77)  — unverändert, fit=1
```

Diese Runde wurde **programmatisch am DOM** gemessen: der Browser-Pane komponierte in dieser Sitzung keine Frames („pane is not displayed"), echte OS-Tastendrücke kamen nicht in der Seite an. Die Handler-Pfade sind dieselben; echte Tastendrücke (Tab-Reihenfolge, Enter, Escape) waren vor dem Rebase im Browser belegt, und `userEvent.keyboard()` deckt Tab, Enter, `[Space]`, Escape und die Pfeiltasten in `ArchitectureAccessibility.test.tsx` ab.

## Automatisierte Accessibility-Tests

`axe-core` läuft nach einer Tastaturauswahl über die Architektur- und die Inspector-Fläche — Graph, Auswahl und Inspector-Übergang in einem Durchgang, inklusive der verschachtelten Aufklapp-Steuerungen aus #34. Zwei Grenzen sind ausdrücklich:

* **Farbregeln sind aus.** jsdom hat weder Layout noch Rendering; `color-contrast` wäre dort unentscheidbar statt bestanden. Dass Farbe nie der einzige Kanal ist, prüft `workStates.test.ts`.
* **Der Audit ist auf die zwei Flächen begrenzt.** Über die ganze Seite meldet axe zusätzlich die beiden Resize-Griffe des Workspace-Layouts unter `region` („all page content should be contained by landmarks"): sie liegen *zwischen* den Flächen und damit in keiner. Best-Practice-Befund am Workspace-Gerüst (#7, von #41 erneut angefasst), nicht am Architekturgraphen.

## Qualität

```
$ npm run lint           → keine Ausgabe
$ npm run typecheck      → tsc --build --force, keine Fehler
$ npm run check:locales  → Translation catalogues agree: 36 keys, de, en, reference de.
$ npm test               → Test Files  40 passed (40)
                           Tests      393 passed (393)     (5 Läufe hintereinander)
$ npm run build          → ✓ built in 15.53s
```

Alle **345** Tests von `develop` bleiben grün; 48 neue kommen dazu (31 in `canvasAccessibility.test.ts`, 17 in `ArchitectureAccessibility.test.tsx`).

**Zu den Suite-Flakes:** in einer früheren Runde fielen unter Last vereinzelt Tests aus #9/#34 aus (`ArchitectureCanvas.test.tsx`, `ArchitectureZoom.test.tsx`), einmal auch breitflächig mit 5-Sekunden-Timeouts quer über unbeteiligte Dateien. Nachgeprüft: **pristine `origin/develop`** 3 von 3 grün, dieser Branch anschließend **5 von 5 grün**. Es sind Maschinenlast-Timeouts, kein Regress — beobachtet, nicht angefasst. Meine eigenen Integrationstests hatten einen echten Renn-Effekt und sind gefixt: `waitForCanvas` wartet jetzt zusätzlich darauf, dass wirklich ein Knoten im DOM ist (ELK lädt über einen dynamischen Import und landet einen Tick nach `data-layouting="false"`).

## Ausdrücklich nicht enthalten

Keine Textmigration des `canvas`-Namespace (#42) — das Gerüst bleibt hart codiert, liegt aber vollständig in `CANVAS_A11Y_TEXT` und, für die Aufklapp-Verben, in `DISCLOSURE_LABELS`. ADR 0014 zählt zugängliche Namen klar zur *übersetzten* Hälfte des Vertrags; beide Sammlungen existieren, damit #42 ein Verschieben wird und keine Suche. **Die Zählung ist die Ausnahme und schon jetzt migriert**, weil sie ohne Katalog in einer der beiden Sprachen falsch wäre. Kein Zoom-/Detailstufen-Umbau (#34), kein Viewport-Umbau (#41), keine Agentenbereich-Änderung (#39), keine Formatierungsänderung (#40) außer den beiden neuen `count.relationship`-Schlüsseln, keine unrelated Refactorings.

ADR: [`docs/decisions/0018-accessible-architecture-nodes.md`](docs/decisions/0018-accessible-architecture-nodes.md)

Closes #35
