### PR TITLE
Sprachwahl persistent und zustandsschonend umsetzen (#36)

### DIFF
--- a/docs/decisions/0021-persistent-language-switch-and-state-preservation.md
+++ b/docs/decisions/0021-persistent-language-switch-and-state-preservation.md
@@ -1,0 +1,181 @@
+# 21. The persistent language switch, and preserving state by not touching it
+
+- **Status:** accepted
+- **Date:** 2026-08-05
+- **Context issue:** #36 (part of the i18n epic #1); unblocks #37
+- **Builds on:** [0014 — Localisation architecture and translation contract](./0014-localisation-architecture-and-translation-contract.md),
+  [0020 — UI text migration and the technical glossary](./0020-ui-text-migration-and-the-technical-glossary.md),
+  [0008 — Architecture canvas layout and edge bundling](./0008-architecture-canvas-layout-and-edge-bundling.md),
+  [0017 — Readable entry zoom and progressive disclosure](./0017-readable-entry-zoom-and-progressive-disclosure.md),
+  [0003 — Frontend state split and live updates](./0003-frontend-state-split-and-live-updates.md)
+
+## Context
+
+Everything the language switch needs already existed. ADR 0014 decided the
+language before the router is built and bound `<html lang>` to it; ADR 0019
+routed every date, number and percentage through one language-aware service;
+ADR 0020 moved all 366 texts into the catalogues, so a `languageChanged` event
+already re-renders the whole cockpit in the other language. `localStorage` was
+already read under `visualise-ai.language`, and #38 wrote the key down precisely
+so that this issue would not invent a second one.
+
+What was missing was a control — and the guarantee that using it does not cost
+the user their place.
+
+That guarantee is the whole of this issue, because the cockpit's state is
+unusually easy to lose. It sits in four places at once:
+
+- the **URL** carries the selection (`?component=`, `?focus=`, `?history=`) and
+  is the only shareable form of a view (ADR 0003);
+- the **persisted half of the UI store** carries the pane split and the collapse
+  flags;
+- the **transient half** carries the canvas camera, the drag positions, the
+  container disclosure and the selection — deliberately *not* persisted,
+  because they describe one concrete architecture snapshot;
+- **React Flow** carries the rendered viewport.
+
+A `location.reload()` — the obvious implementation, and the one most language
+switches ship — destroys the third of those four completely. The user would come
+back to the same URL with the camera thrown back to the entry picture and every
+container they opened closed again. And the canvas has a second, subtler failure
+mode: a language changes text lengths, and if that were allowed to reach ELK or
+`fitView`, the picture would jump even without a reload. The camera policy knows
+exactly three reasons to move (ADR 0008, ADR 0017) and a language is none of
+them.
+
+## Decision
+
+### The switch changes the language and nothing else
+
+`useLanguagePreference().choose(language)` writes the preference and calls
+`i18n.changeLanguage`. That is the entire implementation, and every property
+this issue promises follows from what it does *not* do:
+
+| what is preserved | how |
+| --- | --- |
+| the URL, byte for byte | nothing navigates — the router is never called |
+| pane sizes and collapse flags | nothing writes the UI store |
+| camera, disclosure, selection, drag positions | nothing unmounts, so the transient half of the store is never re-initialised |
+| the rendered viewport | ELK is keyed on the projection signature and the collapsed set, neither of which is language-dependent, so no re-layout happens and `fitView` is never called |
+| reported project data | it never went through the translation layer in the first place (ADR 0014) |
+
+This is preservation by **omission**, and that is the point. The alternative —
+saving state before the switch and restoring it afterwards — has to enumerate
+what state exists, and an enumeration is wrong the moment somebody adds a
+fifth thing. There is no list here to fall out of date.
+
+`<html lang>` is the one thing that does follow, and it already did:
+`bindDocumentLanguage` subscribes to `languageChanged` and was written in #38
+for exactly this moment.
+
+### Where the switch lives, and why not everywhere
+
+Two places, one component:
+
+- **the workspace header**, in its right-hand cluster next to the live badge and
+  the pane toggle — the controls that are about *how* the cockpit is looked at
+  rather than about the data. It is the cockpit's only persistent chrome, and
+  it is where the state-preservation requirement actually bites.
+- **the project list**, next to its heading. It is the entry point and the page
+  every other screen links back to, so choosing a language before opening a
+  workspace is possible.
+
+The error and not-found pages deliberately do **not** carry it. They are dead
+ends with a single action ("back to projects"), and a preference control next to
+a failure is noise at the worst moment; the page it sends the reader to has the
+switch. A global bar above the router was rejected for a harder reason: it would
+cost vertical pixels on every screen, and the desktop budget of ADR 0015 is
+already spent on three panes and a 44 px header.
+
+The control is 59 × 30 px and fits inside the existing header without changing
+its height — which is also why it cannot move the canvas: the drawing surface
+is measured, and a header that grew would have resized it and, through
+`onLayoutReady`, been a legitimate reason to fit.
+
+### Two segments, not a dropdown
+
+There are two languages. A menu would hide both options behind a trigger and
+cost a click to answer "what can I even choose"; two segments show the options
+and the current one at the same time, in the width of a badge. The architecture
+surface stays the widest thing on screen (ADR 0008), which a settings menu with
+a panel would not have threatened either — but a third header control would
+have.
+
+The segments are `aria-pressed` toggle buttons inside a `role="group"` with a
+translated accessible name, not a `radiogroup`. A radio group is the textbook
+mapping for "one of n" and it comes with a roving `tabindex` and arrow-key
+handling that a correct implementation has to write itself; this repository has
+no shadcn toggle group to inherit one from, and writing a keyboard model for two
+options would be more code than the feature. Both segments are ordinary tab
+stops, `Enter` and `Space` activate them, and the pressed state is what a screen
+reader announces.
+
+**Each segment is named in its own language** — "Deutsch" and "English",
+identical in both catalogues. A reader who ended up in a language they cannot
+read has to be able to find their way out, and translating the exit is exactly
+the wrong help. The group's name and the tooltips are translated normally.
+
+### Focus stays on the segment that was used
+
+The click is not a navigation and causes no remount, so the button keeps the
+focus it received. That is the deliberate answer to "where should focus land":
+on the control the user just operated, whose `aria-pressed` has just flipped —
+rather than on a heading somebody chose to move it to, and certainly not on
+`<body>`, which is where a reload would have left it.
+
+### A stored language that is no longer supported is discarded, not just ignored
+
+#38 already treated an unsupported stored value as absent. #36 adds that
+`resolveInitialLanguage` also **removes** it.
+
+Leaving it costs nothing today and is wrong in two ways tomorrow. The switch
+would paint German while storage claims `fr`, so the persisted preference and
+the visible one disagree with no way for the user to see it; and a later release
+that reintroduced `fr` would silently resurrect a choice made before it was
+dropped.
+
+The removal lives inside the resolver rather than in a separate clean-up step at
+start-up, because there is exactly one moment at which the cockpit compares a
+stored value against the supported set, and a second implementation of that
+comparison is a second chance to get it wrong. It only fires for a value that
+is really there: "nothing stored" is the normal case and must not cause a write.
+
+Every storage access — read, write, remove — is individually guarded. A
+private-mode browser that throws on any of them still gets a cockpit; a
+preference that could not be *remembered* is not a reason to refuse the language
+the user just asked for.
+
+### The proof is a before/after inside one rendering
+
+`WorkspacePage.i18n.test.tsx` (#42) already renders the workspace twice and
+compares the reported data. That test cannot see this issue's failure modes,
+because all of them — a fit, a navigation, a remount — only exist on the
+*transition*.
+
+`LanguageSwitch.i18n.test.tsx` therefore measures one rendering before and after
+a real click: the router's `location.href` as a string, the UI store's pane and
+camera fields, `data-fit-view-count`, the `.react-flow__viewport` transform, and
+every `[data-reported]` text content in document order. It waits for the
+workspace to stop moving on its own first — ELK finishing, the initial
+disclosure being written down, the one automatic camera movement landing —
+because measuring earlier would charge the switch for a change it did not cause
+and, worse, hide one it did.
+
+## Consequences
+
+- **`resolveInitialLanguage` now has a side effect**, which its name does not
+  advertise. It is documented at the function and here, and it is the price of
+  having exactly one place that decides whether a stored language is usable.
+- **`storeLanguage` is the only writer of `visualise-ai.language`.** The UI
+  store's `visualise-ai.ui` is untouched by this issue; the two preferences stay
+  separate because one of them is a property of the reader and the other is a
+  property of this browser tab's view of one project.
+- **The switch's texts live in `common`**, not in `workspace`. It appears on two
+  surfaces, so it belongs to neither of them — which is the rule `common` was
+  given in ADR 0014.
+- **#37 inherits a transition to test.** The pseudo-locale and the desktop
+  screenshots it adds can now be taken in both languages *without* reloading,
+  and the `[data-reported]` comparison it reuses has a runtime variant.
+- **Nothing in the canvas, the viewport or the agent pane changed.** The camera
+  stability asserted here is a property those modules already had; this issue
+  only proves that a language switch does not reach them.

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,92 @@
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { SUPPORTED_LANGUAGES, useLanguagePreference } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+/**
+ * The language switch: two segments, German and English.
+ *
+ * ## Why two buttons and not a menu
+ *
+ * There are two languages. A dropdown for two options costs a click to find out
+ * what the options even are, and it hides the *current* one behind a trigger
+ * label. Two segments show the choice and the answer at the same time, in the
+ * width of a badge, which is what keeps this off the architecture surface —
+ * the canvas stays the widest thing on screen (ADR 0008).
+ *
+ * ## Why `aria-pressed` and not a radiogroup
+ *
+ * A radio group is the textbook mapping for "one of n", and it comes with a
+ * roving `tabindex` and arrow-key navigation that a correct implementation has
+ * to write itself — this repository has no shadcn toggle group to inherit one
+ * from. Two toggle buttons inside a named group are operable with `Tab` and
+ * `Enter`/`Space` out of the box, and the pressed state is what a screen reader
+ * announces for the active language. For two options the group semantics buy
+ * nothing that the group's own accessible name does not already give.
+ *
+ * ## Why the segments are named in their own language
+ *
+ * Each button's accessible name is the language's own word for itself —
+ * "Deutsch" and "English" — identical in both catalogues. A reader who ended up
+ * in a language they cannot read has to be able to find their way out, and
+ * "Alemán" in a Spanish UI would be exactly the wrong help. The *group* is
+ * named in the active language (`common:language.label`), and so is the tooltip
+ * on each segment.
+ *
+ * ## Why the focus does not move
+ *
+ * The click switches the language and nothing else: no navigation, no remount,
+ * no dialog. The button the user pressed stays mounted at the same position in
+ * the tree, so it keeps the focus — the switch reads its new pressed state out
+ * where the user already is, instead of dropping focus onto `<body>`.
+ */
+export function LanguageSwitcher({ className }: { className?: string }) {
+  const { t } = useTranslation('common')
+  const { language, choose } = useLanguagePreference()
+
+  return (
+    <div
+      role="group"
+      aria-label={t('language.label')}
+      data-testid="language-switcher"
+      className={cn(
+        'border-border bg-background flex items-center gap-0.5 rounded-md border p-0.5',
+        className,
+      )}
+    >
+      {SUPPORTED_LANGUAGES.map((option) => {
+        const active = option === language
+        const name = t(`language.name.${option}`)
+
+        return (
+          <Tooltip key={option}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant={active ? 'secondary' : 'ghost'}
+                size="xs"
+                aria-label={name}
+                aria-pressed={active}
+                data-testid={`language-option-${option}`}
+                className={cn(
+                  'px-1.5 font-mono text-[0.6875rem] tracking-wide',
+                  active ? 'text-foreground' : 'text-muted-foreground',
+                )}
+                onClick={() => choose(option)}
+              >
+                {t(`language.code.${option}`)}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {active
+                ? t('language.current', { language: name })
+                : t('language.switchTo', { language: name })}
+            </TooltipContent>
+          </Tooltip>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/WorkspaceHeader.tsx
+++ b/frontend/src/components/workspace/WorkspaceHeader.tsx
@@ -3,6 +3,7 @@ import { PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen } from '
 import { useTranslation } from 'react-i18next'
 
 import type { ProjectId, RunId } from '@/api/types'
+import { LanguageSwitcher } from '@/components/LanguageSwitcher'
 import { LiveConnectionBadge } from '@/components/LiveConnectionBadge'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
@@ -67,6 +68,15 @@ export function WorkspaceHeader({ projectId, runId }: WorkspaceHeaderProps) {
 
       <div className="ml-auto flex shrink-0 items-center gap-2">
         <LiveConnectionBadge />
+        <Separator orientation="vertical" className="h-5" />
+        {/*
+          The workspace header is the cockpit's only persistent chrome, so the
+          language switch sits here rather than in a settings screen — and it
+          sits in the header's right cluster, next to the other two controls
+          that are about *how* the cockpit is looked at rather than about the
+          data. The pane toggle stays at the very edge, mirroring the left one.
+        */}
+        <LanguageSwitcher />
         <Separator orientation="vertical" className="h-5" />
         <PaneToggle
           label={t('pane.rightLabel')}

--- a/frontend/src/i18n/README.md
+++ b/frontend/src/i18n/README.md
@@ -5,9 +5,11 @@ holds the whole localisation layer: the catalogues, the i18next factory, and the
 one component that marks text which must never be translated.
 
 The reasoning behind all of it is
-[ADR 0014](../../../docs/decisions/0014-localisation-architecture-and-translation-contract.md)
-and, for the migration of every text into it,
-[ADR 0020](../../../docs/decisions/0020-ui-text-migration-and-the-technical-glossary.md).
+[ADR 0014](../../../docs/decisions/0014-localisation-architecture-and-translation-contract.md),
+for the migration of every text into it
+[ADR 0020](../../../docs/decisions/0020-ui-text-migration-and-the-technical-glossary.md),
+and for the switch between the two languages
+[ADR 0021](../../../docs/decisions/0021-persistent-language-switch-and-state-preservation.md).
 
 ## The translation contract
 
@@ -321,9 +323,47 @@ already in the final language: no flash, no visible switch.
 
 Without a stored choice the language is German. `Accept-Language` is
 deliberately not consulted — German is the default, and a navigator sniff would
-break exactly that for a user who never asked for English. The persisted
-language switch itself is #36; `LANGUAGE_STORAGE_KEY` is defined here so the
-reader and the future writer cannot drift apart.
+break exactly that for a user who never asked for English.
+
+## Switching at runtime
+
+`<LanguageSwitcher>` (`src/components/LanguageSwitcher.tsx`) sits in the
+workspace header and next to the project list's heading — the cockpit's two
+persistent surfaces. Two segments, `DE` and `EN`, each an `aria-pressed` toggle
+button inside a `role="group"` with a translated accessible name. The segments
+are named in their **own** language, identical in both catalogues, so a reader
+who ended up in a language they cannot read can still find the way out.
+
+```tsx
+const { language, choose } = useLanguagePreference()
+choose('en')   // stores the choice, then i18n.changeLanguage('en')
+```
+
+That is the whole of it, and everything #36 promises follows from what it does
+*not* do — see [ADR 0021](../../../docs/decisions/0021-persistent-language-switch-and-state-preservation.md):
+
+| preserved | because |
+| --- | --- |
+| the URL, byte for byte | nothing navigates |
+| pane sizes and collapse flags | nothing writes `uiStore` |
+| camera, container disclosure, selection | nothing unmounts, so the *transient* half of `uiStore` is never re-initialised |
+| the canvas viewport | ELK is keyed on the projection signature and the collapsed set — neither is language-dependent — so no re-layout runs and `fitView` is never called |
+| agent feedback and code diffs | they never went through the translation layer at all |
+| the focus | the pressed segment is not remounted, so it keeps it |
+
+There is **no `location.reload()`**. A reload would throw away exactly the
+transient state `uiStore.ts` deliberately does not persist.
+
+`storeLanguage()` is the only writer of `LANGUAGE_STORAGE_KEY`. Every storage
+access is guarded: a browser that refuses to read, write or remove still gets a
+working cockpit, in German if need be.
+
+**A stored language that is no longer supported** — somebody chose `fr` and a
+later release dropped it — resolves to German *and is removed*.
+`resolveInitialLanguage` does both, because there is exactly one moment at which
+a stored value is compared against the supported set and a second implementation
+of that comparison is a second chance to get it wrong. A value that is simply
+absent causes no write.
 
 ## Using it
 

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -8,6 +8,7 @@ import {
   LANGUAGE_STORAGE_KEY,
   isSupportedLanguage,
   resolveInitialLanguage,
+  storeLanguage,
 } from './languages'
 
 /**
@@ -43,6 +44,35 @@ describe('language resolution', () => {
     expect(isSupportedLanguage('fr')).toBe(false)
   })
 
+  it('discards a stored language the cockpit no longer supports', () => {
+    // Somebody chose French; a later release dropped it. The cockpit comes up
+    // in German — and does not keep a preference around that nothing can act
+    // on and nothing can show.
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'fr')
+
+    expect(resolveInitialLanguage(localStorage)).toBe('de')
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBeNull()
+    // …and the next start reads a clean slate rather than repeating the fall-back.
+    expect(resolveInitialLanguage(localStorage)).toBe('de')
+  })
+
+  it('leaves a supported choice and an empty storage alone', () => {
+    const removed: string[] = []
+    const storage = {
+      getItem: (key: string) => localStorage.getItem(key),
+      removeItem: (key: string) => removed.push(key),
+    }
+
+    expect(resolveInitialLanguage(storage)).toBe('de')
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en')
+    expect(resolveInitialLanguage(storage)).toBe('en')
+
+    // Nothing was stored the first time and the second value is supported, so
+    // the clean-up never ran: it is a reaction to a dropped language, not a
+    // write on every start-up.
+    expect(removed).toEqual([])
+  })
+
   it('starts in German when storage cannot be read at all', () => {
     const blocked = {
       getItem() {
@@ -52,6 +82,29 @@ describe('language resolution', () => {
 
     expect(resolveInitialLanguage(blocked)).toBe('de')
     expect(resolveInitialLanguage(null)).toBe('de')
+  })
+
+  it('starts in the language that was last chosen', () => {
+    storeLanguage('en', localStorage)
+
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('en')
+    expect(resolveInitialLanguage(localStorage)).toBe('en')
+    // The default path — the one `main.tsx` takes — reads the same value.
+    expect(createI18n().language).toBe('en')
+  })
+
+  it('keeps working when the preference cannot be written', () => {
+    const blocked = {
+      getItem: () => null,
+      setItem() {
+        throw new Error('quota exceeded')
+      },
+    }
+
+    // The language the user asked for is already on screen; refusing the switch
+    // because it could not be remembered would trade a session for a byte.
+    expect(() => storeLanguage('en', blocked)).not.toThrow()
+    expect(() => storeLanguage('en', null)).not.toThrow()
   })
 })
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -18,8 +18,11 @@ export {
   SUPPORTED_LANGUAGES,
   isSupportedLanguage,
   resolveInitialLanguage,
+  storeLanguage,
 } from './languages'
-export type { Language } from './languages'
+export type { Language, LanguageStorage } from './languages'
+export { useLanguagePreference } from './useLanguagePreference'
+export type { LanguagePreference } from './useLanguagePreference'
 export type {
   AgentsKey,
   CanvasKey,

--- a/frontend/src/i18n/languages.ts
+++ b/frontend/src/i18n/languages.ts
@@ -1,5 +1,6 @@
 /**
- * The languages the cockpit speaks, and how the first one is chosen.
+ * The languages the cockpit speaks, how the first one is chosen, and how a
+ * choice is kept.
  *
  * German is the product's language; English is the second one. The list is
  * ordered, and its first entry is the default — an unreadable screen is worse
@@ -16,12 +17,22 @@ export const DEFAULT_LANGUAGE: Language = 'de'
 /**
  * `localStorage` key of the user's explicit choice.
  *
- * Nothing in this issue writes it; the language switch that does is #36. The
- * key is defined here so the reader and the future writer cannot drift apart,
- * and it is namespaced like `visualise-ai.ui` (the persisted UI store) rather
- * than being a bare `language`.
+ * Written by the language switch (#36) and read at start-up, namespaced like
+ * `visualise-ai.ui` (the persisted UI store) rather than being a bare
+ * `language`.
  */
 export const LANGUAGE_STORAGE_KEY = 'visualise-ai.language'
+
+/**
+ * The slice of `Storage` the preference needs.
+ *
+ * Reading is required, writing and removing are optional: a caller may hand in
+ * a read-only double, and a browser may refuse either half at any time. Every
+ * access below is guarded, so nothing here can be the reason the cockpit fails
+ * to start.
+ */
+export type LanguageStorage = Pick<Storage, 'getItem'> &
+  Partial<Pick<Storage, 'setItem' | 'removeItem'>>
 
 export function isSupportedLanguage(value: unknown): value is Language {
   return (
@@ -30,25 +41,62 @@ export function isSupportedLanguage(value: unknown): value is Language {
 }
 
 /**
- * The language to start in.
+ * The language to start in — and the one place a dropped language is cleaned
+ * up.
  *
  * A stored, still-supported choice wins; everything else is German.
  *
  * The browser's `Accept-Language` is deliberately *not* consulted. The
  * requirement is that German is the language without a stored choice (#38), and
  * a navigator sniff would break exactly that for a user whose browser is set to
- * English but who never asked the cockpit for English. A stored value that is
- * no longer supported is treated as absent rather than as an error, which is
- * also the behaviour #36 has to keep.
+ * English but who never asked the cockpit for English.
+ *
+ * ## A stored language the cockpit no longer supports
+ *
+ * Somebody chose `fr`, and a later release dropped `fr`. Reading it is not an
+ * error: the value is treated as absent and the cockpit comes up in German
+ * (#38). What #36 adds is that the value is also **removed**. Leaving it would
+ * keep a preference in the browser that nothing can act on and nothing can
+ * show — the switch would paint German while storage claims French, and the
+ * next release that happens to reintroduce `fr` would silently resurrect a
+ * choice the user made years ago.
+ *
+ * The removal lives inside the resolver rather than in a separate clean-up
+ * step, because there is exactly one moment at which the cockpit compares a
+ * stored value against the supported set, and a second implementation of that
+ * comparison is a second chance to get it wrong.
  */
 export function resolveInitialLanguage(
-  storage: Pick<Storage, 'getItem'> | null | undefined = safeLocalStorage(),
+  storage: LanguageStorage | null | undefined = safeLocalStorage(),
 ): Language {
   const stored = readStored(storage)
-  return isSupportedLanguage(stored) ? stored : DEFAULT_LANGUAGE
+  if (isSupportedLanguage(stored)) return stored
+  // Only a value that is really there is discarded — "nothing stored" is the
+  // normal case and must not cause a write.
+  if (stored !== null) discardStored(storage)
+  return DEFAULT_LANGUAGE
 }
 
-function readStored(storage: Pick<Storage, 'getItem'> | null | undefined): string | null {
+/**
+ * Persists an explicit choice, so the next visit starts in it.
+ *
+ * A failed write is swallowed on purpose. Private-mode and quota-exhausted
+ * browsers throw here, and the language the user just asked for is already on
+ * screen; refusing the switch because the preference could not be *remembered*
+ * would trade a working session for a stored byte.
+ */
+export function storeLanguage(
+  language: Language,
+  storage: LanguageStorage | null | undefined = safeLocalStorage(),
+): void {
+  try {
+    storage?.setItem?.(LANGUAGE_STORAGE_KEY, language)
+  } catch {
+    // See above.
+  }
+}
+
+function readStored(storage: LanguageStorage | null | undefined): string | null {
   if (!storage) return null
   try {
     return storage.getItem(LANGUAGE_STORAGE_KEY)
@@ -60,7 +108,16 @@ function readStored(storage: Pick<Storage, 'getItem'> | null | undefined): strin
   }
 }
 
-function safeLocalStorage(): Pick<Storage, 'getItem'> | null {
+function discardStored(storage: LanguageStorage | null | undefined): void {
+  try {
+    storage?.removeItem?.(LANGUAGE_STORAGE_KEY)
+  } catch {
+    // A browser that will not let the value go leaves it there. The cockpit
+    // still runs in German, because the value is unsupported either way.
+  }
+}
+
+function safeLocalStorage(): LanguageStorage | null {
   try {
     return typeof localStorage === 'undefined' ? null : localStorage
   } catch {

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -29,6 +29,19 @@
     "workStep_one": "{{count, number}} Arbeitsschritt",
     "workStep_other": "{{count, number}} Arbeitsschritte"
   },
+  "language": {
+    "code": {
+      "de": "DE",
+      "en": "EN"
+    },
+    "current": "Aktuelle Sprache: {{language}}",
+    "label": "Sprache",
+    "name": {
+      "de": "Deutsch",
+      "en": "English"
+    },
+    "switchTo": "Auf {{language}} umschalten"
+  },
   "state": {
     "loading": "Daten werden geladen…",
     "loadingMore": "Lädt…"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -29,6 +29,19 @@
     "workStep_one": "{{count, number}} work step",
     "workStep_other": "{{count, number}} work steps"
   },
+  "language": {
+    "code": {
+      "de": "DE",
+      "en": "EN"
+    },
+    "current": "Current language: {{language}}",
+    "label": "Language",
+    "name": {
+      "de": "Deutsch",
+      "en": "English"
+    },
+    "switchTo": "Switch to {{language}}"
+  },
   "state": {
     "loading": "Loading data…",
     "loadingMore": "Loading…"

--- a/frontend/src/i18n/useLanguagePreference.ts
+++ b/frontend/src/i18n/useLanguagePreference.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  DEFAULT_LANGUAGE,
+  type Language,
+  isSupportedLanguage,
+  storeLanguage,
+} from './languages'
+
+export interface LanguagePreference {
+  /** The language the cockpit is rendering in right now. */
+  language: Language
+  /** Switches to another language and remembers it. A no-op for the active one. */
+  choose: (language: Language) => void
+}
+
+/**
+ * Reading and changing the cockpit's language.
+ *
+ * The whole of the language switch is these two lines of behaviour, and both
+ * of them are about what the switch must **not** do.
+ *
+ * `choose` calls `i18n.changeLanguage` and nothing else. It does not navigate,
+ * it does not touch the UI store, and above all it does not reload: every text
+ * on screen already comes from the instance (#42), so a `languageChanged` event
+ * re-renders the cockpit in place. The URL, the selected component, the pane
+ * sizes, the collapsed containers and the canvas camera are therefore preserved
+ * by *omission* rather than by being saved and restored — which is the only way
+ * to preserve state that nothing enumerates. A `location.reload()` would throw
+ * away exactly the transient half of the UI store (camera, disclosure,
+ * selection), which `uiStore.ts` deliberately does not persist.
+ *
+ * `language` is read back from the instance rather than kept in state of its
+ * own, so a component can never translate in one language while it believes it
+ * is in another, and an unknown value coming out of i18next resolves to German
+ * the same way a stored one does.
+ */
+export function useLanguagePreference(): LanguagePreference {
+  const { i18n } = useTranslation()
+  const active = i18n.resolvedLanguage ?? i18n.language
+  const language = isSupportedLanguage(active) ? active : DEFAULT_LANGUAGE
+
+  const choose = useCallback(
+    (next: Language) => {
+      if (next === language) return
+      // Stored first: the write is what makes the *next* visit start here, and
+      // it must not depend on the re-render that follows succeeding.
+      storeLanguage(next)
+      void i18n.changeLanguage(next)
+    },
+    [i18n, language],
+  )
+
+  return { language, choose }
+}

--- a/frontend/src/routes/pages/LanguageSwitch.i18n.test.tsx
+++ b/frontend/src/routes/pages/LanguageSwitch.i18n.test.tsx
@@ -1,0 +1,368 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { LANGUAGE_STORAGE_KEY, bindDocumentLanguage, createI18n } from '@/i18n'
+import { useUiStore } from '@/state/uiStore'
+import { largeArchitectureResponse } from '@/test/architectureFixtures'
+import { PROJECT_ID, RUN_ID, component, createFakeFetch } from '@/test/fixtures'
+import {
+  COMPONENT_ID,
+  HISTORY_PATH,
+  INSPECTOR_PATH,
+  historyPage,
+  inspectorPage,
+} from '@/test/inspectorFixtures'
+import { renderApp } from '@/test/renderApp'
+import {
+  longTaskAgentsResponse,
+  openRunResponse,
+  runPaths,
+  runsWithHistoryResponse,
+  twoRevisionPlansResponse,
+} from '@/test/runFixtures'
+
+/**
+ * Switching the language **at runtime** (#36).
+ *
+ * Every assertion in this file is about something that must *not* happen. The
+ * cockpit already renders in two languages (#42); what this issue adds is a
+ * control, and a control that loses the user's place is worse than no control.
+ * So the switch is measured against the state it is not allowed to touch:
+ *
+ * * the URL — which carries the whole selection (`?component=`, `?focus=`,
+ *   `?history=`) and must come out byte-identical;
+ * * the pane arrangement — sizes and collapse flags;
+ * * the canvas camera — a language changes text lengths, and a re-fit would
+ *   throw the reader out of the part of the architecture they were reading.
+ *   The camera policy knows three reasons to move (ADR 0008, ADR 0017) and a
+ *   language switch is none of them, so `data-fit-view-count` and the rendered
+ *   viewport transform have to be the same number before and after;
+ * * the reported data — the agent's task, its feedback, its diffs and every id.
+ *
+ * The one thing that *does* follow is `<html lang>`, plus the words.
+ *
+ * All of it is asserted after a real click on the switch, not after a second
+ * render in another language: the failure modes this issue is about — a fit, a
+ * navigation, a remount — only exist on the transition.
+ */
+
+const WORKSPACE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}`
+const CANVAS_TIMEOUT = 15_000
+
+/** The three panes, each with real reported content in them. */
+function workspaceServer(): typeof fetch {
+  return createFakeFetch({
+    [runPaths.runs]: runsWithHistoryResponse,
+    [runPaths.currentRun]: openRunResponse,
+    [runPaths.runDetail]: openRunResponse,
+    [runPaths.agents]: longTaskAgentsResponse,
+    [runPaths.plans]: twoRevisionPlansResponse,
+    [runPaths.architecture]: {
+      projectPosition: 42,
+      components: [component({ componentId: COMPONENT_ID, name: 'Tax', kind: 'module' })],
+      relationships: [],
+      activeChanges: [],
+    },
+    [INSPECTOR_PATH]: inspectorPage(),
+    [HISTORY_PATH]: historyPage(),
+  })
+}
+
+function englishSegment(): HTMLElement {
+  return screen.getByTestId('language-option-en')
+}
+
+/**
+ * Resolves once the workspace has stopped moving on its own.
+ *
+ * Every measurement here is a before/after comparison inside **one** rendering,
+ * so it has to start after the last thing the cockpit does unprompted: the
+ * three panes arriving, ELK finishing, the initial disclosure being written
+ * down and the one automatic camera movement landing. Measuring earlier would
+ * charge the language switch for a change it did not cause — and, worse, would
+ * hide one it did.
+ */
+async function waitForSettledWorkspace(): Promise<HTMLElement> {
+  const canvas = await screen.findByTestId('architecture-canvas', undefined, {
+    timeout: CANVAS_TIMEOUT,
+  })
+  await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'), {
+    timeout: CANVAS_TIMEOUT,
+  })
+  await waitForCameraSettled()
+  return canvas
+}
+
+/** Every reported value on screen, in document order. */
+function reportedValues(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('[data-reported]')].map(
+    (node) => node.textContent ?? '',
+  )
+}
+
+afterEach(() => {
+  document.documentElement.lang = ''
+})
+
+describe('language switch — the URL is not touched', () => {
+  it('leaves a workspace URL with a selection and a focus byte-identical', async () => {
+    const user = userEvent.setup()
+    const url = `${WORKSPACE_URL}?component=${COMPONENT_ID}&focus=feedback&history=true`
+    const { router } = renderApp(url, { fetchImpl: workspaceServer() })
+
+    await waitForSettledWorkspace()
+    const before = router.state.location.href
+    expect(before).toContain(`component=${COMPONENT_ID}`)
+    expect(before).toContain('focus=feedback')
+    expect(before).toContain('history=true')
+
+    await user.click(englishSegment())
+    await screen.findByRole('heading', { name: 'Architecture' })
+
+    // Not "equivalent" and not "the same parameters": the same string.
+    expect(router.state.location.href).toBe(before)
+    expect(router.state.location.search).toEqual({
+      component: COMPONENT_ID,
+      focus: 'feedback',
+      history: true,
+    })
+    // …and it was one entry in the history, not two.
+    expect(router.history.length).toBe(1)
+  })
+})
+
+describe('language switch — the working context survives', () => {
+  it('keeps pane widths, collapsed panes and the selected component', async () => {
+    const user = userEvent.setup()
+    const { container } = renderApp(`${WORKSPACE_URL}?component=${COMPONENT_ID}`, {
+      fetchImpl: workspaceServer(),
+    })
+    await waitForSettledWorkspace()
+
+    // An arrangement the user made: a dragged split, a folded inspector and a
+    // collapsed branch of the agent tree.
+    useUiStore.getState().setLayout({
+      'workspace-left': 24,
+      'workspace-center': 46,
+      'workspace-right': 30,
+    })
+    useUiStore.getState().setRightCollapsed(true)
+    useUiStore.getState().setAgentCollapsed('subagent-implementer', true)
+    useUiStore.getState().setMinimapVisible(false)
+    await screen.findByTestId('pane-rail-right')
+
+    const before = snapshotUi()
+
+    await user.click(englishSegment())
+    await screen.findByRole('heading', { name: 'Architecture' })
+
+    expect(snapshotUi()).toEqual(before)
+    // The pane really is still folded, not merely flagged as folded.
+    expect(screen.getByTestId('pane-rail-right')).toBeInTheDocument()
+    expect(container.querySelector('[data-reported]')).not.toBeNull()
+  })
+
+  it('leaves every reported value byte-identical across the switch', async () => {
+    const user = userEvent.setup()
+    const { container } = renderApp(`${WORKSPACE_URL}?component=${COMPONENT_ID}`, {
+      fetchImpl: workspaceServer(),
+    })
+    await screen.findByTestId('inspector-context')
+    await screen.findByTestId('agent-tree')
+    await waitForSettledWorkspace()
+
+    const before = reportedValues(container)
+    expect(before.length).toBeGreaterThan(20)
+    // The chrome really is German at this point, so the comparison below is
+    // between two different languages and not between two identical renders.
+    expect(screen.getByRole('heading', { name: 'Architektur' })).toBeVisible()
+
+    await user.click(englishSegment())
+    await screen.findByRole('heading', { name: 'Architecture' })
+
+    // Same strings, same order, character for character — after the switch,
+    // not after a second render.
+    expect(reportedValues(container)).toEqual(before)
+  })
+})
+
+describe('language switch — the canvas camera stays where it was', () => {
+  it(
+    'neither fits the view nor moves the viewport',
+    async () => {
+      const user = userEvent.setup()
+      renderApp(WORKSPACE_URL, {
+        fetchImpl: createFakeFetch({
+          [runPaths.architecture]: largeArchitectureResponse,
+        }),
+      })
+
+      const canvas = await waitForSettledWorkspace()
+
+      const fitsBefore = canvas.getAttribute('data-fit-view-count')
+      const transformBefore = viewportTransform()
+      const cameraBefore = useUiStore.getState().camera
+      expect(fitsBefore).toBe('1')
+      expect(transformBefore).not.toBe('')
+
+      await user.click(englishSegment())
+      await screen.findByRole('heading', { name: 'Architecture' })
+      await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'), {
+        timeout: CANVAS_TIMEOUT,
+      })
+
+      // The one automatic movement of a project's lifetime already happened;
+      // a language is not a second reason for it.
+      expect(canvas.getAttribute('data-fit-view-count')).toBe(fitsBefore)
+      expect(viewportTransform()).toBe(transformBefore)
+      expect(useUiStore.getState().camera).toEqual(cameraBefore)
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('language switch — the page says which language it is in', () => {
+  it('updates <html lang> without reloading', async () => {
+    const user = userEvent.setup()
+    const i18n = createI18n({ language: 'de' })
+    const unbind = bindDocumentLanguage(i18n)
+    renderApp('/projects', { i18n })
+
+    await screen.findByRole('heading', { name: 'Projekte' })
+    expect(document.documentElement.lang).toBe('de')
+
+    await user.click(englishSegment())
+
+    expect(await screen.findByRole('heading', { name: 'Projects' })).toBeVisible()
+    expect(document.documentElement.lang).toBe('en')
+    unbind()
+  })
+})
+
+describe('language switch — the choice is remembered', () => {
+  it('writes the choice and starts the next visit in it', async () => {
+    const user = userEvent.setup()
+    renderApp('/projects')
+
+    await screen.findByRole('heading', { name: 'Projekte' })
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBeNull()
+
+    await user.click(englishSegment())
+    await screen.findByRole('heading', { name: 'Projects' })
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('en')
+
+    // The next visit — a fresh instance that decides its language the way
+    // `main.tsx` does, from storage alone.
+    expect(createI18n().language).toBe('en')
+  })
+})
+
+describe('language switch — the control itself', () => {
+  it('is operable with the keyboard alone and keeps the focus where it was used', async () => {
+    const user = userEvent.setup()
+    renderApp('/projects')
+    await screen.findByRole('heading', { name: 'Projekte' })
+
+    const english = englishSegment()
+    english.focus()
+    expect(english).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+
+    expect(await screen.findByRole('heading', { name: 'Projects' })).toBeVisible()
+    // The switch is not a navigation, so the button the user pressed is still
+    // there and still has the focus — it is not dropped onto `<body>`.
+    expect(screen.getByTestId('language-option-en')).toHaveFocus()
+    expect(document.activeElement).not.toBe(document.body)
+  })
+
+  it('reaches both segments with Tab and shows which one is active', async () => {
+    const user = userEvent.setup()
+    renderApp('/projects')
+    await screen.findByRole('heading', { name: 'Projekte' })
+
+    const german = screen.getByTestId('language-option-de')
+    expect(german).toHaveAttribute('aria-pressed', 'true')
+    expect(englishSegment()).toHaveAttribute('aria-pressed', 'false')
+
+    german.focus()
+    await user.tab()
+    expect(englishSegment()).toHaveFocus()
+
+    await user.keyboard(' ')
+    await screen.findByRole('heading', { name: 'Projects' })
+    expect(screen.getByTestId('language-option-en')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('language-option-de')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('names itself in the active language and its segments in their own', async () => {
+    const user = userEvent.setup()
+    renderApp('/projects')
+    await screen.findByRole('heading', { name: 'Projekte' })
+
+    expect(screen.getByRole('group', { name: 'Sprache' })).toBeInTheDocument()
+    // A reader who ended up in a language they cannot read still has to find
+    // their way out, so each segment is named in its own language.
+    expect(screen.getByRole('button', { name: 'Deutsch' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'English' })).toBeInTheDocument()
+
+    await user.click(englishSegment())
+    await screen.findByRole('heading', { name: 'Projects' })
+
+    expect(screen.getByRole('group', { name: 'Language' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Deutsch' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'English' })).toBeInTheDocument()
+  })
+
+  it('is reachable from the project list and from the workspace', async () => {
+    const list = renderApp('/projects')
+    await screen.findByRole('heading', { name: 'Projekte' })
+    expect(screen.getByTestId('language-switcher')).toBeInTheDocument()
+    list.unmount()
+
+    renderApp(WORKSPACE_URL, { fetchImpl: workspaceServer() })
+    await waitForSettledWorkspace()
+    expect(screen.getByTestId('language-switcher')).toBeInTheDocument()
+  })
+})
+
+/** The part of the UI store a language switch is forbidden to move. */
+function snapshotUi() {
+  const state = useUiStore.getState()
+  return {
+    layout: state.layout,
+    leftCollapsed: state.leftCollapsed,
+    rightCollapsed: state.rightCollapsed,
+    collapsedAgentIds: state.collapsedAgentIds,
+    collapsedComponentIds: state.collapsedComponentIds,
+    minimapVisible: state.minimapVisible,
+    camera: state.camera,
+    selectedComponentId: state.selectedComponentId,
+    deepFocus: state.deepFocus,
+  }
+}
+
+/** The rendered zoom and pan — the ground truth of where the camera is. */
+function viewportTransform(): string {
+  return (
+    document.querySelector<HTMLElement>('.react-flow__viewport')?.style.transform ?? ''
+  )
+}
+
+/** Resolves once the one automatic fit has run its course. */
+async function waitForCameraSettled(): Promise<void> {
+  await waitFor(() => expect(useUiStore.getState().camera.zoom).toBeGreaterThan(0), {
+    timeout: CANVAS_TIMEOUT,
+  })
+  let previous = useUiStore.getState().camera
+  await waitFor(
+    () => {
+      const current = useUiStore.getState().camera
+      const settled = current === previous
+      previous = current
+      expect(settled).toBe(true)
+    },
+    { timeout: CANVAS_TIMEOUT, interval: 40 },
+  )
+}

--- a/frontend/src/routes/pages/ProjectsPage.tsx
+++ b/frontend/src/routes/pages/ProjectsPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import { useProjects } from '@/api/queries'
 import { AsyncState } from '@/components/AsyncState'
+import { LanguageSwitcher } from '@/components/LanguageSwitcher'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { ReportedText, ReportedTime } from '@/i18n'
@@ -25,8 +26,20 @@ export function ProjectsPage() {
     <main className="min-h-0 flex-1">
       <ScrollArea className="h-full">
         <div className="mx-auto w-full max-w-3xl px-6 py-10">
-          <h1 className="text-xl font-semibold">{t('list.title')}</h1>
-          <p className="text-muted-foreground mt-1 text-sm">{t('list.description')}</p>
+          {/*
+            The project list is the cockpit's entry point and the page every
+            other one links back to, so it carries the second — and last —
+            language switch. Choosing the language before opening a workspace
+            has to be possible; repeating the control on every screen would not
+            make it more reachable, only louder.
+          */}
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <h1 className="text-xl font-semibold">{t('list.title')}</h1>
+              <p className="text-muted-foreground mt-1 text-sm">{t('list.description')}</p>
+            </div>
+            <LanguageSwitcher className="mt-0.5 shrink-0" />
+          </div>
 
           <div className="mt-6">
             <AsyncState


### PR DESCRIPTION
Closes #36

Zwei Segmente, `DE` und `EN`, im **Workspace-Header** (rechts, neben Live-Badge
und Pane-Toggle) und neben der Überschrift der **Projektliste**. Ein Klick
schreibt die Auswahl nach `visualise-ai.language` und ruft
`i18n.changeLanguage` — mehr passiert nicht. Genau daraus folgt alles Weitere:
kein `location.reload()`, keine Navigation, kein Schreiben in den UI-Store, kein
Unmount. Der Arbeitskontext bleibt erhalten, weil ihn nichts anfasst, und nicht
weil er gesichert und wiederhergestellt wird.

## Wo die Sprachwahl sitzt, und warum

Der Workspace-Header ist das einzige dauerhafte Chrome des Cockpits, und dort
bewegt sich der Nutzer. Die Projektliste ist der Einstiegspunkt, auf den jede
andere Seite zurückverlinkt — dort muss die Sprache wählbar sein, bevor ein
Workspace geöffnet wird. Fehler- und Not-Found-Seite bekommen sie bewusst
**nicht**: Sackgassen mit genau einer Handlung, und ein Präferenzregler neben
einem Fehler ist Lärm zum falschen Zeitpunkt. Eine globale Leiste über dem
Router hätte auf jedem Bildschirm vertikale Pixel gekostet, die das
Desktopbudget (ADR 0015) schon an drei Panes und 44 px Header vergeben hat.

Kein Dropdown: bei zwei Sprachen zeigen zwei Segmente Auswahl und Antwort
gleichzeitig, in Badge-Breite. Gemessen **59 × 30 px** in einem 44-px-Header,
`headerOverflow = 0` bei 1920 und bei 1280; das Canvas behält 54 % der Breite.

## Nachweis — Laufzeitwechsel, kein Reload

`npm run dev -- --port 5182` gegen den laufenden Stack auf Port 8080, Projekt
`visualise-ai-self`, 1920 × 1080. `visualise-ai.ui` und
`visualise-ai.language` vorher geleert. Ausgangslage bewusst „benutzt": einmal
hineingezoomt, einen Container aufgeklappt, `?component=` und `?focus=` gesetzt
(deep focus, linkes Pane als Rail). Dann ein echter Klick auf `EN`,
programmatisch am DOM gemessen — Screenshots sind in dieser Umgebung nicht
verfügbar („pane not displayed").

| Messwert | vorher | nachher |
| --- | --- | --- |
| `location.href` | `…/runs/run-v0-epic-1?component=visualise-ai.frontend.canvas&focus=feedback` | **identisch** |
| `document.documentElement.lang` | `de` | `en` |
| `localStorage['visualise-ai.language']` | `null` | `en` |
| `data-fit-view-count` | `1` | `1` |
| `.react-flow__viewport` transform | `translate(-655.786px, 63.455px) scale(0.924)` | **identisch** |
| `data-canvas-zoom` | `0.9240` | `0.9240` |
| Pane-Breiten (l/m/r) | `57.542 / 786.375 / 1074.083 px` | **identisch** |
| `flex` je Pane | `3 / 41 / 56` | **identisch** |
| eingeklapptes Pane | `pane-rail-left` | `pane-rail-left` |
| eingeklappte Container | `visualise-ai.backend`, `visualise-ai.frontend.components` | **identisch** |
| verborgene Knoten / Knotenzahl | `12` / `17` | `12` / `17` |
| `localStorage['visualise-ai.ui']` | — | **unverändert** |
| `[data-reported]` | 51 Werte | **51, Array-Vergleich `true`, erste Abweichung `null`** |
| `document.activeElement` | `node-disclosure-…frontend.api` | `language-option-en` |
| Pane-Titel | Run- und Agent-Bereich · Architektur · Beziehungsarten · Arbeitszustände · Inspector · KI-Feedback | Runs and agents · Architecture · Relationship kinds · Work states · Inspector · AI feedback |
| Inspector-Tabs | Aktueller Run · Historie | Current run · History |

`window.__before` (vor dem Klick gesetzt) existierte danach noch — **es gab
keinen Reload**.

Weitere Läufe am selben System:

- **Erneuter Aufruf:** Reload derselben URL → `lang=en`, `stored=en`,
  `aria-pressed`: `de=false`, `en=true`, Gruppenname „Language".
- **Ohne gespeicherte Wahl:** erster Start → `stored=null`, `lang=de`.
- **Nicht mehr unterstützte Sprache:** `localStorage['visualise-ai.language'] =
  'fr'`, Neuladen → `lang=de`, Gruppenname „Sprache", `de` aktiv, Canvas
  vorhanden, **`stored=null`** — der ungültige Wert ist weg, kein Absturz.
- **Tastatur/A11y am laufenden System:** beide Segmente `tabIndex=0`,
  `role=group` mit `aria-label`, zugängliche Namen „Deutsch" / „English",
  sichtbarer Text `DE` / `EN`, `aria-pressed` folgt der aktiven Sprache.
- **1280 × 1024:** `headerOverflow=0`, `bodyOverflowX=0`, Panes `230 / 690 /
  358 px`, Canvas 54 %.

## Verhalten bei einer nicht mehr unterstützten gespeicherten Sprache

`resolveInitialLanguage` fällt weiterhin auf Deutsch zurück (#38) und **entfernt
den Wert jetzt zusätzlich**. Ihn stehen zu lassen wäre auf zwei Arten falsch:
die Sprachwahl zeigte Deutsch, während der Speicher `fr` behauptet, und ein
späteres Release, das `fr` wieder einführt, würde eine längst überholte Wahl
still reaktivieren. Die Bereinigung sitzt im Resolver, weil es genau eine
Stelle gibt, an der ein gespeicherter Wert gegen die unterstützte Menge geprüft
wird — eine zweite Implementierung dieses Vergleichs wäre eine zweite Chance,
ihn falsch zu machen. Ein schlicht fehlender Wert löst keinen Schreibzugriff
aus. Lesen, Schreiben und Löschen sind einzeln abgesichert; ein Browser im
privaten Modus bekommt trotzdem ein laufendes Cockpit.

## Zugänglichkeit

`role="group"` mit übersetztem Namen („Sprache" / „Language"), darin zwei
`aria-pressed`-Umschalter — kein `radiogroup`, weil dessen Roving-`tabindex`
und Pfeiltastenmodell hier selbst geschrieben werden müssten (es gibt keine
shadcn-ToggleGroup im Repo) und bei zwei Optionen nichts einbrächte, was der
Gruppenname nicht schon leistet. Beide Segmente sind normale Tab-Stopps,
`Enter` und `Space` lösen aus.

Jedes Segment trägt seinen Namen **in der eigenen Sprache** („Deutsch",
„English", in beiden Katalogen gleich): Wer in einer für ihn unlesbaren Sprache
gelandet ist, muss wieder herausfinden können. Der Fokus bleibt nach dem Klick
auf dem gedrückten Segment, dessen `aria-pressed` gerade umgesprungen ist —
bewusst dort, wo der Nutzer ohnehin ist, und nicht auf `<body>`, wo ein Reload
ihn abgelegt hätte.

## Tests

429 statt 415, alle grün. Neu (14):

- URL bleibt bytegleich, inklusive `?component=`, `?focus=` und `?history=`;
  `router.history.length` bleibt `1`.
- Pane-Breiten, Kollaps-Flags, kollabierte Agents, Minimap, Kamera,
  Auswahl und Deep-Focus-Zustand unverändert; das rechte Pane ist danach
  wirklich noch eingeklappt.
- Alle `[data-reported]`-Texte vor und nach dem Klick identisch (Array-Vergleich
  in einer Darstellung, nicht zwei Renderings).
- `data-fit-view-count` und `.react-flow__viewport`-Transform unverändert.
- `html lang` folgt ohne Reload.
- Auswahl wird geschrieben; `createI18n()` startet danach in ihr.
- Tastaturbedienung: Tab erreicht beide Segmente, `Enter`/`Space` lösen aus, der
  Fokus bleibt auf dem gedrückten Segment.
- Zugängliche Namen in beiden Sprachen.
- Speicherregeln: ohne Wahl Deutsch, gespeicherte Wahl gewinnt, `fr` wird
  verworfen *und gelöscht*, ein gültiger Wert löst keinen Schreibzugriff aus,
  blockierter Speicher wirft nicht.

Der Testaufbau wartet erst, bis der Workspace von sich aus stillsteht (ELK
fertig, initiale Disclosure geschrieben, die eine automatische Kamerabewegung
gelandet) — sonst würde dem Sprachwechsel eine Änderung angelastet, die er nicht
verursacht hat, und schlimmer: eine verursachte verdeckt.

## Kommandos

| Kommando | Ergebnis |
| --- | --- |
| `npm run lint` | grün |
| `npm run typecheck` | grün |
| `npm run check:locales` | `Translation catalogues agree: 373 keys, de, en, reference de.` |
| `npm run check:ui-strings` | `No hard-coded UI text: 100 files scanned in src, 4 reasoned exceptions.` |
| `npm test` | `43 Dateien, 429 Tests` — grün (vorher 415) |
| `npm run build` | grün (Chunk-Warnung wie bisher, ADR 0003) |

## Umfang

Nur #36. Keine weiteren Textmigrationen, keine Formatierungsänderungen, keine
E2E-Tests (#37), keine Änderung an Canvas, Viewport oder Agentenbereich. Die
sieben Katalogschlüssel unter `common:language.*` sind die der Sprachwahl selbst
— `common` und nicht `workspace`, weil das Bedienelement auf zwei Oberflächen
erscheint und damit zu keiner von beiden gehört.

## Anmerkungen für die Verifikation

- `resolveInitialLanguage` hat jetzt einen Seiteneffekt, den sein Name nicht
  ankündigt. Bewusst so: eine zweite Stelle für denselben Vergleich wäre die
  schlechtere Wahl. Dokumentiert an der Funktion, im README und in ADR 0021.
- Der Tastaturweg ist im laufenden Browser nur strukturell belegt (Rollen,
  Namen, `tabIndex`), nicht als echter Tastendruck: die Eingabezustellung der
  Browser-Automatisierung dieser Umgebung fiel nach den ersten Interaktionen
  aus („pane not displayed"). Der Klickpfad *wurde* echt ausgeführt, und
  Tab/Enter/Space sind in jsdom gegen die reale Anwendung getestet.
- Nichts außerhalb von #36 aufgefallen, das hier zu melden wäre.
