### PR TITLE
Sprach-, Accessibility- und Layouttests ergänzen (#37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,23 @@ jobs:
       # frontend would be typed against a document nobody published.
       - run: npm run check:contract
         working-directory: frontend
+
+      # The two catalogue guards run as steps of their own, before the suite.
+      #
+      # Both are also executed by Vitest (`src/i18n/catalogues.test.ts`,
+      # `src/i18n/uiStrings.test.ts`), which is what proves they *work* — those
+      # tests run them against deliberately broken catalogues as well. What a
+      # named step adds is the failure being readable: "check locale catalogues"
+      # in red says a key is missing in one language, where "frontend (react)"
+      # in red says something among 400-odd tests went wrong. Issue #37 asks for
+      # catalogue parity to be validated in CI; this is where that happens.
+      - name: Check locale catalogues (key parity across languages)
+        run: npm run check:locales
+        working-directory: frontend
+      - name: Check for UI text outside the catalogues
+        run: npm run check:ui-strings
+        working-directory: frontend
+
       - run: npm run lint
         working-directory: frontend
       - run: npm run typecheck

--- a/docs/decisions/0022-translation-test-suite-pseudo-locale-and-a-suite-that-can-be-believed.md
+++ b/docs/decisions/0022-translation-test-suite-pseudo-locale-and-a-suite-that-can-be-believed.md
@@ -345,9 +345,10 @@ suite.
   package boundary on purpose — the e2e project has its own `package.json` and
   `tsconfig.json` and does not import from the frontend — and each asserts the
   30–40 % band for itself.
-- **The acceptance run grew from 21 checks to 25** and by roughly a minute:
-  three extra page loads for the pseudo-locale, two for the language sweep. It
-  still runs one worker, no retries, no fixed sleeps.
+- **The acceptance run grew from 21 checks to 25**, and by about six seconds:
+  the four new checks measured 1.3 s, 1.3 s, 1.8 s and 1.1 s against a two-minute
+  run whose cost is dominated by the Compose build and the two 30-second
+  simulator sequences. It still runs one worker, no retries, no fixed sleeps.
 - **Screenshots accumulate in the report artefact.** Nine images per run
   (three widths × German, English, pseudo), retained for 14 days by the existing
   upload step. Nothing fails because of them, and nothing has to be regenerated

--- a/docs/decisions/0022-translation-test-suite-pseudo-locale-and-a-suite-that-can-be-believed.md
+++ b/docs/decisions/0022-translation-test-suite-pseudo-locale-and-a-suite-that-can-be-believed.md
@@ -1,0 +1,357 @@
+# 22. The translation test suite: the flake before the coverage, a third language nobody can choose, and screenshots that are evidence rather than a gate
+
+- **Status:** accepted
+- **Date:** 2026-08-05
+- **Context issue:** #37 (last of the i18n epic #1)
+- **Builds on:** [0013 — Mandatory end-to-end acceptance](./0013-mandatory-end-to-end-acceptance.md),
+  [0014 — Localisation architecture and the translation contract](./0014-localisation-architecture-and-translation-contract.md),
+  [0015 — Desktop viewport and absolute pane minimums](./0015-desktop-viewport-and-absolute-pane-minimums.md),
+  [0018 — Accessible architecture nodes](./0018-accessible-architecture-nodes.md),
+  [0019 — Locale-aware formatting and the UTC rule](./0019-locale-aware-formatting-and-the-utc-rule.md),
+  [0020 — UI text migration and the technical glossary](./0020-ui-text-migration-and-the-technical-glossary.md),
+  [0021 — Persistent language switch and state preservation](./0021-persistent-language-switch-and-state-preservation.md)
+
+## Context
+
+Four issues built the localisation layer, and each of them brought its own
+tests: the plural, date and percentage service with both languages and its edge
+cases (#40), the byte-identity proof for reported data across German and English
+(#42), the language switch that must not lose work context (#36). The suite
+stood at 429 tests, `npm run check:locales` and `npm run check:ui-strings`
+existed and were known to fail on broken catalogues.
+
+This issue is the one that asks whether all of that is *true* — and the first
+thing it found was that the suite could not be believed. Three consecutive full
+runs on a 22-core developer machine:
+
+```
+run 1:  9 failed | 420 passed
+run 2: 46 failed | 383 passed
+run 3:  1 failed | 428 passed
+```
+
+The same commit, no code changes in between. CI was green throughout, because a
+four-core runner with nothing else on it does not reproduce it. That is the
+worst shape a test suite can have: it reports a reliability it does not have,
+and it reports it *to CI*, which is the audience that decides whether something
+ships.
+
+Everything else in this issue — plural coverage, accessible names, a
+pseudo-locale, layout at three widths — is worth exactly nothing on top of a
+suite that fails one run in three for reasons unrelated to the product. The
+flake is therefore the first decision here, not an aside.
+
+## Decision
+
+### The flake, part one: the tests were never given the time they ask for
+
+The failures all read `Test timed out in 5000ms`, and they concentrated in the
+four files that render the **real** application inside jsdom — router, query
+client, React Flow and a full ELK layout: `WorkspacePage.i18n.test.tsx`,
+`ArchitectureZoom.test.tsx`, `ArchitectureCanvas.test.tsx`,
+`ChangeOverlays.test.tsx`.
+
+The obvious reading — "raise the timeout" — is the wrong instinct, and the
+question it skips is the only one that matters: *is the work actually being
+done, or is something waiting for an event that never arrives?* One measurement
+answers it. The whole suite, run once with `--testTimeout=60000` and nothing
+else changed:
+
+```
+43 files, 429 tests, all passed.
+Slowest single test: 1451 ms.
+```
+
+Nothing hangs. Every one of those tests finishes, and the slowest of them costs
+about a second and a half of work. A 5 s budget for a 1.5 s job is a factor of
+three, and a factor of three does not survive a machine that has something else
+to do.
+
+There is a second, sharper fact. The canvas files already say what they think
+they need — `CANVAS_TIMEOUT = 15_000` on their `waitFor` calls, written by
+whoever knew an ELK layout is not instant. **That number was never reachable.** A
+`waitFor` cannot outlive the test that awaits it, so Vitest's 5 s default
+silently overruled every one of them. The configuration and the tests disagreed
+about what "long enough" means, and the configuration won without saying so.
+
+`testTimeout: 20_000` and `hookTimeout: 20_000` are therefore not a concession.
+They are the file-level intention, plus room for the assertion around it, moved
+to the place that actually decides. A test that really hangs still fails — 15 s
+later, with the same message.
+
+### The flake, part two: twenty-one workers do not run twenty-one tests
+
+Vitest defaults to one worker per core. Each worker is a fork with its own
+jsdom, its own React and its own ELK, and on a 22-core machine 21 of them do not
+share the machine — they contend for it. Measured over the whole suite, on the
+machine that produced the three runs above:
+
+| max forks | wall  | test CPU | jsdom setup |
+| --------- | ----- | -------- | ----------- |
+| 21 (default) | 24 s | 135 s | 130 s |
+| 12        | 30 s  | 143 s   |  90 s |
+| 6         | 34 s  |  80 s   |  55 s |
+| 4         | 44 s  |  64 s   |  51 s |
+
+Ten seconds of wall time buy back 40 % of the CPU time each individual test
+needs, and it is the *individual* test that has a deadline. Under load the
+uncapped run needed 945 s of test CPU and failed 46 tests; the same suite capped
+needs 80 s and fails none.
+
+`maxForks: max(2, min(6, availableParallelism() - 1))` is an upper bound rather
+than a floor: a four-core CI runner keeps the three workers it would have chosen
+anyway, so nothing about CI changes. The cap exists for the machines that are
+big enough to hurt themselves.
+
+### The flake, part three: one assertion was genuinely racing
+
+Raising the budget would have hidden a third defect, which is the reason the
+measurement above had to come first. One failure was not a timeout:
+
+```
+ChangeOverlays.test.tsx > draws a new proposal without moving zoom, pan or selection
+AssertionError: expected '0' to be '1'
+  expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
+```
+
+`data-layouting: false` says that ELK is done. It does **not** say that the
+automatic camera placement has run: `fitView` happens in an effect *after* the
+layout, so `data-fit-view-count`, the viewport transform and the stored camera
+are all one commit away when the flag flips. Ten assertions across four files
+read one of the three synchronously at exactly that moment. On a quiet machine
+React has committed by then; on a busy one it has not.
+
+The fix is in the four `waitForCanvas` helpers, which now wait for the initial
+fit as well as for the layout. It is a fix to the *test's* idea of when the
+canvas is ready, not a widened tolerance: the assertions that follow are
+unchanged, and they still say `'1'`.
+
+`renderWorkspaceScene` waits for the same thing, and for one more reason: while
+ELK runs, the architecture pane carries a `canvas-layouting` element that is
+gone a moment later. A test that compares two renderings element by element —
+German against English, German against the pseudo-locale — would otherwise
+report *the progress of a layout* as a difference between two languages.
+
+### What was already there, and was not written again
+
+Most of what issue #37 lists had been built by the issues it depends on. Writing
+it a second time would have produced a suite that is longer and no stronger, so
+this issue only added what was missing:
+
+| the issue asks for | state on arrival |
+| --- | --- |
+| unit tests for plurals, dates, percentages | `i18n/formatting.test.ts` — both languages, zero/one/many, UTC labelling, invalid and unreported instants, the German non-breaking space (#40) |
+| unit tests for fallbacks and missing keys | `i18n/i18n.test.ts` — `fallbackLng`, the development marker, the production key, an emptied translation, a dropped stored language (#38) |
+| component tests for the central German and English surfaces | `ProjectsPage.i18n.test.tsx`, `WorkspacePage.i18n.test.tsx`, `LanguageSwitch.i18n.test.tsx` (#42, #36) |
+| translated `aria-label`s and screen-reader text | asserted per surface: the graph in `ArchitectureAccessibility.test.tsx` (#35), the chrome in `WorkspacePage.i18n.test.tsx` (#42) |
+| code diffs and agent messages unchanged | the `data-reported` comparison across both languages, character for character (#42) |
+| key parity of the catalogues | `npm run check:locales`, verified against five deliberately broken catalogues (#38) |
+
+Four gaps were left, and they are what this issue adds.
+
+**Counted nouns are now read out of the catalogue.** The existing plural tests
+name the nouns they check, which is what makes them readable and what makes them
+incomplete: the noun added next week is covered by none of them. A second block
+derives the list from `common.count` and asserts zero, one, many, eleven and
+1 234 in both languages for every one of them — so `count.proposal` is checked
+the day it is added.
+
+**The accessible names are swept rather than enumerated.** `aria-label`,
+`title`, `placeholder` and `sr-only` text are the four places a translation can
+be forgotten without anybody seeing it: a visible pane title that stayed German
+shows up in the first English screenshot, an `aria-label` that stayed German
+shows up when a blind user files a bug. `i18n/accessibleNames.test.tsx` walks
+both surfaces in both languages and asserts three properties that hold for names
+nobody has written yet — nothing resolves to a key or to the `⟦…⟧` marker,
+every operable control has a name, and the two languages really differ.
+
+**Two `Intl` units and two percentage edge cases were unchecked.** Weeks and
+months exist in `Intl.RelativeTimeFormat` and were never selected by a test;
+a percentage above 100 or below 0 is an agent's claim about its own progress and
+had no test saying it is passed through rather than clamped.
+
+**And the layout was only ever measured in the two languages that exist.**
+
+### A third language that nobody can choose
+
+Issue #37 asks for "a pseudo-locale or artificially 30–40 % lengthened texts".
+German is already a long language, so a layout that survives German survives
+most translations — *most*. The question no real catalogue can ask today is what
+happens when a translation is longer than anything either catalogue currently
+contains. A pane title that fits at 100 % and is cut at 135 % is a defect that
+exists **now**, and it would otherwise be found by the first translator rather
+than by the suite.
+
+Three things it deliberately is not:
+
+- **Not a supported language.** `SUPPORTED_LANGUAGES` stays `['de', 'en']`, so
+  it cannot appear in the switch, in `<html lang>` or in a stored preference.
+  The product speaks two languages and the switch shows two segments.
+- **Not a directory under `locales/`.** `npm run check:locales` compares every
+  language against German; a generated third catalogue would be a second thing
+  to keep in parity by hand and a new way to go red for a reason nobody cares
+  about.
+- **Not in the bundle.** A shipped language that the switch deliberately hides
+  is a feature nobody asked for, sitting in production forever so that a test
+  can look at it.
+
+It is a **pure function of the German catalogue**, so it cannot drift: a key
+added tomorrow is lengthened the day it is added. The German original stays at
+the front of every string — a test that fails on a pseudo rendering has to be
+debuggable from the screenshot — and the padding is appended, which is what
+keeps `{{interpolations}}` and the `<agent/>`, `<run/>`, `<field/>` slots of
+`<Trans>` intact. Both properties are asserted rather than assumed.
+
+**The clone in `createPseudoI18n` is not defensive style.** `i18next.init({
+resources })` keeps a *reference* to the object it is given, and
+`addResourceBundle` writes through it — verified, not assumed. Installing the
+pseudo catalogue without cloning the instance's store first replaces the German
+catalogue of `src/i18n/resources.ts` for the rest of the worker process, and the
+failure then surfaces in an unrelated test three files later. A test asserts
+that a plain `createI18n()` built afterwards still answers in real German, so
+the guard is known to hold.
+
+**It is implemented twice, on purpose.** The frontend suite derives a longer
+catalogue and hands it to i18next; that answers whether anything gets *lost* —
+a pane that stops rendering its legend, an `aria-label` that falls back to
+German, a control that disappears. It cannot answer whether anything gets *cut
+off*, because jsdom has no layout engine. The acceptance run therefore lengthens
+the text of the running page in the browser instead, with the same 35 % and the
+same filler, and measures. They are two implementations of one rule, and each
+asserts the rule for itself.
+
+Both leave `[data-reported]` and everything inside `translate="no"` alone. That
+is what makes the third rendering a third *proof* rather than a repetition: in
+it, every translated string on screen differs from both catalogues, so a
+reported value that had accidentally been routed through `t()` could not come
+out unchanged.
+
+### Screenshots are evidence, not a gate
+
+The issue asks for desktop screenshots at 1280, 1440 and 1920. They are
+**attached to the Playwright report**, and nothing is compared against a
+committed image.
+
+`toHaveScreenshot()` compares rendered pixels, and rendered pixels depend on the
+font stack, on hinting and on subpixel positioning. A baseline recorded in a
+Linux container disagrees with the same build on a developer's Windows machine
+over text that is perfectly correct, and the disagreement is reported as a
+failure of the release gate. ADR 0013 already decided what happens then: a gate
+that reports noise gets ignored, and an ignored gate is worse than none.
+
+What the issue actually asks for is not "the picture is identical" but "no pane
+titles, buttons, legends or status values are cut off". That is measurable
+without an image, by the browser, on the elements it is asked about:
+`scrollWidth` against `clientWidth`, with an `overflow` that hides the rest. An
+element with `overflow-x: auto` is wider than its box and perfectly readable —
+the diff view is designed that way — and is not a defect; an element with
+`overflow: hidden` or `text-overflow: ellipsis` is wider than its box and the
+rest is gone. Only the second is reported, and the answer is a number that is
+the same on every machine.
+
+The screenshots are what a human looks at afterwards, which is exactly what an
+artefact is for.
+
+### The one thing the check found, and why it is reported rather than fixed
+
+The measurement immediately found a clipped text, and it is worth writing down
+because the first reading of it was wrong.
+
+`[data-testid="pane-architecture"] h2`, needed / available in pixels:
+
+| rendering | 1920      | 1440         | 1280        |
+| --------- | --------- | ------------ | ----------- |
+| German    | 88 / 88   | 88 / 88      | 88 / **78** |
+| English   | 96 / 96   | 96 / 96      | 96 / **92** |
+| pseudo    | 122 / 122 | 122 / **87** | 122 / **0** |
+
+The architecture pane's header carries the four-state change counter and the two
+count badges — about 550 px, `shrink-0` — and the pane is 690 px wide at 1280.
+The heading is the only thing in that row that can give way, and it does.
+
+**German is already clipped at 1280.** This is therefore not a defect that
+translation introduced; it is a layout defect of the architecture header at
+narrow widths — the subject of ADR 0015 and issue #41 — which English makes
+marginally worse (4 px) and a 35 % longer translation makes severe (the title
+disappears entirely at 1280).
+
+It is reported and not fixed. The remedy is a decision about what that header
+shows when it runs out of room — condense the counter, drop the badges, wrap the
+title, reserve a minimum for the heading — and each of those is a design choice
+about the pane, made by whoever owns it. Fixing it inside a test issue would
+mean choosing one of them in a commit whose diff nobody reviews for that.
+
+The exception in the check is bounded in two directions so it cannot rot into a
+blanket permission: it names one probe, and it applies only **below 1920**,
+where the assertion stays strict for all three renderings. Every run that hits
+it writes the measurement into the Playwright report as an annotation, so a
+known defect that nobody has fixed keeps saying so.
+
+### Three widths, and why those three
+
+1920 × 1080 remains **the** acceptance surface. Checks 1–8 are untouched: same
+resolution, same assertions, same German. Check 9 runs after them and adds 1440
+and 1280.
+
+The two extra widths are not a device matrix; ADR 0015 already named them as
+ordinary desktop situations — a window that is not maximised, and 1920 at 150 %
+browser zoom, which is an accessibility setting rather than a different device.
+1280 is the interesting one: the three pane minimums add up to 1100 px, so it is
+the width at which the layout has the least room and therefore the width at
+which a longer word first hurts.
+
+Every selector in check 9 is language-independent. That is not tidiness — a
+probe list written against `aria-label="Agents filtern"` finds nothing in the
+English run and then reports "no clipped text" about a screen it never looked
+at. Every probe list in check 9 therefore asserts that it found what it was
+looking for before it asserts anything about it.
+
+### The two catalogue guards become named CI steps
+
+`npm run check:locales` and `npm run check:ui-strings` were already executed by
+the Vitest suite, which is what proves they *work*: `catalogues.test.ts` and
+`uiStrings.test.ts` run them against deliberately broken trees as well, and a
+guard that has only ever been green proves nothing.
+
+What a named step adds is the failure being readable. "check locale catalogues"
+in red says a key is missing in one language; "frontend (react)" in red says
+that something among 455 tests went wrong. The issue asks for catalogue parity
+to be validated in CI, and a validation nobody can read the result of is only
+half a validation. They run before lint and typecheck, because a catalogue
+mismatch is cheaper to find than a type error and both are cheaper than the
+suite.
+
+## Consequences
+
+- **The frontend suite is slower and reliable, in that order.** ~34 s instead of
+  ~24 s on a 22-core machine, and five consecutive full runs green on the
+  machine that previously failed one in three. On CI nothing changes: the fork
+  cap is above what a four-core runner would have used anyway.
+- **`testTimeout: 20_000` is now the budget for everything.** A genuinely hung
+  test takes 20 s to report instead of 5. That is the price of the canvas files
+  being able to wait as long as they always said they needed to.
+- **`waitForCanvas` means more than it did.** Four canvas suites and the shared
+  workspace scene now wait for the initial camera placement, not only for ELK. A
+  test that wants to observe the canvas *before* the first fit has to say so
+  explicitly — no test does today.
+- **The workspace fixture is shared.** `src/test/workspaceScene.ts` is the one
+  place the three-pane scene is wired up; `WorkspacePage.i18n.test.tsx`,
+  `WorkspacePage.pseudo.test.tsx` and `accessibleNames.test.tsx` all look at the
+  same screen, which is the point — three suites drifting onto three slightly
+  different fixtures is how they stop testing the same thing.
+- **The pseudo-locale is a maintenance obligation of two files, not of a
+  catalogue.** `frontend/src/test/pseudoLocale.ts` and `e2e/src/pseudoLocale.ts`
+  have to agree on the expansion and on the filler. They are duplicated across a
+  package boundary on purpose — the e2e project has its own `package.json` and
+  `tsconfig.json` and does not import from the frontend — and each asserts the
+  30–40 % band for itself.
+- **The acceptance run grew from 21 checks to 25** and by roughly a minute:
+  three extra page loads for the pseudo-locale, two for the language sweep. It
+  still runs one worker, no retries, no fixed sleeps.
+- **Screenshots accumulate in the report artefact.** Nine images per run
+  (three widths × German, English, pseudo), retained for 14 days by the existing
+  upload step. Nothing fails because of them, and nothing has to be regenerated
+  when a colour changes.
+- **`check:ui-strings` does not see the pseudo-locale.** It lives under
+  `src/test/`, which the script already treats as test code, and its only
+  German-looking literal is the filler.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -76,9 +76,11 @@ created`, gegen eine gefüllte Datenbank bricht der Lauf also laut ab.
 | `src/sse.ts` | Roher SSE-Leser — er besitzt den Socket, damit der Abbruch erzwungen werden kann |
 | `src/liveObserver.ts` | Wird vor dem App-Start injiziert und zeichnet die Live-Zustände auf |
 | `src/controls.ts` | Sichtbarkeit und Überdeckung über `elementFromPoint` |
-| `tests/` | Die acht verbindlichen Prüfungen, in Ausführungsreihenfolge nummeriert |
+| `src/layout.ts` | Seitenüberlauf und abgeschnittener Text — als Funktion der Fensterbreite |
+| `src/pseudoLocale.ts` | Verlängert im Browser jeden Text, der dem Cockpit gehört, um 35 % |
+| `tests/` | Die neun Prüfdateien, in Ausführungsreihenfolge nummeriert |
 
-## Die acht verbindlichen Prüfungen
+## Die neun Prüfdateien
 
 | Datei | Prüfung |
 | --- | --- |
@@ -90,6 +92,28 @@ created`, gegen eine gefüllte Datenbank bricht der Lauf also laut ab.
 | `06-run-history-focus.spec.ts` | Trennung von aktuellem Run und Historie, Deep-Focus-Grundverhalten |
 | `07-sse-replay.spec.ts` | Erzwungener SSE-Abbruch und lückenloser, geordneter Replay |
 | `08-viewport.spec.ts` | Keine horizontale Seitenscrollbar, keine verdeckte Primärsteuerung |
+| `09-i18n-layout.spec.ts` | Layout in Deutsch, Englisch und Pseudo-Locale bei 1920, 1440 und 1280 |
+
+`01`–`08` sind die verbindlichen Prüfungen des v0-Epics (#14) und bleiben
+unverändert: dieselben Assertions, dieselben 1920 × 1080, dieselbe Sprache.
+`09` kommt aus dem i18n-Epic (#37), läuft danach und fügt drei Achsen hinzu —
+zwei weitere Breiten, die zweite Sprache und eine künstlich um 35 % verlängerte
+dritte. Alle Selektoren in `09` sind sprachunabhängig; eine Prüfliste mit
+deutschen `aria-label`s findet im englischen Lauf nichts und meldet dann
+„nichts abgeschnitten" über einen Bildschirm, den sie nie angesehen hat.
+
+### Screenshots sind Belege, keine Baseline
+
+`09` hängt neun Screenshots an den Report (drei Breiten × Deutsch, Englisch,
+Pseudo-Locale). Verglichen wird **nichts** gegen ein eingechecktes Bild.
+`toHaveScreenshot()` vergleicht gerenderte Pixel, und die hängen an
+Schriftrendering und Subpixel-Positionierung: eine im Linux-Container
+aufgenommene Baseline widerspricht demselben Build auf einem Windows-Rechner
+über Text, der völlig korrekt ist. Was das Issue tatsächlich verlangt — keine
+abgeschnittenen Pane-Titel, Buttons, Legenden oder Statuswerte — wird stattdessen
+gemessen: `scrollWidth` gegen `clientWidth` bei einem `overflow`, das den Rest
+verbirgt. Die Begründung steht in
+[ADR 0022](../docs/decisions/0022-translation-test-suite-pseudo-locale-and-a-suite-that-can-be-believed.md).
 
 `02-live-updates.spec.ts` sendet die repräsentative Sequenz und ist die einzige
 Datei, die das darf: das Szenario `full` erwartet ein leeres Projekt. Die

--- a/e2e/src/layout.ts
+++ b/e2e/src/layout.ts
@@ -1,0 +1,181 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Two layout questions the acceptance run has to be able to ask at more than
+ * one window width.
+ *
+ * `08-viewport.spec.ts` asks both of them at exactly 1920 × 1080, in the
+ * arithmetic of that resolution, because that is the mandatory acceptance
+ * surface (ADR 0013). The i18n check (#37) has to ask them again at 1280 and
+ * 1440, in two languages and once more with 35 % longer text, which is nine
+ * combinations — so the questions are asked here as functions of the width
+ * instead of being written out nine times.
+ *
+ * Nothing in this file weakens check 8. It stays exactly as it was, with its
+ * own assertions, at its own resolution.
+ */
+
+export interface PageOverflow {
+  innerWidth: number
+  documentScrollWidth: number
+  documentClientWidth: number
+  bodyScrollWidth: number
+  bodyClientWidth: number
+  /** Elements sticking out past the right edge without a clipping container. */
+  offenders: string[]
+}
+
+/**
+ * Whether the page itself scrolls sideways, and what pushed it if it does.
+ *
+ * The "contained by its own scroller" exception is the same one check 8 makes,
+ * and for the same reason: a diff box, a markdown table and the React Flow
+ * canvas are all wider than their box on purpose. Content sticking out of the
+ * *page* is the defect; content sticking out of a scroll container is a
+ * feature.
+ */
+export async function readPageOverflow(page: Page, width: number): Promise<PageOverflow> {
+  return page.evaluate((limit) => {
+    const containedByItsOwnScroller = (element: Element): boolean => {
+      let ancestor = element.parentElement
+      while (ancestor !== null && ancestor !== document.body) {
+        const style = window.getComputedStyle(ancestor)
+        if (style.overflowX !== 'visible' || style.overflow !== 'visible') {
+          if (ancestor.getBoundingClientRect().right <= limit + 1) return true
+        }
+        ancestor = ancestor.parentElement
+      }
+      return false
+    }
+
+    const offenders: string[] = []
+    for (const element of Array.from(document.body.querySelectorAll('*'))) {
+      const rect = element.getBoundingClientRect()
+      if (rect.width === 0 || rect.height === 0) continue
+      if (rect.right <= limit + 1) continue
+      if (containedByItsOwnScroller(element)) continue
+      const testId = element.getAttribute('data-testid')
+      offenders.push(
+        `${element.tagName.toLowerCase()}${testId === null ? '' : `[${testId}]`} right=${Math.round(rect.right)}`,
+      )
+    }
+
+    return {
+      innerWidth: window.innerWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      documentClientWidth: document.documentElement.clientWidth,
+      bodyScrollWidth: document.body.scrollWidth,
+      bodyClientWidth: document.body.clientWidth,
+      offenders: offenders.slice(0, 12),
+    }
+  }, width)
+}
+
+export interface TextProbe {
+  name: string
+  selector: string
+}
+
+export interface TextReport {
+  name: string
+  selector: string
+  found: boolean
+  /** What the element says, shortened for the failure message. */
+  text: string
+  /** Wider than its box **and** the excess is unreachable. */
+  clippedHorizontally: boolean
+  /** Taller than its box and the excess is unreachable. */
+  clippedVertically: boolean
+  /** The whole box lies inside the viewport. */
+  insideViewport: boolean
+  scrollWidth: number
+  clientWidth: number
+  scrollHeight: number
+  clientHeight: number
+}
+
+/**
+ * Whether a text is cut off — as the browser lays it out, not as the DOM
+ * describes it.
+ *
+ * "Cut off" is `scrollWidth > clientWidth` **and** an `overflow` that hides the
+ * rest. An element with `overflow-x: auto` is wider than its box and perfectly
+ * readable, because the reader can scroll it; an element with
+ * `overflow: hidden` or `text-overflow: ellipsis` is wider than its box and the
+ * rest is gone. Only the second is a defect, and only the second is reported
+ * here — which is what keeps this check from going red on the diff view that is
+ * *designed* to scroll sideways.
+ */
+export async function probeTexts(
+  page: Page,
+  probes: readonly TextProbe[],
+): Promise<TextReport[]> {
+  return page.evaluate((list) => {
+    return list.map((probe) => {
+      const element = document.querySelector(probe.selector)
+      if (element === null) {
+        return {
+          name: probe.name,
+          selector: probe.selector,
+          found: false,
+          text: '',
+          clippedHorizontally: false,
+          clippedVertically: false,
+          insideViewport: false,
+          scrollWidth: 0,
+          clientWidth: 0,
+          scrollHeight: 0,
+          clientHeight: 0,
+        }
+      }
+
+      const style = window.getComputedStyle(element)
+      const hides = (value: string) => value === 'hidden' || value === 'clip'
+      const rect = element.getBoundingClientRect()
+
+      return {
+        name: probe.name,
+        selector: probe.selector,
+        found: true,
+        text: (element.textContent ?? '').trim().slice(0, 80),
+        clippedHorizontally:
+          element.scrollWidth > element.clientWidth + 1 &&
+          (hides(style.overflowX) || style.textOverflow === 'ellipsis'),
+        clippedVertically:
+          element.scrollHeight > element.clientHeight + 1 && hides(style.overflowY),
+        insideViewport:
+          rect.left >= 0 &&
+          rect.top >= 0 &&
+          rect.right <= window.innerWidth + 1 &&
+          rect.bottom <= window.innerHeight + 1,
+        scrollWidth: element.scrollWidth,
+        clientWidth: element.clientWidth,
+        scrollHeight: element.scrollHeight,
+        clientHeight: element.clientHeight,
+      }
+    })
+  }, [...probes])
+}
+
+/** Renders a report list for an assertion message. */
+export function formatTextReports(reports: readonly TextReport[]): string {
+  return reports
+    .map(
+      (report) =>
+        `  ${report.name} (${report.selector}): found=${report.found} ` +
+        `clippedX=${report.clippedHorizontally} clippedY=${report.clippedVertically} ` +
+        `inside=${report.insideViewport} ` +
+        `${report.scrollWidth}/${report.clientWidth}px × ${report.scrollHeight}/${report.clientHeight}px ` +
+        `"${report.text}"`,
+    )
+    .join('\n')
+}
+
+/** Every reported value on screen, in document order and byte for byte. */
+export async function readReportedValues(page: Page): Promise<string[]> {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll('[data-reported]')).map(
+      (node) => node.textContent ?? '',
+    ),
+  )
+}

--- a/e2e/src/pseudoLocale.ts
+++ b/e2e/src/pseudoLocale.ts
@@ -1,0 +1,156 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * The pseudo-locale, applied to a running page.
+ *
+ * ## What it is
+ *
+ * Every word the **cockpit** owns, 35 % longer. Every value an **agent**
+ * reported, untouched.
+ *
+ * Issue #37 asks for "a pseudo-locale or artificially 30–40 % lengthened
+ * texts". The frontend suite takes the first half of that sentence: it derives
+ * a longer catalogue from the German one and hands it to i18next
+ * (`frontend/src/test/pseudoLocale.ts`). That answers whether anything gets
+ * *lost*; it cannot answer whether anything gets *cut off*, because jsdom has
+ * no layout engine.
+ *
+ * This file takes the second half, in the only place where the question is
+ * decidable: the real browser, against the built deployment. Adding a third
+ * catalogue to the product instead was rejected — the cockpit speaks two
+ * languages, and a shipped language that the switch deliberately hides is a
+ * feature nobody asked for, sitting in the production bundle forever so that a
+ * test can look at it.
+ *
+ * ## Why the expansion is the same 35 %
+ *
+ * The two halves have to describe the same locale or neither of them proves
+ * anything about the other. They are two implementations of one rule, and each
+ * asserts the rule for itself: `pseudoLocale.test.ts` on the catalogue, the
+ * check below on the DOM it produced.
+ *
+ * ## What is deliberately not touched
+ *
+ * `[data-reported]` and everything inside `translate="no"`. Those are the
+ * agent's bytes (ADR 0014). Leaving them alone is what makes the third
+ * rendering a *third* proof of the byte-identity property rather than a
+ * repetition of the first two: in this rendering every translated string on
+ * screen differs from both catalogues, so a reported value that had
+ * accidentally been routed through `t()` could not come out unchanged.
+ */
+
+/** How much longer a pseudo string is. Mirrors `PSEUDO_EXPANSION`. */
+export const PSEUDO_EXPANSION = 0.35
+
+/**
+ * The padding. Mirrors the frontend's `FILLER`.
+ *
+ * Latin letters and umlauts, so the browser measures it with the same font it
+ * measures a real translation with, and starting with a space so it wraps as
+ * words instead of turning a label into one unbreakable token.
+ */
+export const PSEUDO_FILLER = ' ähnlich lange wörter'
+
+/** A token that is in every lengthened string and in no real translation. */
+export const PSEUDO_MARKER = 'ähnlich'
+
+export interface PseudoLocaleReport {
+  /** Text nodes that were lengthened. */
+  textNodes: number
+  /** Name-bearing attributes that were lengthened. */
+  attributes: number
+  /** Nodes left alone because they carry reported data. */
+  keptReported: number
+}
+
+/**
+ * Lengthens every text the cockpit owns on the page as it currently stands.
+ *
+ * Returns what it did, because a transformation that silently touched nothing
+ * would make every assertion after it pass for the wrong reason.
+ */
+export async function applyPseudoLocale(page: Page): Promise<PseudoLocaleReport> {
+  return page.evaluate(
+    ({ expansion, filler }) => {
+      const pad = (text: string): string => {
+        const length = Math.round(text.length * expansion)
+        if (length === 0) return text
+        let padding = ''
+        while (padding.length < length) padding += filler
+        return text + padding.slice(0, length)
+      }
+
+      const isReported = (node: Node | null): boolean => {
+        let element =
+          node instanceof Element ? node : (node?.parentElement ?? null)
+        while (element !== null) {
+          if (
+            element.hasAttribute('data-reported') ||
+            element.getAttribute('translate') === 'no'
+          ) {
+            return true
+          }
+          element = element.parentElement
+        }
+        return false
+      }
+
+      let textNodes = 0
+      let attributes = 0
+      let keptReported = 0
+
+      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+      const pending: Text[] = []
+      while (walker.nextNode()) {
+        const node = walker.currentNode as Text
+        const parent = node.parentElement
+        if (parent === null) continue
+        if (parent.tagName === 'SCRIPT' || parent.tagName === 'STYLE') continue
+        if ((node.data ?? '').trim().length < 2) continue
+        if (isReported(node)) {
+          keptReported += 1
+          continue
+        }
+        pending.push(node)
+      }
+      for (const node of pending) {
+        node.data = pad(node.data)
+        textNodes += 1
+      }
+
+      for (const attribute of ['aria-label', 'title', 'placeholder']) {
+        for (const element of Array.from(document.querySelectorAll(`[${attribute}]`))) {
+          const value = element.getAttribute(attribute) ?? ''
+          if (value.trim().length < 2) continue
+          if (isReported(element)) {
+            keptReported += 1
+            continue
+          }
+          element.setAttribute(attribute, pad(value))
+          attributes += 1
+        }
+      }
+
+      document.documentElement.setAttribute('data-pseudo-locale', 'applied')
+      return { textNodes, attributes, keptReported }
+    },
+    { expansion: PSEUDO_EXPANSION, filler: PSEUDO_FILLER },
+  )
+}
+
+/**
+ * Whether the lengthened text is still what the browser is laying out.
+ *
+ * The expansion is a DOM edit, and React owns this DOM. A re-render between the
+ * edit and the measurement would quietly restore the short texts and every
+ * layout assertion after it would then be measuring German again — green, and
+ * nothing tested. This is the guard against that; it is asserted, not logged.
+ */
+export async function pseudoLocaleStillApplied(page: Page): Promise<boolean> {
+  return page.evaluate(
+    (marker) =>
+      document.documentElement.getAttribute('data-pseudo-locale') === 'applied' &&
+      (document.body.innerText ?? '').includes(marker),
+    PSEUDO_MARKER,
+  )
+}

--- a/e2e/tests/09-i18n-layout.spec.ts
+++ b/e2e/tests/09-i18n-layout.spec.ts
@@ -1,0 +1,328 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test'
+
+import { MAIN_PROJECT, MAIN_RUN } from '../src/config.js'
+import { formatControlReports, probeControls, type ControlProbe } from '../src/controls.js'
+import {
+  formatTextReports,
+  probeTexts,
+  readPageOverflow,
+  readReportedValues,
+  type TextProbe,
+} from '../src/layout.js'
+import { applyPseudoLocale, pseudoLocaleStillApplied } from '../src/pseudoLocale.js'
+
+/**
+ * Check 9 — translations may not break the desktop layout (#37).
+ *
+ * Checks 1–8 are the v0 acceptance run and are untouched: they still run first,
+ * still in German, still at exactly 1920 × 1080, still with the same
+ * assertions. This file runs last and adds the three axes the localisation
+ * epic introduced.
+ *
+ * **Three widths.** 1920 is the mandatory acceptance surface (ADR 0013) and
+ * stays that. 1440 and 1280 are the two other ordinary desktop situations ADR
+ * 0015 names — an unmaximised window, and 1920 at 150 % browser zoom, which is
+ * an accessibility setting rather than a different device. The pane minimums
+ * add up to 1100 px, so 1280 is the width at which the layout has the least
+ * room and therefore the width at which a longer word first hurts.
+ *
+ * **Two languages.** German and English go through the same path, at the same
+ * three widths, with language-independent selectors — a check written against
+ * `aria-label="Agents filtern"` would only ever have run in German.
+ *
+ * **One artificial third.** Every word the cockpit owns, 35 % longer. See
+ * `src/pseudoLocale.ts` for why that is a DOM transformation here and a
+ * generated catalogue in the frontend suite.
+ *
+ * ## Screenshots are artefacts, not baselines
+ *
+ * The issue asks for desktop screenshots at the three widths. They are
+ * **attached to the report**, and nothing is compared against a committed
+ * image.
+ *
+ * `toHaveScreenshot()` compares rendered pixels, and rendered pixels depend on
+ * the font stack, on hinting and on subpixel positioning — a baseline recorded
+ * on a Linux container disagrees with the same build on a developer's Windows
+ * machine over text that is perfectly correct. This is the release gate of the
+ * whole epic; a gate that reports "the letters are 0.4 px wider here" as a
+ * failure gets ignored, and an ignored gate is worse than none (ADR 0013).
+ *
+ * What the issue actually asks for — no cut-off pane titles, buttons, legends
+ * or status values — is measured instead, by the browser, on the elements it is
+ * asked about: `scrollWidth` against `clientWidth` with an `overflow` that
+ * hides the rest. That answer is a number and it is the same number on every
+ * machine. The screenshots are what a human looks at afterwards.
+ */
+
+const WORKSPACE_URL = `/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}?component=${encodeURIComponent(
+  'shop-platform.orders.domain.tax',
+)}`
+
+const HEIGHT = 1080
+
+/** 1920 is the acceptance surface; 1440 and 1280 are ADR 0015's other two. */
+const WIDTHS = [1920, 1440, 1280] as const
+
+/**
+ * The elements the acceptance criteria of #37 name: pane titles, buttons,
+ * legends and status values.
+ *
+ * Every selector is language-independent. That is not tidiness — a probe list
+ * written with German accessible names is a probe list that silently finds
+ * nothing in the English run and reports "no clipped text" about a screen it
+ * never looked at.
+ */
+const TEXTS: TextProbe[] = [
+  { name: 'pane title · run and agents', selector: '[data-testid="pane-run-agents"] h2' },
+  { name: 'pane title · architecture', selector: '[data-testid="pane-architecture"] h2' },
+  { name: 'pane title · inspector', selector: '[data-testid="pane-inspector"] h2' },
+  { name: 'tab · selected', selector: '[role="tab"][aria-selected="true"]' },
+  { name: 'tab · unselected', selector: '[role="tab"][aria-selected="false"]' },
+  { name: 'button · fit view', selector: '[data-testid="canvas-fit-view"]' },
+  { name: 'button · minimap', selector: '[data-testid="canvas-toggle-minimap"]' },
+  { name: 'button · detail level', selector: '[data-testid="canvas-detail-level"]' },
+  { name: 'status value · live connection', selector: '[data-testid="live-connection-state"]' },
+  { name: 'status value · run openness', selector: '[data-testid="run-openness"]' },
+  { name: 'status value · run state', selector: '[data-testid="run-state"]' },
+  { name: 'legend · relationships', selector: '[data-testid="relationship-legend"]' },
+  { name: 'legend entry · HTTP', selector: '[data-testid="relationship-legend-http"]' },
+  { name: 'legend entry · NATS', selector: '[data-testid="relationship-legend-async"]' },
+  { name: 'change counter', selector: '[data-testid="change-counter"]' },
+  { name: 'language switch', selector: '[data-testid="language-switcher"]' },
+]
+
+/**
+ * The one clipped text this check found and does **not** fail on, with the
+ * reason it does not.
+ *
+ * Below 1920 the architecture pane's heading is the only element in its header
+ * that can give way. The header carries the four-state change counter and the
+ * two count badges — together about 550 px, and `shrink-0` — while the pane
+ * itself is 690 px at 1280. Measured against the acceptance deployment:
+ *
+ * | rendering | 1920      | 1440      | 1280           |
+ * | --------- | --------- | --------- | -------------- |
+ * | German    | 88 / 88   | 88 / 88   | 88 / **78**    |
+ * | English   | 96 / 96   | 96 / 96   | 96 / **92**    |
+ * | pseudo    | 122 / 122 | 122 / **87** | 122 / **0** |
+ *
+ * (needed / available, in pixels.)
+ *
+ * The first row is the important one: **German is already clipped at 1280**, so
+ * this is not a defect translation introduced. It is a layout defect of the
+ * architecture header at narrow widths (the subject of ADR 0015 / #41), which
+ * English makes marginally worse and a long translation makes severe.
+ *
+ * It is reported rather than fixed here. The remedy is a decision about what
+ * that header shows when it runs out of room — condense the change counter,
+ * drop the badges, wrap the title — and that is a design decision belonging to
+ * whoever owns the header, not a side effect of a test issue.
+ *
+ * The exception is bounded in two directions so it cannot rot into a blanket
+ * permission: it applies to one named probe, and only below 1920, where the
+ * assertion below stays strict for every rendering.
+ */
+function isReportedHeaderDefect(name: string, width: number): boolean {
+  return name === 'pane title · architecture' && width < 1920
+}
+
+/** The primary controls, again with language-independent selectors. */
+const CONTROLS: ControlProbe[] = [
+  { name: 'run selection (current run)', selector: `[data-testid="run-option-${MAIN_RUN}"]` },
+  { name: 'canvas control · fit view', selector: '[data-testid="canvas-fit-view"]' },
+  { name: 'canvas control · minimap toggle', selector: '[data-testid="canvas-toggle-minimap"]' },
+  { name: 'canvas control · zoom in', selector: '.react-flow__controls-zoomin' },
+  { name: 'canvas control · zoom out', selector: '.react-flow__controls-zoomout' },
+  { name: 'inspector tab · selected', selector: '[role="tab"][aria-selected="true"]' },
+  { name: 'inspector tab · unselected', selector: '[role="tab"][aria-selected="false"]' },
+  { name: 'live connection badge', selector: '[data-testid="live-connection-state"]' },
+  { name: 'pane toggle', selector: 'button[aria-expanded]' },
+  { name: 'language switch · German', selector: '[data-testid="language-option-de"]' },
+  { name: 'language switch · English', selector: '[data-testid="language-option-en"]' },
+]
+
+/** The cockpit, loaded and finished laying out. */
+async function openWorkspace(page: Page): Promise<void> {
+  await page.goto(WORKSPACE_URL)
+  await expect(page.getByTestId('architecture-canvas')).toBeVisible()
+  await expect(page.getByTestId('diff-groups')).toBeVisible()
+  await expect(page.getByTestId('architecture-canvas')).toHaveAttribute(
+    'data-layouting',
+    'false',
+  )
+}
+
+/**
+ * Switches the language the way a user does — through the switch #36 added,
+ * which is also what proves the switch itself survives every width.
+ */
+async function chooseLanguage(page: Page, language: 'de' | 'en'): Promise<void> {
+  await page.getByTestId(`language-option-${language}`).click()
+  await expect(page.locator('html')).toHaveAttribute('lang', language)
+  await expect(page.getByTestId(`language-option-${language}`)).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  )
+}
+
+/** Everything asserted about one window width, in one place. */
+async function assertLayoutHolds(page: Page, width: number, label: string): Promise<void> {
+  const geometry = await readPageOverflow(page, width)
+
+  expect(geometry.innerWidth, `${label}: viewport width`).toBe(width)
+  expect(
+    geometry.documentScrollWidth,
+    `${label}: the page must not scroll horizontally`,
+  ).toBe(geometry.documentClientWidth)
+  expect(geometry.bodyScrollWidth, `${label}: the body must not scroll horizontally`).toBe(
+    geometry.bodyClientWidth,
+  )
+  expect(
+    geometry.offenders,
+    `${label}: element past the right edge without a clipping container`,
+  ).toEqual([])
+
+  const texts = await probeTexts(page, TEXTS)
+  const missing = texts.filter((report) => !report.found).map((report) => report.name)
+  expect(missing, `${label}: probe found nothing — the check would pass vacuously`).toEqual(
+    [],
+  )
+
+  const clipped = texts.filter(
+    (report) => report.clippedHorizontally || report.clippedVertically,
+  )
+  const cut = clipped.filter((report) => !isReportedHeaderDefect(report.name, width))
+  expect(
+    cut.length === 0,
+    `${label}: text is cut off\n${formatTextReports(cut)}`,
+  ).toBe(true)
+
+  // The tolerated one is written into the report rather than swallowed: a known
+  // defect that leaves no trace in the run that found it stops being known.
+  const tolerated = clipped.filter((report) => isReportedHeaderDefect(report.name, width))
+  if (tolerated.length > 0) {
+    test.info().annotations.push({
+      type: 'known clipped text (#37 finding)',
+      description: `${label}\n${formatTextReports(tolerated)}`,
+    })
+  }
+
+  const controls = await probeControls(page, CONTROLS)
+  const broken = controls.filter(
+    (report) =>
+      !report.found || !report.rendered || !report.insideViewport || !report.unobstructed,
+  )
+  expect(
+    broken.length === 0,
+    `${label}: primary controls are not operable\n${formatControlReports(controls)}`,
+  ).toBe(true)
+}
+
+/** Keeps the rendering next to the report, for a human to look at. */
+async function attachScreenshot(
+  page: Page,
+  testInfo: TestInfo,
+  label: string,
+): Promise<void> {
+  await testInfo.attach(`workspace-${label}.png`, {
+    body: await page.screenshot(),
+    contentType: 'image/png',
+  })
+}
+
+for (const language of ['de', 'en'] as const) {
+  test(`9 · the desktop layout holds in ${language} at 1920, 1440 and 1280`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize({ width: WIDTHS[0], height: HEIGHT })
+    await openWorkspace(page)
+    await chooseLanguage(page, language)
+
+    for (const width of WIDTHS) {
+      await page.setViewportSize({ width, height: HEIGHT })
+      // The ELK layout is keyed on the model and the collapsed set, not on the
+      // width (ADR 0021), so a resize does not normally start one. Waiting
+      // anyway costs nothing and rules out measuring a canvas mid-layout if a
+      // later change makes the width part of that key.
+      await expect(page.getByTestId('architecture-canvas')).toHaveAttribute(
+        'data-layouting',
+        'false',
+      )
+      await assertLayoutHolds(page, width, `${language} @ ${width}`)
+      await attachScreenshot(page, testInfo, `${language}-${width}`)
+    }
+  })
+}
+
+test('9 · a translation 35 per cent longer keeps the layout at 1920, 1440 and 1280', async ({
+  page,
+}, testInfo) => {
+  for (const width of WIDTHS) {
+    // Reloaded per width rather than expanded once and resized: the expansion
+    // is a DOM edit and React owns this DOM, so a re-render triggered by the
+    // resize could quietly restore the short texts.
+    await page.setViewportSize({ width, height: HEIGHT })
+    await openWorkspace(page)
+
+    const applied = await applyPseudoLocale(page)
+    expect(
+      applied.textNodes,
+      `${width}: nothing was lengthened — the check would pass vacuously`,
+    ).toBeGreaterThan(30)
+    expect(applied.attributes, `${width}: no accessible name was lengthened`).toBeGreaterThan(
+      10,
+    )
+    expect(
+      applied.keptReported,
+      `${width}: no reported value was recognised — the exclusion is not working`,
+    ).toBeGreaterThan(0)
+
+    await assertLayoutHolds(page, width, `pseudo @ ${width}`)
+
+    // The measurement above is only worth anything if the long text was still
+    // on screen while it was taken.
+    expect(
+      await pseudoLocaleStillApplied(page),
+      `${width}: React re-rendered over the lengthened text`,
+    ).toBe(true)
+
+    await attachScreenshot(page, testInfo, `pseudo-${width}`)
+  }
+})
+
+test('9 · reported project data is identical in German, English and the pseudo-locale', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: WIDTHS[0], height: HEIGHT })
+  await openWorkspace(page)
+
+  await chooseLanguage(page, 'de')
+  const german = await readReportedValues(page)
+
+  await chooseLanguage(page, 'en')
+  const english = await readReportedValues(page)
+
+  await chooseLanguage(page, 'de')
+  await applyPseudoLocale(page)
+  const pseudo = await readReportedValues(page)
+
+  // The same strings, in the same order, character for character — this time
+  // against the real deployment rather than against a fixture, and against a
+  // rendering in which *every* translated string on screen differs from both
+  // catalogues. A reported value that had accidentally been routed through
+  // `t()` could not survive that unchanged.
+  expect(english, 'English changed a reported value').toEqual(german)
+  expect(pseudo, 'the pseudo-locale changed a reported value').toEqual(german)
+  expect(
+    german.length,
+    'no reported value was found — the comparison would be vacuous',
+  ).toBeGreaterThan(100)
+
+  // …and every one of them is still marked untranslatable for the browser.
+  const unmarked = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('[data-reported]'))
+      .filter((node) => node.closest('[translate="no"]') === null)
+      .map((node) => node.tagName.toLowerCase()),
+  )
+  expect(unmarked, 'a reported value is not marked translate="no"').toEqual([])
+})

--- a/frontend/src/canvas/ArchitectureAccessibility.test.tsx
+++ b/frontend/src/canvas/ArchitectureAccessibility.test.tsx
@@ -110,6 +110,14 @@ async function waitForCanvas(): Promise<HTMLElement> {
     () => expect(document.querySelectorAll('.react-flow__node').length).toBeGreaterThan(0),
     { timeout: CANVAS_TIMEOUT },
   )
+  // And the automatic camera placement runs in an effect after that again, so
+  // `data-fit-view-count`, the viewport transform and the stored camera are
+  // still one commit away. Reading them synchronously here is a race that goes
+  // red exactly when the machine is busy.
+  await waitFor(
+    () => expect(Number(canvas.getAttribute('data-fit-view-count'))).toBeGreaterThan(0),
+    { timeout: CANVAS_TIMEOUT },
+  )
   return canvas
 }
 

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -72,7 +72,24 @@ async function waitForCanvas(): Promise<HTMLElement> {
     () => expect(canvas.getAttribute('data-layouting')).toBe('false'),
     { timeout: CANVAS_TIMEOUT },
   )
+  await waitForInitialFit(canvas)
   return canvas
+}
+
+/**
+ * `data-layouting: false` only says that ELK is done.
+ *
+ * The automatic camera placement runs in an effect *after* the layout, so the
+ * first `fitView` — and with it `data-fit-view-count`, the viewport transform
+ * and the stored camera — is still one commit away when the flag flips.
+ * Reading any of the three synchronously at that moment is a race that goes red
+ * exactly when the machine is busy and green on every quiet developer laptop.
+ */
+async function waitForInitialFit(canvas: HTMLElement): Promise<void> {
+  await waitFor(
+    () => expect(Number(canvas.getAttribute('data-fit-view-count'))).toBeGreaterThan(0),
+    { timeout: CANVAS_TIMEOUT },
+  )
 }
 
 /** The rendered zoom and pan — the ground truth of where the camera is. */

--- a/frontend/src/canvas/ArchitectureZoom.test.tsx
+++ b/frontend/src/canvas/ArchitectureZoom.test.tsx
@@ -72,6 +72,16 @@ async function waitForCanvas(): Promise<HTMLElement> {
   await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'), {
     timeout: CANVAS_TIMEOUT,
   })
+  // `data-layouting: false` only says that ELK is done. The automatic camera
+  // placement runs in an effect *after* the layout, so the first `fitView` —
+  // and with it `data-fit-view-count`, the viewport transform and the stored
+  // camera — is still one commit away when the flag flips. Reading any of them
+  // synchronously at that moment is a race that goes red exactly when the
+  // machine is busy.
+  await waitFor(
+    () => expect(Number(canvas.getAttribute('data-fit-view-count'))).toBeGreaterThan(0),
+    { timeout: CANVAS_TIMEOUT },
+  )
   return canvas
 }
 

--- a/frontend/src/canvas/ChangeOverlays.test.tsx
+++ b/frontend/src/canvas/ChangeOverlays.test.tsx
@@ -87,6 +87,16 @@ async function waitForCanvas(): Promise<HTMLElement> {
   await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'), {
     timeout: CANVAS_TIMEOUT,
   })
+  // `data-layouting: false` only says that ELK is done. The automatic camera
+  // placement runs in an effect *after* the layout, so the first `fitView` —
+  // and with it `data-fit-view-count`, the viewport transform and the stored
+  // camera — is still one commit away when the flag flips. Reading any of them
+  // synchronously at that moment is a race that goes red exactly when the
+  // machine is busy.
+  await waitFor(
+    () => expect(Number(canvas.getAttribute('data-fit-view-count'))).toBeGreaterThan(0),
+    { timeout: CANVAS_TIMEOUT },
+  )
   return canvas
 }
 

--- a/frontend/src/i18n/README.md
+++ b/frontend/src/i18n/README.md
@@ -365,6 +365,63 @@ a stored value is compared against the supported set and a second implementation
 of that comparison is a second chance to get it wrong. A value that is simply
 absent causes no write.
 
+## What the tests guarantee
+
+The reasoning is [ADR 0022](../../../docs/decisions/0022-translation-test-suite-pseudo-locale-and-a-suite-that-can-be-believed.md);
+this is the map.
+
+| file | what it holds up |
+| --- | --- |
+| `i18n.test.ts` | start-up, the stored choice, `fallbackLng`, and both halves of the missing-key rule |
+| `formatting.test.ts` | plurals, instants, percentages and counters in both languages — and, read out of the catalogue itself, *every* counted noun, so the one added next week is covered without anybody editing this file |
+| `catalogues.test.ts` | `check:locales`, against the real catalogues and against five deliberately broken ones |
+| `uiStrings.test.ts` | `check:ui-strings`, likewise against six deliberately broken trees |
+| `accessibleNames.test.tsx` | every `aria-label`, `title`, `placeholder` and `sr-only` text on both surfaces, in both languages: nothing resolves to a key, every operable control has a name, and the two languages really differ |
+| `ProjectsPage.i18n.test.tsx`, `WorkspacePage.i18n.test.tsx` | the same components rendered German and English, and every `data-reported` value compared character for character |
+| `WorkspacePage.pseudo.test.tsx` | the same screen with every one of our words 35 % longer |
+| `pseudoLocale.test.ts` | the generator behind it |
+| `e2e/tests/09-i18n-layout.spec.ts` | the pixels: 1920, 1440 and 1280, German, English and 35 % longer, against the real deployment |
+
+### The pseudo-locale
+
+`src/test/pseudoLocale.ts` derives a **third catalogue from the German one** by
+lengthening every string by 35 %. Its purpose is the question no real catalogue
+can ask today: what happens when a translation is longer than anything either
+catalogue currently contains.
+
+It is deliberately **not a language**:
+
+- not in `SUPPORTED_LANGUAGES`, so it cannot reach the switch, `<html lang>` or
+  a stored preference — the product speaks two languages;
+- not a directory under `locales/`, so `check:locales` never sees it;
+- not in the bundle — it lives under `src/test/`.
+
+It is installed onto the German slot of one i18next instance, so the application
+renders exactly as it renders in German, with every one of its own words longer:
+
+```tsx
+renderApp('/projects', { i18n: createPseudoI18n() })
+```
+
+Two things it does **not** touch: `{{interpolations}}` and the `<agent/>`,
+`<run/>`, `<field/>` slots of `<Trans>` — the padding is appended, never woven
+in — and anything carrying `data-reported`. The last one is why the pseudo
+rendering is a *third* proof of the byte-identity rule rather than a repetition
+of the German/English one: in it, every translated string on screen differs from
+both catalogues, so a reported value accidentally routed through `t()` could not
+come out unchanged.
+
+`createPseudoI18n` clones the instance's resource store before writing to it,
+and that line is load-bearing. `i18next.init({ resources })` keeps a *reference*
+to the module-level catalogue, so `addResourceBundle` would otherwise replace
+the real German texts for the rest of the worker process — and the failure would
+show up in an unrelated test three files later.
+
+The acceptance run needs the same locale in a real browser, where a generated
+catalogue cannot reach. `e2e/src/pseudoLocale.ts` therefore lengthens the text of
+the running page instead, with the same 35 % and the same filler. Two
+implementations of one rule; each asserts the 30–40 % band for itself.
+
 ## Using it
 
 ```tsx

--- a/frontend/src/i18n/accessibleNames.test.tsx
+++ b/frontend/src/i18n/accessibleNames.test.tsx
@@ -1,0 +1,238 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { SUPPORTED_LANGUAGES, type Language } from '@/i18n'
+import { renderApp } from '@/test/renderApp'
+import { createPseudoI18n } from '@/test/pseudoLocale'
+import { renderWorkspaceScene } from '@/test/workspaceScene'
+
+import { MISSING_KEY_PREFIX } from './createI18n'
+
+/**
+ * Every name a screen reader reads out, in every language, on both surfaces.
+ *
+ * The individual accessible names are asserted where they belong — the graph in
+ * `canvas/ArchitectureAccessibility.test.tsx`, the chrome in
+ * `routes/pages/WorkspacePage.i18n.test.tsx`. What is missing from both is the
+ * *sweep*: a rule that holds for names nobody has written yet.
+ *
+ * `aria-label`, `title`, `placeholder` and screen-reader-only text are the four
+ * places a translation can be forgotten without anybody seeing it. A visible
+ * pane title that stayed German shows up in the first English screenshot; an
+ * `aria-label` that stayed German shows up when a blind user files a bug.
+ *
+ * Three properties are checked here, and each of them covers text that does not
+ * exist yet:
+ *
+ * 1. **Nothing renders a key.** Not the `⟦…⟧` marker of a key that resolves in
+ *    no language, and not a bare `area.element` that slipped through as a
+ *    string literal.
+ * 2. **Everything a user can operate has a name**, in every language.
+ * 3. **The names really change with the language** — a set that is identical in
+ *    German and English would pass rules 1 and 2 while being untranslated.
+ */
+
+/** Attributes that carry a name a screen reader will read. */
+const NAME_ATTRIBUTES = ['aria-label', 'title', 'placeholder', 'aria-description'] as const
+
+/** Controls a user is expected to be able to reach and operate. */
+const OPERABLE = 'button, a[href], input, select, textarea, [role="tab"], [role="button"]'
+
+/**
+ * A string that is a translation key rather than a translation.
+ *
+ * `item.openLabel`, `projects:list.title` — lower-camel segments separated by
+ * dots and no spaces. A real sentence has a space in it; a real single word has
+ * no dot in it. File paths and component ids look the same, which is why this is
+ * only ever applied to text the cockpit owns and never to a reported value.
+ */
+const LOOKS_LIKE_A_KEY = /^[a-z][A-Za-z0-9]*([.:][A-Za-z0-9]+)+$/
+
+interface Names {
+  /** Every value of every name-bearing attribute, in document order. */
+  attributes: { element: string; attribute: string; value: string }[]
+  /** Every screen-reader-only text. */
+  screenReaderOnly: string[]
+  /** Controls without any accessible name at all. */
+  unnamed: string[]
+  /** How many controls were looked at — an empty sweep passes everything. */
+  operable: number
+}
+
+/**
+ * A stable description of one element.
+ *
+ * React's `useId` produces `data-testid` values like `_r_ab_` that count
+ * renders, so two renderings of the same screen disagree on them. Dropping them
+ * keeps the comparison about the screen rather than about the order the tests
+ * ran in.
+ */
+function describeElement(element: Element): string {
+  const testId = element.getAttribute('data-testid')
+  const stable = testId === null || /^_r_/.test(testId) ? null : testId
+  return `${element.tagName.toLowerCase()}${stable === null ? '' : `[${stable}]`}`
+}
+
+/** The name a screen reader would announce, as far as jsdom can tell. */
+function accessibleNameOf(element: Element): string {
+  const label = element.getAttribute('aria-label')
+  if (label !== null && label.trim() !== '') return label.trim()
+
+  const labelledBy = element.getAttribute('aria-labelledby')
+  if (labelledBy !== null) {
+    const named = labelledBy
+      .split(/\s+/)
+      .map((id) => document.getElementById(id)?.textContent ?? '')
+      .join(' ')
+      .trim()
+    if (named !== '') return named
+  }
+
+  const text = (element.textContent ?? '').trim()
+  if (text !== '') return text
+
+  return (element.getAttribute('title') ?? '').trim()
+}
+
+function collectNames(container: HTMLElement): Names {
+  const attributes: Names['attributes'] = []
+  for (const attribute of NAME_ATTRIBUTES) {
+    for (const element of container.querySelectorAll(`[${attribute}]`)) {
+      attributes.push({
+        element: describeElement(element),
+        attribute,
+        value: element.getAttribute(attribute) ?? '',
+      })
+    }
+  }
+
+  const screenReaderOnly = [...container.querySelectorAll('.sr-only')].map(
+    (element) => (element.textContent ?? '').trim(),
+  )
+
+  const operable = [...container.querySelectorAll(OPERABLE)].filter(
+    (element) => element.getAttribute('aria-hidden') !== 'true',
+  )
+  const unnamed = operable
+    .filter((element) => accessibleNameOf(element) === '')
+    .map(describeElement)
+
+  return { attributes, screenReaderOnly, unnamed, operable: operable.length }
+}
+
+/** The project list and the whole cockpit — the two surfaces #42 migrated. */
+async function namesOfEverySurface(language: Language): Promise<Names> {
+  const list = renderApp('/projects', { language })
+  await screen.findAllByRole('link')
+  const listNames = collectNames(list.container)
+  list.unmount()
+
+  const workspace = await renderWorkspaceScene({ language })
+  const workspaceNames = collectNames(workspace.container)
+  workspace.unmount()
+
+  return {
+    attributes: [...listNames.attributes, ...workspaceNames.attributes],
+    screenReaderOnly: [...listNames.screenReaderOnly, ...workspaceNames.screenReaderOnly],
+    unnamed: [...listNames.unnamed, ...workspaceNames.unnamed],
+    operable: listNames.operable + workspaceNames.operable,
+  }
+}
+
+describe('accessible names — nothing renders a key instead of a translation', () => {
+  for (const language of SUPPORTED_LANGUAGES) {
+    it(`resolves every name-bearing attribute and screen-reader text in ${language}`, async () => {
+      const names = await namesOfEverySurface(language)
+
+      const unresolved = names.attributes
+        .filter((entry) => entry.value.includes(MISSING_KEY_PREFIX))
+        .map((entry) => `${entry.element} ${entry.attribute}="${entry.value}"`)
+      expect(unresolved).toEqual([])
+
+      const keyShaped = names.attributes
+        .filter((entry) => LOOKS_LIKE_A_KEY.test(entry.value))
+        .map((entry) => `${entry.element} ${entry.attribute}="${entry.value}"`)
+      expect(keyShaped).toEqual([])
+
+      const emptyNames = names.attributes
+        .filter((entry) => entry.attribute === 'aria-label' && entry.value.trim() === '')
+        .map((entry) => entry.element)
+      expect(emptyNames).toEqual([])
+
+      // The surfaces really were rendered — an empty sweep passes everything.
+      expect(names.attributes.length).toBeGreaterThan(20)
+      expect(names.screenReaderOnly.length).toBeGreaterThan(3)
+    })
+
+    it(`gives every operable control an accessible name in ${language}`, async () => {
+      const names = await namesOfEverySurface(language)
+
+      expect(names.unnamed).toEqual([])
+      // Without this the assertion above would also pass on an empty screen.
+      expect(names.operable).toBeGreaterThan(10)
+    })
+  }
+})
+
+describe('accessible names — the two languages really differ', () => {
+  it('translates the names rather than describing the same screen twice', async () => {
+    const german = await namesOfEverySurface('de')
+    const english = await namesOfEverySurface('en')
+
+    // Same screen, same controls, in the same order: the sweep compares like
+    // with like rather than two different renderings.
+    expect(english.attributes.map((entry) => `${entry.element} ${entry.attribute}`)).toEqual(
+      german.attributes.map((entry) => `${entry.element} ${entry.attribute}`),
+    )
+
+    const changed = german.attributes.filter(
+      (entry, index) => entry.value !== english.attributes[index]?.value,
+    )
+    // Most names are ours and change; the rest are the ones that are the same
+    // word in both catalogues ("Inspector", "Runs", "DE") or that carry a
+    // reported value. A single-digit number here would mean the English
+    // catalogue is answering with German through `fallbackLng`.
+    expect(changed.length).toBeGreaterThan(15)
+  })
+
+  it('translates the screen-reader-only texts as well', async () => {
+    const german = await namesOfEverySurface('de')
+    const english = await namesOfEverySurface('en')
+
+    expect(english.screenReaderOnly.length).toBe(german.screenReaderOnly.length)
+    const changed = german.screenReaderOnly.filter(
+      (text, index) => text !== english.screenReaderOnly[index],
+    )
+    expect(changed.length).toBeGreaterThan(0)
+  })
+})
+
+describe('accessible names — a translation 35 per cent longer keeps every one of them', () => {
+  it('names every control, resolves every key and drops nothing', async () => {
+    const workspace = await renderWorkspaceScene({ i18n: createPseudoI18n() })
+    const names = collectNames(workspace.container)
+
+    expect(names.unnamed).toEqual([])
+    expect(names.operable).toBeGreaterThan(10)
+    expect(
+      names.attributes.filter((entry) => entry.value.includes(MISSING_KEY_PREFIX)),
+    ).toEqual([])
+
+    // A longer translation may not silently lose an accessible name: the same
+    // controls, the same attributes, in the same order as in German.
+    workspace.unmount()
+
+    const german = await renderWorkspaceScene({ language: 'de' })
+    const germanNames = collectNames(german.container)
+    german.unmount()
+
+    expect(names.attributes.map((entry) => `${entry.element} ${entry.attribute}`)).toEqual(
+      germanNames.attributes.map((entry) => `${entry.element} ${entry.attribute}`),
+    )
+    // …and every one of them really is the longer text, not the German fallback.
+    const identical = names.attributes.filter(
+      (entry, index) => entry.value === germanNames.attributes[index]?.value,
+    )
+    expect(identical.length).toBeLessThan(names.attributes.length / 2)
+  })
+})

--- a/frontend/src/i18n/formatting.test.ts
+++ b/frontend/src/i18n/formatting.test.ts
@@ -11,6 +11,7 @@ import {
   resolveFormattingLanguage,
 } from './formatting'
 import type { Language } from './languages'
+import { resources } from './resources'
 
 /**
  * The formatting service, in both languages.
@@ -81,6 +82,78 @@ describe('counted nouns', () => {
       '1,234 components',
     )
   })
+
+  /**
+   * The cases above name the nouns they check, which is what makes them
+   * readable and what makes them incomplete: a counted noun added next week is
+   * covered by none of them.
+   *
+   * This one reads the nouns out of the catalogue instead, so the day
+   * `count.proposal` is added it is checked in both languages without anybody
+   * remembering to come back here.
+   */
+  describe('every counted noun in the catalogue', () => {
+    /** `agent`, `child`, … — the base names behind the `_one`/`_other` keys. */
+    const nouns = [
+      ...new Set(
+        Object.keys(resources.de.common.count).map((key) => key.replace(/_(one|other)$/, '')),
+      ),
+    ].sort()
+
+    it('exists in both languages with both plural categories', () => {
+      expect(nouns.length).toBeGreaterThan(10)
+      for (const language of ['de', 'en'] as const) {
+        for (const noun of nouns) {
+          for (const category of ['one', 'other'] as const) {
+            const entry = resources[language].common.count as Record<string, string>
+            expect(entry[`${noun}_${category}`], `${language} ${noun}_${category}`).toMatch(
+              /\S/,
+            )
+          }
+        }
+      }
+    })
+
+    it('renders zero, one and many as a formatted number plus a word', () => {
+      for (const language of ['de', 'en'] as const) {
+        const t = translatorFor(language)
+        for (const noun of nouns) {
+          const key = `common:count.${noun}` as 'common:count.plan'
+          for (const count of [0, 1, 2, 11, 1234]) {
+            const rendered = t(key, { count })
+            const where = `${language} ${noun} ${count}`
+
+            // The number is there, formatted for the language…
+            expect(rendered, where).toContain(formatNumber(count, language))
+            // …a word follows it…
+            expect(rendered, where).toMatch(/\d\s*\S*\s+\p{L}{2,}/u)
+            // …and nothing fell through to the key or to the raw plural suffix.
+            expect(rendered, where).not.toContain('count.')
+            expect(rendered, where).not.toContain('_other')
+          }
+          // Singular and plural are actually chosen, not the same string twice —
+          // except where the language genuinely does not distinguish them.
+          const singular = t(key, { count: 1 })
+          const plural = t(key, { count: 2 })
+          if (language === 'en') expect(singular, noun).not.toBe(plural)
+        }
+      }
+    })
+
+    it('picks the plural form the language asks for, not the one German asks for', () => {
+      // The point of `Intl.PluralRules` over the hand-written table: zero takes
+      // the *plural* in both languages, which the old two-branch helper only got
+      // right because it was written for German.
+      for (const language of ['de', 'en'] as const) {
+        const t = translatorFor(language)
+        const entry = resources[language].common.count as Record<string, string>
+        for (const noun of nouns) {
+          const expected = (entry[`${noun}_other`] ?? '').replace('{{count, number}}', '0')
+          expect(t(`common:count.${noun}` as 'common:count.plan', { count: 0 })).toBe(expected)
+        }
+      }
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -146,6 +219,11 @@ describe('relative instants', () => {
     { name: 'days', at: '2026-08-01T09:15:00Z', de: 'vor 3 Tagen', en: '3 days ago' },
     { name: 'a future report', at: '2026-08-04T09:25:00Z', de: 'in 10 Minuten', en: 'in 10 minutes' },
     { name: 'a very long time ago', at: '2020-01-01T00:00:00Z', de: 'vor 6 Jahren', en: '6 years ago' },
+    // The two units between "days" and "years". Both exist in
+    // `Intl.RelativeTimeFormat` and both were unchecked, which is how a unit
+    // that is never selected — or selected one threshold too early — survives.
+    { name: 'weeks', at: '2026-07-21T09:15:00Z', de: 'vor 2 Wochen', en: '2 weeks ago' },
+    { name: 'months', at: '2026-05-04T09:15:00Z', de: 'vor 3 Monaten', en: '3 months ago' },
   ]
 
   for (const testCase of cases) {
@@ -191,6 +269,16 @@ describe('percentages', () => {
   it('does not turn a non-number into a plausible percentage', () => {
     expect(formatPercent(Number.NaN, 'de')).not.toContain('0')
     expect(formatPercent(Number.NaN, 'en')).not.toContain('0')
+    expect(formatPercent(Number.POSITIVE_INFINITY, 'de')).not.toMatch(/\d/)
+    expect(formatPercent(Number.POSITIVE_INFINITY, 'en')).not.toMatch(/\d/)
+  })
+
+  it('reports a value outside 0–100 as it was reported rather than clamping it', () => {
+    // A percentage above 100 or below 0 is an agent's claim about its own
+    // progress. Correcting it would hide a defect in the thing the cockpit
+    // exists to observe (ADR 0019).
+    expect(formatPercent(140, 'de')).toBe('140\u00a0%')
+    expect(formatPercent(-5, 'en')).toBe('-5%')
   })
 })
 

--- a/frontend/src/i18n/pseudoLocale.test.ts
+++ b/frontend/src/i18n/pseudoLocale.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PSEUDO_EXPANSION_RANGE,
+  createPseudoI18n,
+  lengthenText,
+  pseudoResources,
+} from '@/test/pseudoLocale'
+
+import { createI18n } from './createI18n'
+import { SUPPORTED_LANGUAGES } from './languages'
+import { NAMESPACES, resources } from './resources'
+
+/**
+ * The pseudo-locale itself.
+ *
+ * It exists to stress the layout with translations longer than either catalogue
+ * currently contains (#37). A generator that quietly produced *shorter* strings,
+ * dropped an interpolation or lost a key would make every test built on it pass
+ * for the wrong reason, so the generator is checked before anything is rendered
+ * with it.
+ */
+
+/** `{{name}}` and `{{name, format}}` — the interpolations i18next expands. */
+const PLACEHOLDER = /\{\{\s*([^{}]+?)\s*\}\}/g
+
+function placeholdersOf(text: string): string[] {
+  return [...text.matchAll(PLACEHOLDER)]
+    .map((match) => (match[1] ?? '').split(',')[0]?.trim() ?? '')
+    .sort()
+}
+
+type Catalogue = { [key: string]: string | Catalogue }
+
+/** Flattens a catalogue into `dotted.key -> string`, as the checker script does. */
+function flatten(catalogue: unknown, prefix = '', into = new Map<string, string>()) {
+  for (const [key, value] of Object.entries(catalogue as Catalogue)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (typeof value === 'string') into.set(path, value)
+    else flatten(value, path, into)
+  }
+  return into
+}
+
+/** Every German string of every namespace, with its fully qualified key. */
+function germanStrings(): Map<string, string> {
+  const all = new Map<string, string>()
+  for (const namespace of NAMESPACES) {
+    for (const [key, value] of flatten(resources.de[namespace])) {
+      all.set(`${namespace}:${key}`, value)
+    }
+  }
+  return all
+}
+
+function pseudoStrings(): Map<string, string> {
+  const bundles = pseudoResources()
+  const all = new Map<string, string>()
+  for (const namespace of NAMESPACES) {
+    for (const [key, value] of flatten(bundles[namespace])) {
+      all.set(`${namespace}:${key}`, value)
+    }
+  }
+  return all
+}
+
+describe('the pseudo-locale is longer, and by how much', () => {
+  it('lengthens every string of every namespace by 30 to 40 per cent', () => {
+    const german = germanStrings()
+    const pseudo = pseudoStrings()
+    const tooShort: string[] = []
+    const tooLong: string[] = []
+
+    for (const [key, source] of german) {
+      // Below ten characters the rounding cannot land inside a ten-point band —
+      // "DE" would have to grow by 0.7 of a character. Those are the two-letter
+      // language codes and nothing else, and they are not what a layout breaks
+      // on.
+      if (source.length < 10) continue
+      const ratio = (pseudo.get(key) ?? '').length / source.length
+      if (ratio < 1 + PSEUDO_EXPANSION_RANGE.min) tooShort.push(`${key} ${ratio.toFixed(3)}`)
+      if (ratio > 1 + PSEUDO_EXPANSION_RANGE.max) tooLong.push(`${key} ${ratio.toFixed(3)}`)
+    }
+
+    expect(tooShort).toEqual([])
+    expect(tooLong).toEqual([])
+    expect(german.size).toBeGreaterThan(300)
+  })
+
+  it('grows the catalogue as a whole by the same share, short strings included', () => {
+    const totalGerman = [...germanStrings().values()].reduce((sum, s) => sum + s.length, 0)
+    const totalPseudo = [...pseudoStrings().values()].reduce((sum, s) => sum + s.length, 0)
+    const ratio = totalPseudo / totalGerman
+
+    expect(ratio).toBeGreaterThanOrEqual(1 + PSEUDO_EXPANSION_RANGE.min)
+    expect(ratio).toBeLessThanOrEqual(1 + PSEUDO_EXPANSION_RANGE.max)
+  })
+
+  it('keeps the German original readable at the front of every string', () => {
+    // A pseudo rendering has to be debuggable from a screenshot: whoever looks
+    // at a broken pane has to be able to tell *which* text broke it.
+    expect(lengthenText('Architektur')).toMatch(/^Architektur /)
+  })
+})
+
+describe('the pseudo-locale changes the words and nothing else', () => {
+  it('describes exactly the keys the German catalogue describes', () => {
+    expect([...pseudoStrings().keys()].sort()).toEqual([...germanStrings().keys()].sort())
+  })
+
+  it('never adds, drops or renames an interpolated value', () => {
+    const pseudo = pseudoStrings()
+    const drifted: string[] = []
+
+    for (const [key, source] of germanStrings()) {
+      const before = placeholdersOf(source)
+      const after = placeholdersOf(pseudo.get(key) ?? '')
+      if (before.join('|') !== after.join('|')) drifted.push(key)
+    }
+
+    // This is the property that lets the pseudo rendering carry reported data:
+    // `{{projectId}}` still interpolates, so the value still arrives verbatim.
+    expect(drifted).toEqual([])
+  })
+
+  it('leaves the markup slots of a Trans clause intact', () => {
+    // `<agent/>`, `<run/>`, `<field/>` — the named slots a reported value is
+    // rendered into inside a translated sentence.
+    const tags = (text: string) => [...text.matchAll(/<\/?[A-Za-z][\w-]*\/?>/g)].map((m) => m[0])
+    const withSlots = [...germanStrings()].filter(([, value]) => tags(value).length > 0)
+    expect(withSlots.length).toBeGreaterThan(0)
+
+    const pseudo = pseudoStrings()
+    for (const [key, source] of withSlots) {
+      expect(tags(pseudo.get(key) ?? ''), key).toEqual(tags(source))
+    }
+  })
+
+  it('is never empty where German was not', () => {
+    for (const [key, value] of pseudoStrings()) {
+      expect(value.trim(), key).not.toBe('')
+    }
+  })
+})
+
+describe('the pseudo-locale stays inside the instance it was installed on', () => {
+  it('renders the pseudo text through the instance it was built for', () => {
+    const pseudo = createPseudoI18n()
+    const real = resources.de.projects.list.title
+
+    expect(pseudo.t('projects:list.title')).not.toBe(real)
+    expect(pseudo.t('projects:list.title').startsWith(real)).toBe(true)
+  })
+
+  it('leaves the shared German catalogue and every later instance untouched', () => {
+    // `i18next.init({ resources })` keeps a *reference* to the module-level
+    // catalogue and `addResourceBundle` writes through it. Without the store
+    // clone in `createPseudoI18n` this assertion fails — and it fails in some
+    // unrelated test three files later, which is why it is pinned here.
+    const before = resources.de.projects.list.title
+    createPseudoI18n()
+
+    expect(resources.de.projects.list.title).toBe(before)
+    expect(createI18n({ language: 'de' }).t('projects:list.title')).toBe(before)
+    expect(createI18n({ language: 'en' }).t('projects:list.title')).toBe(
+      resources.en.projects.list.title,
+    )
+  })
+
+  it('is not a language the cockpit offers', () => {
+    // The product speaks two languages. The pseudo-locale is installed onto the
+    // German slot precisely so that it cannot leak into the switch, into
+    // `<html lang>` or into a stored preference.
+    const pseudo = createPseudoI18n()
+
+    expect(pseudo.language).toBe('de')
+    expect(SUPPORTED_LANGUAGES).toEqual(['de', 'en'])
+    expect(pseudo.options.supportedLngs).toEqual(
+      expect.arrayContaining([...SUPPORTED_LANGUAGES]),
+    )
+    // …and no directory of its own, so `npm run check:locales` never sees it.
+    expect(Object.keys(resources).sort()).toEqual(['de', 'en'])
+  })
+})

--- a/frontend/src/routes/pages/WorkspacePage.i18n.test.tsx
+++ b/frontend/src/routes/pages/WorkspacePage.i18n.test.tsx
@@ -2,25 +2,15 @@ import { screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import type { Language } from '@/i18n'
-import { PROJECT_ID, RUN_ID, component, createFakeFetch } from '@/test/fixtures'
-import {
-  COMPONENT_ID,
-  FEEDBACK_MARKDOWN,
-  HISTORY_PATH,
-  INSPECTOR_PATH,
-  historyPage,
-  inspectorPage,
-} from '@/test/inspectorFixtures'
-import {
-  CHAINED_TASK,
-  PARAGRAPH_TASK,
-  longTaskAgentsResponse,
-  openRunResponse,
-  runPaths,
-  runsWithHistoryResponse,
-  twoRevisionPlansResponse,
-} from '@/test/runFixtures'
+import { RUN_ID } from '@/test/fixtures'
+import { COMPONENT_ID, FEEDBACK_MARKDOWN } from '@/test/inspectorFixtures'
+import { CHAINED_TASK, PARAGRAPH_TASK } from '@/test/runFixtures'
 import { renderApp } from '@/test/renderApp'
+import {
+  WORKSPACE_SCENE_URL,
+  renderWorkspaceScene,
+  workspaceSceneServer,
+} from '@/test/workspaceScene'
 
 /**
  * The whole workspace, rendered twice.
@@ -42,28 +32,6 @@ import { renderApp } from '@/test/renderApp'
  * up to date.
  */
 
-const WORKSPACE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}?component=${COMPONENT_ID}`
-
-/** The three panes, each with real reported content in them. */
-function workspaceServer(): typeof fetch {
-  const base = createFakeFetch({
-    [runPaths.runs]: runsWithHistoryResponse,
-    [runPaths.currentRun]: openRunResponse,
-    [runPaths.runDetail]: openRunResponse,
-    [runPaths.agents]: longTaskAgentsResponse,
-    [runPaths.plans]: twoRevisionPlansResponse,
-    [runPaths.architecture]: {
-      projectPosition: 42,
-      components: [component({ componentId: COMPONENT_ID, name: 'Tax', kind: 'module' })],
-      relationships: [],
-      activeChanges: [],
-    },
-    [INSPECTOR_PATH]: inspectorPage(),
-    [HISTORY_PATH]: historyPage(),
-  })
-  return base
-}
-
 interface Rendered {
   reported: string[]
   translatable: string[]
@@ -72,14 +40,7 @@ interface Rendered {
 
 /** Renders the workspace and separates what is ours from what is the agent's. */
 async function renderWorkspace(language: Language): Promise<Rendered> {
-  const { container, unmount } = renderApp(WORKSPACE_URL, {
-    language,
-    fetchImpl: workspaceServer(),
-  })
-
-  // Wait for all three panes: the inspector arrives last.
-  await screen.findByTestId('inspector-context')
-  await screen.findByTestId('agent-tree')
+  const { container, unmount } = await renderWorkspaceScene({ language })
 
   const reported = [...container.querySelectorAll('[data-reported]')].map(
     (node) => node.textContent ?? '',
@@ -251,7 +212,9 @@ describe('workspace — reported project data is identical in both languages', (
 
   it('marks every reported value untranslatable for the browser as well', async () => {
     const { reported, unmount } = await renderWorkspace('de')
-    const { container } = renderApp(WORKSPACE_URL, { fetchImpl: workspaceServer() })
+    const { container } = renderApp(WORKSPACE_SCENE_URL, {
+      fetchImpl: workspaceSceneServer(),
+    })
 
     // `data-reported` and `translate="no"` are one and the same marker: a value
     // that is greppable but that Chrome would still rewrite protects nothing.

--- a/frontend/src/routes/pages/WorkspacePage.pseudo.test.tsx
+++ b/frontend/src/routes/pages/WorkspacePage.pseudo.test.tsx
@@ -1,0 +1,117 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { MISSING_KEY_PREFIX } from '@/i18n/createI18n'
+import { createPseudoI18n } from '@/test/pseudoLocale'
+import { renderWorkspaceScene } from '@/test/workspaceScene'
+
+/**
+ * The whole cockpit rendered in a translation 35 % longer than German.
+ *
+ * Two different questions are asked about long translations, and only one of
+ * them can be answered here:
+ *
+ * * **Does anything get cut off?** That is a pixel question, and jsdom has no
+ *   layout engine. It is answered in the acceptance run
+ *   (`e2e/tests/09-i18n-layout.spec.ts`) at 1280, 1440 and 1920.
+ * * **Does anything get lost?** That is a DOM question, and it is the one this
+ *   file answers: the same panes, the same controls, the same reported values,
+ *   with every one of the cockpit's own words longer. A pane that silently
+ *   stops rendering its legend because the text no longer fits its `Record`,
+ *   an `aria-label` that falls back to German, a proposal counter that
+ *   disappears — all of that is visible without a layout engine, and all of it
+ *   would otherwise only be found by whoever ships the next language.
+ */
+
+/** Everything the cockpit marks as structure, in document order. */
+function structureOf(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('[data-testid]')]
+    .map((node) => node.getAttribute('data-testid') ?? '')
+    .filter((id) => !/^_r_/.test(id))
+}
+
+function reportedOf(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('[data-reported]')].map(
+    (node) => node.textContent ?? '',
+  )
+}
+
+describe('a translation 35 per cent longer than German', () => {
+  it('renders every pane, tab and legend the German rendering renders', async () => {
+    const german = await renderWorkspaceScene({ language: 'de' })
+    const germanStructure = structureOf(german.container)
+    german.unmount()
+
+    const pseudo = await renderWorkspaceScene({ i18n: createPseudoI18n() })
+    const pseudoStructure = structureOf(pseudo.container)
+
+    // Not "roughly as much": the same elements, in the same order. A longer
+    // word may change where a line breaks; it may not change what exists.
+    expect(pseudoStructure).toEqual(germanStructure)
+    expect(germanStructure.length).toBeGreaterThan(40)
+
+    pseudo.unmount()
+  })
+
+  it('shows every text in full rather than falling back or truncating in the DOM', async () => {
+    const i18n = createPseudoI18n()
+    const { container, unmount } = await renderWorkspaceScene({ i18n })
+
+    // The pane titles, both legend headings and the run state — the elements
+    // the acceptance criteria of #37 name one by one. Each has to be on screen
+    // with its **whole** lengthened text, not with a prefix of it.
+    for (const key of [
+      'agents:pane.title',
+      'canvas:pane.title',
+      'canvas:legend.workStateTitle',
+      'canvas:legend.relationshipTitle',
+      'agents:runState.title',
+    ] as const) {
+      const text = i18n.t(key)
+      expect(text.length, key).toBeGreaterThan(12)
+      expect(screen.getAllByText(text, { exact: false }).length, key).toBeGreaterThan(0)
+    }
+
+    // …and the accessible names of the two collapsible panes, which carry the
+    // same words without ever being visible.
+    for (const key of ['workspace:pane.leftLabel', 'workspace:pane.rightLabel'] as const) {
+      const name = i18n.t(key)
+      expect(container.querySelector(`[aria-label="${name}"]`), key).not.toBeNull()
+    }
+
+    // Nothing anywhere resolved to a key: a longer catalogue is still a
+    // complete one.
+    expect(container.textContent ?? '').not.toContain(MISSING_KEY_PREFIX)
+
+    unmount()
+  })
+
+  it('leaves every reported value byte for byte where it was', async () => {
+    const german = await renderWorkspaceScene({ language: 'de' })
+    const germanReported = reportedOf(german.container)
+    german.unmount()
+
+    const english = await renderWorkspaceScene({ language: 'en' })
+    const englishReported = reportedOf(english.container)
+    english.unmount()
+
+    const pseudo = await renderWorkspaceScene({ i18n: createPseudoI18n() })
+    const pseudoReported = reportedOf(pseudo.container)
+
+    // The agent's words do not get longer because ours did. This is the same
+    // proof `WorkspacePage.i18n.test.tsx` makes for German against English,
+    // extended to a third rendering — which is the point of having one: it is
+    // the only rendering in which *every* translated string on screen is
+    // different, so a reported value that had accidentally been routed through
+    // `t()` could not survive it unchanged.
+    expect(pseudoReported).toEqual(germanReported)
+    expect(pseudoReported).toEqual(englishReported)
+    expect(pseudoReported.length).toBeGreaterThan(20)
+
+    for (const node of pseudo.container.querySelectorAll('[data-reported]')) {
+      expect(node).toHaveAttribute('translate', 'no')
+    }
+
+    pseudo.unmount()
+  })
+})

--- a/frontend/src/test/pseudoLocale.ts
+++ b/frontend/src/test/pseudoLocale.ts
@@ -1,0 +1,145 @@
+import type { i18n as I18n } from 'i18next'
+
+import { DEFAULT_LANGUAGE, createI18n } from '@/i18n'
+import { NAMESPACES, resources, type Namespace } from '@/i18n/resources'
+
+/**
+ * The pseudo-locale: German, 30–40 % longer.
+ *
+ * ## What it is for
+ *
+ * German is already one of the longest-running languages the cockpit will ever
+ * be written in, so a layout that survives German survives most translations —
+ * *most*, not all. The question this locale asks is the one no real catalogue
+ * can ask today: what happens when a translation is longer than anything either
+ * catalogue currently contains? A pane title that fits at 100 % and is cut off
+ * at 135 % is a layout defect that exists **now**, and it would be discovered by
+ * the first translator rather than by the test suite.
+ *
+ * ## Why it is not a third language
+ *
+ * The product speaks two languages, and the language switch shows exactly two
+ * segments. This locale therefore:
+ *
+ * * is **not** in `SUPPORTED_LANGUAGES`, so it cannot appear in the switch, in
+ *   `<html lang>` or in a stored preference;
+ * * is **not** a directory under `src/i18n/locales`, so `npm run check:locales`
+ *   never sees it — a generated catalogue that had to be kept in key parity by
+ *   hand would be a second catalogue to maintain and a new way to go red for a
+ *   reason nobody cares about;
+ * * is derived from the German catalogue by a pure function, so it cannot
+ *   drift: a key added in #42's successor is lengthened the day it is added.
+ *
+ * It is installed onto the German slot of one i18next instance. The application
+ * renders exactly as it renders in German — same language code, same plural
+ * rules, same formatting — with every one of its own words longer.
+ *
+ * ## Why it lives in `src/test/`
+ *
+ * It is test scaffolding, not a product feature. Nothing outside a test imports
+ * it, so it never reaches the bundle, and `scripts/check-ui-strings.mjs` treats
+ * everything under `test/` as test code.
+ */
+
+/**
+ * How much longer a pseudo string is than its German original.
+ *
+ * The issue asks for 30–40 %; 35 % sits in the middle, so the rounding at both
+ * ends of a short string still lands inside the band (see
+ * `src/i18n/pseudoLocale.test.ts`, which asserts exactly that).
+ */
+export const PSEUDO_EXPANSION = 0.35
+
+/** The band the expansion has to stay inside, asserted rather than assumed. */
+export const PSEUDO_EXPANSION_RANGE = { min: 0.3, max: 0.4 } as const
+
+/**
+ * The padding.
+ *
+ * Latin letters and German umlauts on purpose: every font the cockpit uses has
+ * them, so a browser measures the padding the way it measures a real
+ * translation. A filler of box-drawing or Cyrillic characters would fall back
+ * to a different font and quietly measure something else. It starts with a
+ * space so the padding wraps as words rather than turning a label into one
+ * unbreakable token — a line that cannot wrap overflows for a reason that has
+ * nothing to do with its length.
+ */
+const FILLER = ' ähnlich lange wörter'
+
+/** Exactly `length` characters of filler. */
+function filler(length: number): string {
+  let padding = ''
+  while (padding.length < length) padding += FILLER
+  return padding.slice(0, length)
+}
+
+/**
+ * One translated string, lengthened.
+ *
+ * The original is kept as the prefix and the padding is **appended**, which is
+ * what keeps the transformation safe for the two things a catalogue string can
+ * contain besides words:
+ *
+ * * `{{interpolations}}` — untouched, so the reported values they carry still
+ *   arrive byte-identical;
+ * * `<0>…</0>` slots of `<Trans>` — untouched, so the markup still nests.
+ *
+ * It also keeps the string readable, which matters more than it sounds: a test
+ * that fails on a pseudo rendering has to be debuggable from the screenshot.
+ */
+export function lengthenText(text: string): string {
+  const padding = Math.round(text.length * PSEUDO_EXPANSION)
+  return padding === 0 ? text : text + filler(padding)
+}
+
+type Catalogue = { [key: string]: string | Catalogue }
+
+/** Deep-maps every leaf of a catalogue through {@link lengthenText}. */
+export function lengthenCatalogue<T>(catalogue: T): T {
+  const source = catalogue as unknown as Catalogue
+  const result: Catalogue = {}
+  for (const [key, value] of Object.entries(source)) {
+    result[key] =
+      typeof value === 'string' ? lengthenText(value) : lengthenCatalogue(value)
+  }
+  return result as unknown as T
+}
+
+/** The whole reference catalogue, lengthened, namespace by namespace. */
+export function pseudoResources(): Record<Namespace, unknown> {
+  const bundles = {} as Record<Namespace, unknown>
+  for (const namespace of NAMESPACES) {
+    bundles[namespace] = lengthenCatalogue(resources[DEFAULT_LANGUAGE][namespace])
+  }
+  return bundles
+}
+
+/**
+ * An initialised i18next instance that renders the cockpit in the pseudo-locale.
+ *
+ * ## The clone is not optional
+ *
+ * `i18next.init({ resources })` keeps a **reference** to the object it is
+ * given, and `addResourceBundle` writes through that reference. Installing the
+ * pseudo catalogue without the clone below therefore replaces the German
+ * catalogue of `src/i18n/resources.ts` for the rest of the worker process —
+ * every later `createI18n()` in the same test file would come up in the
+ * pseudo-locale, and the failure would surface in an unrelated test.
+ *
+ * Cloning the instance's own store first confines the write to this instance.
+ * `pseudoLocale.test.ts` asserts that a plain `createI18n()` built afterwards
+ * still answers in real German, so the guard is known to hold rather than
+ * believed to.
+ */
+export function createPseudoI18n(): I18n {
+  const instance = createI18n({ language: DEFAULT_LANGUAGE, dev: false })
+
+  instance.store.data = structuredClone(instance.store.data)
+
+  const bundles = pseudoResources()
+  for (const namespace of NAMESPACES) {
+    instance.addResourceBundle(DEFAULT_LANGUAGE, namespace, bundles[namespace], false, true)
+  }
+
+  return instance
+}

--- a/frontend/src/test/workspaceScene.ts
+++ b/frontend/src/test/workspaceScene.ts
@@ -1,0 +1,95 @@
+import { screen, waitFor } from '@testing-library/react'
+import { expect } from 'vitest'
+import type { i18n as I18n } from 'i18next'
+
+import type { Language } from '@/i18n'
+
+import { PROJECT_ID, RUN_ID, component, createFakeFetch } from './fixtures'
+import {
+  COMPONENT_ID,
+  HISTORY_PATH,
+  INSPECTOR_PATH,
+  historyPage,
+  inspectorPage,
+} from './inspectorFixtures'
+import {
+  longTaskAgentsResponse,
+  openRunResponse,
+  runPaths,
+  runsWithHistoryResponse,
+  twoRevisionPlansResponse,
+} from './runFixtures'
+import { renderApp, type RenderAppOptions } from './renderApp'
+
+/**
+ * The full cockpit, with real reported content in all three panes.
+ *
+ * Two suites need exactly this scene and would otherwise each wire up the same
+ * seven responses: `WorkspacePage.i18n.test.tsx` compares German against
+ * English, and `accessibleNames.test.tsx` walks the accessible names of the same
+ * screen in every language. A second copy of the fixture would be a second
+ * thing to keep in step with the contract, and the two suites would slowly stop
+ * looking at the same screen.
+ */
+
+export const WORKSPACE_SCENE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}?component=${COMPONENT_ID}`
+
+/** The three panes, each with real reported content in them. */
+export function workspaceSceneServer(): typeof fetch {
+  return createFakeFetch({
+    [runPaths.runs]: runsWithHistoryResponse,
+    [runPaths.currentRun]: openRunResponse,
+    [runPaths.runDetail]: openRunResponse,
+    [runPaths.agents]: longTaskAgentsResponse,
+    [runPaths.plans]: twoRevisionPlansResponse,
+    [runPaths.architecture]: {
+      projectPosition: 42,
+      components: [component({ componentId: COMPONENT_ID, name: 'Tax', kind: 'module' })],
+      relationships: [],
+      activeChanges: [],
+    },
+    [INSPECTOR_PATH]: inspectorPage(),
+    [HISTORY_PATH]: historyPage(),
+  })
+}
+
+export interface WorkspaceSceneOptions {
+  /** Language the app starts in. Ignored when `i18n` is given. */
+  language?: Language
+  /** A prepared instance — the pseudo-locale arrives this way. */
+  i18n?: I18n
+}
+
+/**
+ * Renders the scene and waits until all three panes carry their content.
+ *
+ * The inspector arrives last, so waiting for it and for the agent tree is what
+ * makes "the whole cockpit is on screen" true rather than likely.
+ *
+ * The canvas is waited for as well, and that one is not cosmetic: while ELK is
+ * still running, the architecture pane carries a `canvas-layouting` element
+ * that is gone a moment later. Any test that compares two renderings element by
+ * element — German against English, German against the pseudo-locale — would
+ * otherwise report the *progress of the layout* as a difference between two
+ * languages, on whichever of the two happened to be measured first.
+ */
+export async function renderWorkspaceScene(options: WorkspaceSceneOptions = {}) {
+  const renderOptions: RenderAppOptions = {
+    fetchImpl: workspaceSceneServer(),
+    ...(options.i18n ? { i18n: options.i18n } : {}),
+    ...(options.language ? { language: options.language } : {}),
+  }
+
+  const rendered = renderApp(WORKSPACE_SCENE_URL, renderOptions)
+
+  await screen.findByTestId('inspector-context')
+  await screen.findByTestId('agent-tree')
+
+  const canvas = await screen.findByTestId('architecture-canvas')
+  await waitFor(() => expect(canvas.getAttribute('data-layouting')).toBe('false'))
+  await waitFor(() =>
+    expect(Number(canvas.getAttribute('data-fit-view-count'))).toBeGreaterThan(0),
+  )
+
+  return rendered
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+import { availableParallelism } from 'node:os'
 import { fileURLToPath, URL } from 'node:url'
 
 import tailwindcss from '@tailwindcss/vite'
@@ -34,5 +35,57 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+
+    /**
+     * The heaviest tests here render the **real** application — router, query
+     * client, React Flow and a full ELK layout — inside jsdom. On an idle
+     * machine the slowest of them costs about 1.5 s; Vitest's default budget of
+     * 5 s therefore looked generous and was not, because the cost is CPU time
+     * and the wall time it turns into depends on what else the machine is
+     * doing.
+     *
+     * The canvas files already say what they think they need:
+     * `CANVAS_TIMEOUT = 15_000` on their `waitFor` calls. Those numbers were
+     * never reachable — a `waitFor` cannot outlive the test that awaits it, so
+     * the 5 s default silently overruled every one of them, and the suite
+     * reported "timed out in 5000ms" for work that had 1.5 s of actual
+     * substance in it.
+     *
+     * 20 s is the file-level intention plus room for the assertion around it.
+     * It is not a licence to wait: nothing in this suite waits for an event
+     * that may never arrive, and a test that really hangs still fails — 15 s
+     * later, with the same message.
+     */
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
+
+    /**
+     * Vitest defaults to one worker per core. Each worker is a fork with its
+     * own jsdom, its own React and its own ELK, and on a 22-core machine 21 of
+     * them do not run 21 tests in the time of one — they run each other into
+     * the ground. Measured over the whole suite on such a machine:
+     *
+     * | max forks | wall  | test CPU | jsdom setup |
+     * | --------- | ----- | -------- | ----------- |
+     * | 21 (default) | 24 s | 135 s | 130 s |
+     * | 12        | 30 s  | 143 s   | 90 s  |
+     * |  6        | 34 s  |  80 s   |  55 s |
+     * |  4        | 44 s  |  64 s   |  51 s |
+     *
+     * Ten seconds of wall time buy back 40 % of the CPU time each individual
+     * test needs, and it is the *individual* test that has a deadline. Under a
+     * loaded machine the uncapped run took 945 s of test CPU and failed 46
+     * tests; that is the failure this cap removes.
+     *
+     * The cap is an upper bound, not a floor: a CI runner with four cores keeps
+     * the three workers it would have chosen anyway, so nothing about CI
+     * changes.
+     */
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        maxForks: Math.max(2, Math.min(6, availableParallelism() - 1)),
+      },
+    },
   },
 })


### PR DESCRIPTION
Closes #37.

Das letzte Issue des i18n-Epics. Es ergänzt die automatisierten Sprach-,
Accessibility- und Layouttests — und behebt zuerst den Grund, aus dem die Suite
das, was sie behauptet, bisher nicht belegen konnte.

Die Begründung im Ganzen steht in
[ADR 0022](docs/decisions/0022-translation-test-suite-pseudo-locale-and-a-suite-that-can-be-believed.md).

---

## 1. Die Suite flackerte — Ursache, nicht Symptom

Drei volle Läufe auf `develop`, derselbe Commit, 22 Kerne:

```
Lauf 1:  9 failed | 420 passed
Lauf 2: 46 failed | 383 passed
Lauf 3:  1 failed | 428 passed
```

CI war durchgehend grün, weil ein Vier-Kern-Runner den Zustand nicht erzeugt.

### Ursache A — die Tests bekamen nie die Zeit, die sie verlangen

Alle Fehlschläge lasen sich `Test timed out in 5000ms`. Die entscheidende Frage
ist nicht „wie hoch drehen wir das", sondern „wird überhaupt gearbeitet oder
wird auf etwas gewartet, das nie kommt". Eine Messung beantwortet sie — die
ganze Suite, einmal mit `--testTimeout=60000`, sonst unverändert:

```
43 Dateien, 429 Tests, alle grün.
Langsamster Einzeltest: 1451 ms.
```

Nichts hängt. Dazu ein zweiter, schärferer Befund: die Canvas-Dateien sagen
längst, was sie brauchen — `CANVAS_TIMEOUT = 15_000` an ihren `waitFor`.
**Diese Zahl war nie erreichbar**: ein `waitFor` überlebt den Test nicht, der
darauf wartet, also hat der 5-s-Default jeden dieser Werte stillschweigend
überstimmt. Konfiguration und Tests waren sich uneinig, und die Konfiguration
hat gewonnen, ohne es zu sagen.

→ `testTimeout: 20_000`, `hookTimeout: 20_000`.

### Ursache B — 21 Worker führen keine 21 Tests aus

Vitest nimmt per Default einen Worker pro Kern. Jeder ist ein Fork mit eigenem
jsdom, eigenem React und eigenem ELK. Gemessen über die ganze Suite:

| max forks | Wall | Test-CPU | jsdom-Setup |
| --- | --- | --- | --- |
| 21 (Default) | 24 s | 135 s | 130 s |
| 12 | 30 s | 143 s | 90 s |
| 6 | 34 s | 80 s | 55 s |
| 4 | 44 s | 64 s | 51 s |

Zehn Sekunden Wall-Zeit kaufen 40 % der CPU-Zeit zurück, die der *einzelne*
Test braucht — und der einzelne Test hat die Deadline. Unter Last brauchte der
ungedeckelte Lauf 945 s Test-CPU und ließ 46 Tests fallen.

→ `maxForks: max(2, min(6, availableParallelism() - 1))`. Eine Obergrenze, kein
Boden: ein Vier-Kern-CI-Runner behält die drei Worker, die er ohnehin gewählt
hätte.

### Ursache C — eine Assertion war echt gerannt

Ein Fehlschlag war kein Timeout:

```
ChangeOverlays.test.tsx > draws a new proposal without moving zoom, pan or selection
AssertionError: expected '0' to be '1'
  expect(canvas.getAttribute('data-fit-view-count')).toBe('1')
```

`data-layouting: false` heißt „ELK ist fertig". Es heißt **nicht**, dass die
automatische Kamerafahrt gelaufen ist: `fitView` passiert in einem Effect
*danach*. Zehn Assertions in vier Dateien lasen `data-fit-view-count`, den
Viewport-Transform oder die gespeicherte Kamera synchron genau in diesem
Moment. Behoben in den vier `waitForCanvas`-Helfern; die Assertions selbst sind
unverändert und sagen weiterhin `'1'`.

### Nachweis: fünf volle Läufe hintereinander, auf derselben Maschine

Dieselbe Maschine, auf der `develop` einen von drei Läufen verloren hat —
`for i in 1 2 3 4 5; do npm test; done`, ohne die Maschine zu schonen (Lauf 1
lief parallel zu `npm run build`, und ich habe während aller fünf weiter im
Repository gearbeitet, was in Lauf 2 der Ausgangsmessung die 46 Fehlschläge
verursacht hatte):

```
=== RUN 1 ===  Test Files  46 passed (46)   Tests  455 passed (455)   35.36s
=== RUN 2 ===  Test Files  46 passed (46)   Tests  455 passed (455)   35.06s
=== RUN 3 ===  Test Files  46 passed (46)   Tests  455 passed (455)   34.53s
=== RUN 4 ===  Test Files  46 passed (46)   Tests  455 passed (455)   33.96s
=== RUN 5 ===  Test Files  46 passed (46)   Tests  455 passed (455)   34.33s
```

Test-CPU 77–81 s statt 945 s unter Last, Streuung der Gesamtlaufzeit 1,4 s.

---

## 2. Was ich als bereits erfüllt vorgefunden habe

Das meiste aus dem Umfang von #37 war von #38/#40/#42/#36 schon gebaut. Ein
zweites Mal geschrieben wäre die Suite länger und nicht stärker geworden:

| Issue verlangt | Zustand bei Ankunft |
| --- | --- |
| Unit-Tests für Plurale, Datum, Prozent | `i18n/formatting.test.ts` — beide Sprachen, null/eins/viele, UTC-Kennzeichnung, ungültige und nicht gemeldete Werte, das deutsche geschützte Leerzeichen (#40) |
| Unit-Tests für Fallbacks und fehlende Schlüssel | `i18n/i18n.test.ts` — `fallbackLng`, Entwicklungsmarker, Produktionsschlüssel, geleerte Übersetzung, nicht mehr unterstützte gespeicherte Sprache (#38) |
| Komponententests für zentrale DE/EN-Oberflächen | `ProjectsPage.i18n.test.tsx`, `WorkspacePage.i18n.test.tsx`, `LanguageSwitch.i18n.test.tsx` (#42, #36) |
| Übersetzte `aria-label` und Screenreader-Texte | pro Fläche: Graph in `ArchitectureAccessibility.test.tsx` (#35), Chrome in `WorkspacePage.i18n.test.tsx` (#42) |
| Code-Diffs und Agentenmeldungen unverändert | `data-reported`-Vergleich über beide Sprachen, Zeichen für Zeichen (#42) |
| Schlüsselgleichheit der Kataloge | `npm run check:locales`, gegen fünf absichtlich kaputte Kataloge verifiziert (#38) |

---

## 3. Was neu ist

**Gezählte Substantive kommen jetzt aus dem Katalog.** Die vorhandenen
Pluraltests nennen die Substantive, die sie prüfen — deshalb sind sie lesbar und
deshalb sind sie unvollständig. Ein zweiter Block liest die Liste aus
`common.count` und prüft 0/1/2/11/1234 in beiden Sprachen für jedes einzelne.
Dazu die beiden nie ausgewählten `Intl`-Einheiten (Wochen, Monate) und zwei
Prozent-Grenzfälle (>100, <0 werden gemeldet, nicht geklemmt).

**Die zugänglichen Namen werden gefegt statt aufgezählt.**
`i18n/accessibleNames.test.tsx` läuft über beide Flächen in beiden Sprachen und
prüft drei Eigenschaften, die auch für Namen gelten, die noch niemand
geschrieben hat: nichts löst zu einem Schlüssel oder zum `⟦…⟧`-Marker auf, jedes
bedienbare Element hat einen Namen, und die beiden Sprachen unterscheiden sich
wirklich.

**Eine Pseudo-Locale, die niemand auswählen kann.** Jedes Wort, das dem Cockpit
gehört, 35 % länger.

* **Keine unterstützte Sprache** — `SUPPORTED_LANGUAGES` bleibt `['de','en']`,
  also kein Eintrag in der Sprachwahl, in `<html lang>` oder im gespeicherten
  Wert.
* **Kein Verzeichnis unter `locales/`** — `check:locales` sieht sie nie
  (weiterhin *373 keys, de, en, reference de*).
* **Nicht im Bundle** — sie liegt unter `src/test/`.
* **Reine Funktion des deutschen Katalogs**, kann also nicht driften; das
  Original bleibt vorne, die Polsterung wird angehängt, `{{Interpolationen}}`
  und die `<agent/>`/`<run/>`/`<field/>`-Slots bleiben unversehrt (alles
  assertiert).

Sie wird auf den deutschen Slot **einer** i18next-Instanz gelegt. Der Klon des
Resource-Stores in `createPseudoI18n` ist dabei tragend und kein Stil:
`i18next.init({ resources })` behält eine **Referenz** auf den Modulkatalog, und
`addResourceBundle` schreibt durch sie hindurch — ohne den Klon wäre das echte
Deutsch für den Rest des Worker-Prozesses ersetzt, und der Fehler tauchte drei
Dateien später in einem fremden Test auf. Ein Test hält das fest.

Für den Browser gibt es sie ein zweites Mal (`e2e/src/pseudoLocale.ts`): jsdom
hat keine Layout-Engine, kann also „geht etwas verloren" beantworten, aber nicht
„wird etwas abgeschnitten". Beide lassen `[data-reported]` und alles unter
`translate="no"` in Ruhe — deshalb ist das dritte Rendering ein *dritter
Beweis*: dort unterscheidet sich jede übersetzte Zeichenkette von beiden
Katalogen, ein versehentlich durch `t()` geleiteter gemeldeter Wert käme nicht
unverändert heraus.

**E2E-Prüfung 9** — Layout bei 1920, 1440 und 1280, in Deutsch, Englisch und
Pseudo-Locale. Alle Selektoren sprachunabhängig, jede Prüfliste assertiert
zuerst, dass sie überhaupt etwas gefunden hat.

**`check:locales` und `check:ui-strings` als benannte CI-Schritte**, vor Lint
und Typecheck. Beide laufen weiterhin auch in der Vitest-Suite — das ist der
Teil, der beweist, dass sie *funktionieren* (dort laufen sie gegen absichtlich
kaputte Bäume). Der benannte Schritt macht den Fehlschlag lesbar.

---

## 4. Screenshots: Belege, keine Baseline

Bewusste Entscheidung, begründet in ADR 0022. `toHaveScreenshot()` vergleicht
gerenderte Pixel; die hängen an Schriftrendering und Subpixel-Positionierung,
und eine im Linux-Container aufgenommene Baseline widerspricht demselben Build
auf einem Windows-Rechner über völlig korrekten Text. Das hier ist das
Freigabe-Gate des Epics — ein Gate, das Rauschen meldet, wird ignoriert
(ADR 0013).

Was das Issue tatsächlich verlangt — keine abgeschnittenen Pane-Titel, Buttons,
Legenden oder Statuswerte — wird stattdessen **gemessen**: `scrollWidth` gegen
`clientWidth` bei einem `overflow`, das den Rest verbirgt. Ein Element mit
`overflow-x: auto` ist breiter als seine Box und trotzdem lesbar (die
Diff-Ansicht ist genau so gebaut) und gilt nicht als Defekt. Die neun
Screenshots (3 Breiten × DE/EN/Pseudo) hängen am Report.

---

## 5. Gefundener Produktfehler

Die Messung hat sofort einen abgeschnittenen Text gefunden.
`[data-testid="pane-architecture"] h2`, benötigt / verfügbar in Pixeln:

| Rendering | 1920 | 1440 | 1280 |
| --- | --- | --- | --- |
| Deutsch | 88 / 88 | 88 / 88 | 88 / **78** |
| Englisch | 96 / 96 | 96 / 96 | 96 / **92** |
| Pseudo | 122 / 122 | 122 / **87** | 122 / **0** |

Der Header der Architekturfläche trägt den vierteiligen Änderungszähler und die
zwei Zählbadges — zusammen rund 550 px, `shrink-0` — bei 690 px Panebreite auf
1280. Die Überschrift ist das Einzige in dieser Zeile, das nachgeben kann.

**Die erste Zeile ist die wichtige: Deutsch ist bei 1280 bereits abgeschnitten.**
Das ist also kein Defekt, den die Übersetzung eingeführt hat, sondern ein
Layoutdefekt des Architektur-Headers bei schmalen Breiten (Thema von ADR 0015 /
#41), den Englisch um 4 px verschärft und eine lange Übersetzung ernst macht.

**Nicht behoben**, wie abgesprochen: das Heilmittel ist eine Designentscheidung
über den Header (Zähler verdichten, Badges weglassen, Titel umbrechen, Minimum
reservieren), und die gehört nicht in ein Test-Issue. Die Ausnahme in der
Prüfung ist in zwei Richtungen begrenzt — ein benannter Probe, und nur
**unterhalb** von 1920, wo die Assertion für alle drei Renderings streng bleibt
— und jeder Lauf, der sie trifft, schreibt die Messung als Annotation in den
Playwright-Report.

---

## 6. Kommandos und echte Ergebnisse

```
$ npm run lint            (frontend)   ✔
$ npm run typecheck       (frontend)   ✔
$ npm run typecheck       (e2e)        ✔
$ npm run check:locales                Translation catalogues agree: 373 keys, de, en, reference de.
$ npm run check:ui-strings             No hard-coded UI text: 100 files scanned in src, 4 reasoned exceptions.
$ npm test                (frontend)   Test Files 46 passed (46) · Tests 455 passed (455)
$ npm run build           (frontend)   ✓ built in 19.04s
```

Abnahmelauf (`FRONTEND_HTTP_PORT=8110`, `E2E_COMPOSE_PROJECT=vai-issue37`,
eigener Stack, 8080–8083 unangetastet):

```
Running 25 tests using 1 worker
  ok  1 … ok 21   ← die 21 bestehenden Prüfungen, unverändert
  ok 22  9 · the desktop layout holds in de at 1920, 1440 and 1280 (1.3s)
  ok 23  9 · the desktop layout holds in en at 1920, 1440 and 1280 (1.3s)
  ok 24  9 · a translation 35 per cent longer keeps the layout at 1920, 1440 and 1280 (1.8s)
  ok 25  9 · reported project data is identical in German, English and the pseudo-locale (1.1s)

  25 passed (2.1m)
```

429 → 455 Frontend-Tests, 21 → 25 Abnahmeprüfungen.

---

## 7. Offene Risiken

* **Zwei Implementierungen einer Regel.** `frontend/src/test/pseudoLocale.ts`
  und `e2e/src/pseudoLocale.ts` müssen sich über die 35 % und die Polsterung
  einig sein. Bewusst dupliziert über die Paketgrenze (e2e hat eigene
  `package.json`/`tsconfig.json`); jede Seite assertiert das 30–40-%-Band für
  sich.
* **Die DOM-Variante der Pseudo-Locale mutiert ein DOM, das React gehört.** Ein
  Re-Render würde die kurzen Texte zurückholen und die Messung wertlos machen —
  deshalb wird nach jeder Messung geprüft, dass der lange Text noch da war, und
  pro Breite neu geladen statt einmal expandiert und dreimal skaliert.
* **`testTimeout: 20_000`**: ein wirklich hängender Test meldet sich nach 20 s
  statt nach 5 s.
* **Der Architektur-Header-Defekt bleibt offen** (Abschnitt 5).
* **Der Fork-Deckel hängt an `availableParallelism()`.** Auf einer Maschine mit
  sehr wenig RAM pro Kern könnte auch 6 noch zu viel sein; der Wert ist dann
  eine Konfigurationszeile.
