### PR TITLE
Clarify architecture graph counters

### DIFF
--- a/e2e/src/config.ts
+++ b/e2e/src/config.ts
@@ -90,6 +90,12 @@ export const VALIDATION_AGENT = 'e2e-validation-orchestrator'
 export const RETRY_PROJECT = 'visualise-ai-retry'
 export const CONFLICT_PROJECT = 'visualise-ai-conflict'
 
+/** Self-reporting run: the repository's 28-component model and open proposal. */
+export const SELF_PROJECT = 'visualise-ai-self'
+export const SELF_RUN = 'run-v0-epic-1'
+export const SELF_BOOTSTRAP_RUN = 'run-e2e-self-bootstrap'
+export const SELF_BOOTSTRAP_AGENT = 'e2e-self-bootstrap-orchestrator'
+
 /**
  * Forced-disconnect replay probe. A project of its own so the cut, the reconnect
  * and the position arithmetic cannot be disturbed by, or disturb, the browser

--- a/e2e/src/simulator.ts
+++ b/e2e/src/simulator.ts
@@ -36,7 +36,7 @@ export interface SimulatorSummary {
 }
 
 export interface SimulatorOptions {
-  scenario?: 'full' | 'retry' | 'conflict'
+  scenario?: 'full' | 'retry' | 'conflict' | 'self'
   projectId?: string
   runId?: string
   /** Pause multiplier. `1` keeps the pauses the live checks need. */

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -1,8 +1,16 @@
 import { expect, test, type Page } from '@playwright/test'
 
-import { getJson } from '../src/api.js'
+import { asAccepted, bootstrapEvent, getJson, postEvent } from '../src/api.js'
 import { showWholeModel } from '../src/canvas.js'
-import { MAIN_PROJECT, MAIN_RUN } from '../src/config.js'
+import {
+  MAIN_PROJECT,
+  MAIN_RUN,
+  SELF_BOOTSTRAP_AGENT,
+  SELF_BOOTSTRAP_RUN,
+  SELF_PROJECT,
+  SELF_RUN,
+} from '../src/config.js'
+import { startSimulator } from '../src/simulator.js'
 
 /**
  * Mandatory check 2 — the full architecture canvas: hierarchy and typed
@@ -48,6 +56,8 @@ const RELATIONSHIP_KINDS = [
   'nats_topic',
   'dependency',
 ] as const
+
+const SELF_BOOTSTRAP_EVENT_ID = '22222222-0000-4000-8000-000000000002'
 
 async function openWorkspace(page: Page): Promise<void> {
   await page.goto(`/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}`)
@@ -250,6 +260,67 @@ test('2 · every relationship kind is drawn, and every reported NATS topic stays
   expect(edgeInventory.appliedEdges).toBe(architecture.relationships.length)
   expect(edgeInventory.labels).toBe(
     edgeInventory.appliedEdges + edgeInventory.overlayEdges,
+  )
+})
+
+test('2 · the self run keeps 28 model components apart from its open proposal at initial depth', async ({
+  page,
+}) => {
+  const opened = await postEvent(
+    bootstrapEvent({
+      clientEventId: SELF_BOOTSTRAP_EVENT_ID,
+      projectId: SELF_PROJECT,
+      runId: SELF_BOOTSTRAP_RUN,
+      agentId: SELF_BOOTSTRAP_AGENT,
+      displayName: 'Self-run acceptance bootstrap',
+    }),
+  )
+  expect(opened.status, JSON.stringify(opened.body)).toBe(201)
+  expect(asAccepted(opened).position).toBe(1)
+
+  await page.goto(`/projects/${SELF_PROJECT}/runs/${SELF_RUN}`)
+  await expect(page.getByTestId('live-connection-state')).toHaveAttribute(
+    'data-state',
+    'live',
+  )
+
+  // The browser is subscribed before the self scenario publishes its snapshot;
+  // speed 0 keeps this structural check short without sampling transient work states.
+  const simulator = startSimulator({ scenario: 'self', speed: 0 })
+  await expect(page.getByTestId('architecture-canvas')).toBeVisible({ timeout: 120_000 })
+
+  const summary = await simulator.done
+  expect(summary.scenario).toBe('self')
+  expect(summary.projectId).toBe(SELF_PROJECT)
+  expect(summary.runId).toBe(SELF_RUN)
+  expect(summary.conflicts).toBe(0)
+  expect(summary.duplicates).toBe(0)
+  expect(summary.created).toBe(summary.eventsSent)
+  expect(summary.endPosition).toBe(summary.eventsSent + 1)
+
+  const canvas = page.getByTestId('architecture-canvas')
+  await expect(canvas).toHaveAttribute('data-node-count', '28')
+  await expect(canvas).toHaveAttribute('data-overlay-node-count', '1')
+  await expect(canvas).toHaveAttribute('data-total-element-count', '29')
+  await expect(canvas).toHaveAttribute('data-reported-relationship-count', '35')
+  await expect(page.getByTestId('architecture-model-count')).toContainText(
+    '28 Modellkomponenten',
+  )
+  await expect(page.getByTestId('architecture-proposal-count')).toContainText(
+    '+ 1 Vorschlag',
+  )
+  await expect(page.getByTestId('canvas-node-visualise-ai.repository-provider')).toHaveAttribute(
+    'data-presence',
+    'proposal',
+  )
+
+  // The initial depth shows ten of the 29 total elements. The open proposal is
+  // included in that visible-element count but remains outside the 28-model
+  // component count above; nine connections are visible at this depth.
+  await expect(canvas).toHaveAttribute('data-visible-node-count', '10')
+  await expect(canvas).toHaveAttribute('data-visible-connection-count', '9')
+  await expect(page.getByTestId('architecture-relationship-count')).toContainText(
+    '35 gemeldete Beziehungen · 9 Verbindungen dargestellt',
   )
 })
 

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -300,27 +300,39 @@ test('2 · the self run keeps 28 model components apart from its open proposal a
 
   const canvas = page.getByTestId('architecture-canvas')
   await expect(canvas).toHaveAttribute('data-node-count', '28')
-  await expect(canvas).toHaveAttribute('data-overlay-node-count', '1')
-  await expect(canvas).toHaveAttribute('data-total-element-count', '29')
-  await expect(canvas).toHaveAttribute('data-reported-relationship-count', '35')
+  // The overlay count is deliberately not used as the proposal count: the
+  // self run also keeps one removed component as evidence (a ghost).
+  await expect(canvas).toHaveAttribute('data-overlay-node-count', '2')
+  await expect(canvas).toHaveAttribute('data-total-element-count', '30')
+  await expect(canvas).toHaveAttribute('data-reported-relationship-count', '37')
   await expect(page.getByTestId('architecture-model-count')).toContainText(
     '28 Modellkomponenten',
   )
   await expect(page.getByTestId('architecture-proposal-count')).toContainText(
     '+ 1 Vorschlag',
   )
+  await expect(page.getByTestId('architecture-evidence-count')).toContainText(
+    '+ 1 Komponente nur als Beleg',
+  )
+  await expect(
+    page.locator('[data-testid^="canvas-node-"][data-presence="proposal"]'),
+  ).toHaveCount(1)
+  await expect(
+    page.locator('[data-testid^="canvas-node-"][data-presence="ghost"]'),
+  ).toHaveCount(1)
   await expect(page.getByTestId('canvas-node-visualise-ai.repository-provider')).toHaveAttribute(
     'data-presence',
     'proposal',
   )
 
-  // The initial depth shows ten of the 29 total elements. The open proposal is
-  // included in that visible-element count but remains outside the 28-model
-  // component count above; nine connections are visible at this depth.
+  // The initial depth shows ten of the 30 total elements. The proposal and the
+  // evidence ghost remain outside the 28-model component count above; ten
+  // connections are visible at this depth.
+  await expect(canvas).toHaveAttribute('data-collapsed-count', '2')
   await expect(canvas).toHaveAttribute('data-visible-node-count', '10')
-  await expect(canvas).toHaveAttribute('data-visible-connection-count', '9')
+  await expect(canvas).toHaveAttribute('data-visible-connection-count', '10')
   await expect(page.getByTestId('architecture-relationship-count')).toContainText(
-    '35 gemeldete Beziehungen · 9 Verbindungen dargestellt',
+    '37 gemeldete Beziehungen · 10 Verbindungen dargestellt',
   )
 })
 

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -317,9 +317,6 @@ test('2 · the self run keeps 28 model components apart from its open proposal a
   await expect(
     page.locator('[data-testid^="canvas-node-"][data-presence="proposal"]'),
   ).toHaveCount(1)
-  await expect(
-    page.locator('[data-testid^="canvas-node-"][data-presence="ghost"]'),
-  ).toHaveCount(1)
   await expect(page.getByTestId('canvas-node-visualise-ai.repository-provider')).toHaveAttribute(
     'data-presence',
     'proposal',

--- a/e2e/tests/09-i18n-layout.spec.ts
+++ b/e2e/tests/09-i18n-layout.spec.ts
@@ -91,41 +91,6 @@ const TEXTS: TextProbe[] = [
   { name: 'language switch', selector: '[data-testid="language-switcher"]' },
 ]
 
-/**
- * The one clipped text this check found and does **not** fail on, with the
- * reason it does not.
- *
- * Below 1920 the architecture pane's heading is the only element in its header
- * that can give way. The header carries the four-state change counter and the
- * two count badges — together about 550 px, and `shrink-0` — while the pane
- * itself is 690 px at 1280. Measured against the acceptance deployment:
- *
- * | rendering | 1920      | 1440      | 1280           |
- * | --------- | --------- | --------- | -------------- |
- * | German    | 88 / 88   | 88 / 88   | 88 / **78**    |
- * | English   | 96 / 96   | 96 / 96   | 96 / **92**    |
- * | pseudo    | 122 / 122 | 122 / **87** | 122 / **0** |
- *
- * (needed / available, in pixels.)
- *
- * The first row is the important one: **German is already clipped at 1280**, so
- * this is not a defect translation introduced. It is a layout defect of the
- * architecture header at narrow widths (the subject of ADR 0015 / #41), which
- * English makes marginally worse and a long translation makes severe.
- *
- * It is reported rather than fixed here. The remedy is a decision about what
- * that header shows when it runs out of room — condense the change counter,
- * drop the badges, wrap the title — and that is a design decision belonging to
- * whoever owns the header, not a side effect of a test issue.
- *
- * The exception is bounded in two directions so it cannot rot into a blanket
- * permission: it applies to one named probe, and only below 1920, where the
- * assertion below stays strict for every rendering.
- */
-function isReportedHeaderDefect(name: string, width: number): boolean {
-  return name === 'pane title · architecture' && width < 1920
-}
-
 /** The primary controls, again with language-independent selectors. */
 const CONTROLS: ControlProbe[] = [
   { name: 'run selection (current run)', selector: `[data-testid="run-option-${MAIN_RUN}"]` },
@@ -191,21 +156,10 @@ async function assertLayoutHolds(page: Page, width: number, label: string): Prom
   const clipped = texts.filter(
     (report) => report.clippedHorizontally || report.clippedVertically,
   )
-  const cut = clipped.filter((report) => !isReportedHeaderDefect(report.name, width))
   expect(
-    cut.length === 0,
-    `${label}: text is cut off\n${formatTextReports(cut)}`,
+    clipped.length === 0,
+    `${label}: text is cut off\n${formatTextReports(clipped)}`,
   ).toBe(true)
-
-  // The tolerated one is written into the report rather than swallowed: a known
-  // defect that leaves no trace in the run that found it stops being known.
-  const tolerated = clipped.filter((report) => isReportedHeaderDefect(report.name, width))
-  if (tolerated.length > 0) {
-    test.info().annotations.push({
-      type: 'known clipped text (#37 finding)',
-      description: `${label}\n${formatTextReports(tolerated)}`,
-    })
-  }
 
   const controls = await probeControls(page, CONTROLS)
   const broken = controls.filter(

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -132,6 +132,17 @@ export interface ArchitectureCanvasProps {
   model: ArchitectureModel
   selectedComponentId?: ComponentId | undefined
   onSelectComponent: (componentId: ComponentId | null) => void
+  /** Reports the counts the canvas actually draws to the pane header. */
+  onMetricsChange?: (metrics: ArchitectureCanvasMetrics) => void
+}
+
+export interface ArchitectureCanvasMetrics {
+  appliedComponentCount: number
+  overlayComponentCount: number
+  visibleElementCount: number
+  totalElementCount: number
+  reportedRelationshipCount: number
+  visibleConnectionCount: number
 }
 
 export function ArchitectureCanvas(props: ArchitectureCanvasProps) {
@@ -147,6 +158,7 @@ function ArchitectureCanvasInner({
   model,
   selectedComponentId,
   onSelectComponent,
+  onMetricsChange,
 }: ArchitectureCanvasProps) {
   const { t } = useTranslation('canvas')
   // The words *and* the counted nouns the accessible names are built from —
@@ -580,6 +592,31 @@ function ArchitectureCanvasInner({
   const problemCount = diagnosticsCount(graph.diagnostics)
   const hiddenCount = graph.hiddenComponentIds.size
 
+  const canvasMetrics = useMemo<ArchitectureCanvasMetrics>(
+    () => ({
+      appliedComponentCount: graph.appliedNodeCount,
+      overlayComponentCount: graph.overlayNodeCount,
+      visibleElementCount: graph.visibleNodeCount,
+      totalElementCount: graph.appliedNodeCount + graph.overlayNodeCount,
+      reportedRelationshipCount: graph.reportedRelationshipCount,
+      visibleConnectionCount: graph.visibleEdgeCount,
+    }),
+    [
+      graph.appliedNodeCount,
+      graph.overlayNodeCount,
+      graph.visibleNodeCount,
+      graph.reportedRelationshipCount,
+      graph.visibleEdgeCount,
+    ],
+  )
+
+  // Publish before the browser paints. Collapse and overlay updates change the
+  // visible connection count without necessarily changing the pane's model
+  // counts, so a passive effect would briefly expose the previous number.
+  useLayoutEffect(() => {
+    onMetricsChange?.(canvasMetrics)
+  }, [canvasMetrics, onMetricsChange])
+
   // The applied model and the overlay are counted separately on purpose: a
   // planned change must become visible on the canvas **without** changing what
   // the applied model contains, and these two numbers are how that stays
@@ -597,6 +634,9 @@ function ArchitectureCanvasInner({
       data-overlay-node-count={graph.overlayNodeCount}
       data-overlay-edge-count={graph.overlayEdgeCount}
       data-visible-node-count={graph.visibleNodeCount}
+      data-visible-connection-count={graph.visibleEdgeCount}
+      data-reported-relationship-count={graph.reportedRelationshipCount}
+      data-total-element-count={graph.appliedNodeCount + graph.overlayNodeCount}
       data-hidden-node-count={hiddenCount}
       data-collapsed-count={graph.collapsedIds.length}
       // The surface the camera was computed against. Reported so "is this node
@@ -781,7 +821,7 @@ function ArchitectureCanvasInner({
                 </TooltipContent>
               </Tooltip>
 
-              {hiddenCount > 0 && (
+              {graph.appliedNodeCount + graph.overlayNodeCount > 0 && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span
@@ -790,7 +830,8 @@ function ArchitectureCanvasInner({
                     >
                       {t(DISCLOSURE_LABEL_KEYS.visibility, {
                         visible: graph.visibleNodeCount,
-                        total: graph.visibleNodeCount + hiddenCount,
+                        total: graph.appliedNodeCount + graph.overlayNodeCount,
+                        count: graph.appliedNodeCount + graph.overlayNodeCount,
                       })}
                     </span>
                   </TooltipTrigger>
@@ -899,4 +940,3 @@ function diagnosticLines(
   }
   return lines
 }
-

--- a/frontend/src/canvas/ChangeOverlays.test.tsx
+++ b/frontend/src/canvas/ChangeOverlays.test.tsx
@@ -1,7 +1,7 @@
 import { act, screen, waitFor, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
-import type { ArchitectureResponse, Component } from '@/api/types'
+import type { ArchitectureResponse, Component, Relationship } from '@/api/types'
 import { applyLiveEvent } from '@/api/useLiveStream'
 import { DEFAULT_CAMERA, useUiStore } from '@/state/uiStore'
 import { WORK_STATES } from '@/state/workStates'
@@ -39,6 +39,15 @@ const PAYMENTS_DESCRIPTOR: Component = {
   name: 'Payment Provider',
   kind: 'external',
   parentComponentId: null,
+}
+
+/** A relationship-only proposal whose endpoints are already in the model. */
+const RELATIONSHIP_ONLY_PROPOSAL: Relationship = {
+  relationshipId: 'r-10',
+  sourceComponentId: 'platform.core.orders',
+  targetComponentId: 'external.payments',
+  kind: 'dependency',
+  label: 'Order payment dependency',
 }
 
 /** The nested model after the payment provider and its edge were removed. */
@@ -128,6 +137,15 @@ describe('live change overlays — every state appears after its own event', () 
       const edgesBefore = canvas.getAttribute('data-edge-count')
       expect(nodesBefore).toBe(String(NESTED_COMPONENTS.length))
       expect(canvas.getAttribute('data-overlay-node-count')).toBe('0')
+      expect(canvas.getAttribute('data-total-element-count')).toBe(
+        String(NESTED_COMPONENTS.length),
+      )
+      expect(canvas.getAttribute('data-visible-connection-count')).toBe('6')
+      await waitFor(() =>
+        expect(screen.getByTestId('architecture-relationship-count')).toHaveTextContent(
+          '8 gemeldete Beziehungen · 6 Verbindungen dargestellt',
+        ),
+      )
       expect(screen.queryByTestId('canvas-node-platform.core.shipping')).toBeNull()
 
       // A planned change never enters `components`/`relationships` — the read
@@ -161,6 +179,16 @@ describe('live change overlays — every state appears after its own event', () 
       expect(canvas.getAttribute('data-edge-count')).toBe(edgesBefore)
       // …and the proposal is drawn next to it, marked as a proposal.
       expect(canvas.getAttribute('data-overlay-node-count')).toBe('1')
+      expect(canvas.getAttribute('data-total-element-count')).toBe(
+        String(NESTED_COMPONENTS.length + 1),
+      )
+      expect(screen.getByTestId('architecture-model-count')).toHaveTextContent(
+        `${NESTED_COMPONENTS.length} Modellkomponenten`,
+      )
+      expect(screen.getByTestId('architecture-proposal-count')).toHaveTextContent('+ 1 Vorschlag')
+      expect(screen.getByTestId('canvas-visibility')).toHaveTextContent(
+        `${NESTED_COMPONENTS.length + 1} von ${NESTED_COMPONENTS.length + 1} Elementen sichtbar`,
+      )
       expect(proposal).toHaveAttribute('data-work-state', 'planned')
       expect(proposal).toHaveAttribute('data-work-state-label', 'geplant')
       expect(proposal).toHaveAttribute('data-presence', 'proposal')
@@ -527,6 +555,9 @@ describe('live change overlays — a replacing snapshot', () => {
           'ghost',
         ),
       )
+      expect(screen.getByTestId('architecture-evidence-count')).toHaveTextContent(
+        '+ 1 Komponente nur als Beleg',
+      )
 
       // Then a snapshot that contains the component again. A ghost of it would
       // now contradict the model on screen.
@@ -642,6 +673,56 @@ describe('live change overlays — the camera and the selection stay put', () =>
       expect(screen.getByTestId('canvas-node-platform.db')).toHaveAttribute(
         'data-selected',
         'true',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+})
+
+describe('live change overlays — relationship metrics stay current', () => {
+  it(
+    'updates rendered connections for a relationship-only proposal',
+    async () => {
+      const { queryClient, publish } = renderCanvas()
+      const canvas = await waitForCanvas()
+
+      await waitFor(() =>
+        expect(screen.getByTestId('architecture-relationship-count')).toHaveTextContent(
+          '8 gemeldete Beziehungen · 6 Verbindungen dargestellt',
+        ),
+      )
+
+      publish(
+        architectureWithChanges([
+          activeChange({
+            changeId: 'change-rel-only',
+            targetKind: 'relationship',
+            targetId: RELATIONSHIP_ONLY_PROPOSAL.relationshipId,
+            snapshot: RELATIONSHIP_ONLY_PROPOSAL as unknown as Record<string, unknown>,
+          }),
+        ]),
+      )
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent(
+            'relationship.change_planned',
+            {
+              changeId: 'change-rel-only',
+              operation: 'add',
+              relationship: RELATIONSHIP_ONLY_PROPOSAL,
+            },
+            { position: 59 },
+          ),
+        )
+      })
+
+      await waitForSettledLayout(canvas)
+      expect(canvas.getAttribute('data-overlay-edge-count')).toBe('1')
+      await waitFor(() =>
+        expect(screen.getByTestId('architecture-relationship-count')).toHaveTextContent(
+          '8 gemeldete Beziehungen · 7 Verbindungen dargestellt',
+        ),
       )
     },
     CANVAS_TIMEOUT,

--- a/frontend/src/canvas/canvasAccessibility.test.ts
+++ b/frontend/src/canvas/canvasAccessibility.test.ts
@@ -359,7 +359,7 @@ describe('canvas accessibility — edges are named from what they carry', () => 
     const edge = model.edges[0]
     expect(edge).toBeDefined()
     expect(edgeAccessibleName(edge!, names, voice)).toBe(
-      'Beziehung von Orders zu Orders DB, Datenzugriff SELECT/INSERT, kein Änderungsstatus gemeldet',
+      'Gemeldete Beziehung von Orders zu Orders DB, Datenzugriff SELECT/INSERT, kein Änderungsstatus gemeldet',
     )
   })
 

--- a/frontend/src/canvas/collapse.test.ts
+++ b/frontend/src/canvas/collapse.test.ts
@@ -19,6 +19,7 @@ import {
 import { INITIAL_EXPANDED_DEPTH } from './detailLevel'
 import {
   LEAF_NODE_SIZE,
+  countRelationships,
   projectArchitecture,
   projectionSignature,
   resolveEdgeBundle,
@@ -144,6 +145,11 @@ describe('collapsing the graph', () => {
       'lr-1a1',
       'lr-1b1',
     ])
+    // The pane's rendered-connection count is the number of visible edge
+    // objects after lifting and bundling; the carried relationship count stays
+    // equal to what the applied model reported.
+    expect(visible.edges).toHaveLength(9)
+    expect(countRelationships(visible.edges)).toBe(LARGE_RELATIONSHIPS.length)
   })
 
   it('does not draw a relationship whose two ends collapsed into the same box', () => {

--- a/frontend/src/canvas/graphProjection.test.ts
+++ b/frontend/src/canvas/graphProjection.test.ts
@@ -10,6 +10,7 @@ import {
   appliedRelationship,
   reorder,
 } from '@/test/architectureFixtures'
+import type { ChangeOverlay, ChangeOverlayModel } from './changeOverlays'
 
 import {
   COMPONENT_NODE_TYPE,
@@ -196,6 +197,58 @@ describe('projectArchitecture — bundling and NATS topics', () => {
     const { edges } = projectArchitecture({ components, relationships })
     expect(edges).toHaveLength(2)
     expect(edges.every((edge) => edge.data?.bundled === false)).toBe(true)
+  })
+})
+
+describe('projectArchitecture — model and overlay counts', () => {
+  it('keeps proposed elements out of the applied model count', () => {
+    const proposal = appliedComponent({
+      componentId: 'platform.proposal',
+      name: 'Proposed component',
+      kind: 'module',
+      parentComponentId: null,
+    })
+    const proposalRelationship = appliedRelationship({
+      relationshipId: 'r-proposal',
+      sourceComponentId: 'platform.proposal',
+      targetComponentId: 'platform.db',
+      kind: 'dependency',
+    })
+    const proposalOverlay: ChangeOverlay = {
+      targetKind: 'component',
+      targetId: proposal.componentId,
+      state: 'planned',
+      presence: 'proposal',
+      operation: 'add',
+      contributions: [],
+      agentIds: [],
+      descriptor: proposal,
+    }
+    const relationshipOverlay: ChangeOverlay = {
+      ...proposalOverlay,
+      targetKind: 'relationship',
+      targetId: proposalRelationship.relationshipId,
+      descriptor: proposalRelationship,
+    }
+    const overlay: ChangeOverlayModel = {
+      components: new Map(),
+      relationships: new Map(),
+      extraComponents: [{ component: proposal, overlay: proposalOverlay }],
+      extraRelationships: [{ relationship: proposalRelationship, overlay: relationshipOverlay }],
+      counts: { planned: 2, active: 0, recently_applied: 0, removed: 0 },
+      total: 2,
+    }
+
+    const projection = projectArchitecture({
+      components: NESTED_COMPONENTS,
+      relationships: NESTED_RELATIONSHIPS,
+      overlay,
+    })
+
+    expect(projection.appliedNodeCount).toBe(NESTED_COMPONENTS.length)
+    expect(projection.overlayNodeCount).toBe(1)
+    expect(projection.appliedEdgeCount).toBe(6)
+    expect(projection.overlayEdgeCount).toBe(1)
   })
 })
 

--- a/frontend/src/canvas/useArchitectureGraph.ts
+++ b/frontend/src/canvas/useArchitectureGraph.ts
@@ -48,8 +48,12 @@ export interface ArchitectureGraph {
   initialCollapsedIds: ComponentId[]
   /** Components hidden inside a collapsed container. */
   hiddenComponentIds: Set<ComponentId>
-  /** Components of the model that are drawn right now. */
+  /** Applied-model and overlay elements drawn right now. */
   visibleNodeCount: number
+  /** Rendered connections after collapse and relationship bundling. */
+  visibleEdgeCount: number
+  /** Relationships the applied model reported, before rendering decisions. */
+  reportedRelationshipCount: number
   /** The containers that have to be opened for a component to be on screen. */
   ancestorsOf: (componentId: ComponentId) => ComponentId[]
 }
@@ -91,6 +95,7 @@ export function useArchitectureGraph(
   options: ArchitectureGraphOptions = { collapsedComponentIds: [] },
 ): ArchitectureGraph {
   const { collapsedComponentIds, revealComponentId } = options
+  const reportedRelationshipCount = model?.relationships.length ?? 0
 
   const projection = useMemo(
     () => projectArchitecture(model ?? EMPTY_MODEL),
@@ -189,9 +194,11 @@ export function useArchitectureGraph(
       initialCollapsedIds: initialCollapsedIds(projection.nodes),
       hiddenComponentIds: visible.hiddenComponentIds,
       visibleNodeCount: visible.nodes.length,
+      visibleEdgeCount: visible.edges.length,
+      reportedRelationshipCount,
       ancestorsOf: (componentId) => ancestorIds(projection.nodes, componentId),
     }
-  }, [laidOut, projection, visible, signature, error])
+  }, [laidOut, projection, visible, signature, error, reportedRelationshipCount])
 }
 
 /**

--- a/frontend/src/components/workspace/ArchitecturePane.tsx
+++ b/frontend/src/components/workspace/ArchitecturePane.tsx
@@ -96,10 +96,15 @@ export function ArchitecturePane({
       <PaneHeader
         title={t('pane.title')}
         subtitle={<ReportedText value={projectId} />}
+        // The architecture counters are intentionally allowed to wrap inside
+        // the pane. Keeping them in one unbreakable row makes the title lose
+        // all available width as soon as a locale has longer count labels.
+        className="h-auto min-h-10 items-start py-1 [&>div:first-child]:shrink-0"
+        actionsClassName="min-w-0 flex-1 shrink"
         actions={
           architecture.isSuccess && (
-            <div className="flex items-center gap-2">
-              <ChangeCounter counts={overlay.counts} />
+            <div className="flex w-full min-w-0 flex-wrap items-center justify-end gap-2">
+              <ChangeCounter counts={overlay.counts} className="shrink-0" />
               <span className="bg-border h-4 w-px" aria-hidden="true" />
               {/*
                 The grammatical plural of these two counts is #40's, not this

--- a/frontend/src/components/workspace/ArchitecturePane.tsx
+++ b/frontend/src/components/workspace/ArchitecturePane.tsx
@@ -1,9 +1,12 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useArchitecture } from '@/api/queries'
 import type { ComponentId, ProjectId } from '@/api/types'
-import { ArchitectureCanvas } from '@/canvas/ArchitectureCanvas'
+import {
+  ArchitectureCanvas,
+  type ArchitectureCanvasMetrics,
+} from '@/canvas/ArchitectureCanvas'
 import { useChangeOverlays } from '@/canvas/useChangeOverlays'
 import { AsyncState } from '@/components/AsyncState'
 import { StatusLegend } from '@/components/StatusLegend'
@@ -41,6 +44,27 @@ export function ArchitecturePane({
 
   const componentCount = architecture.data?.components.length ?? 0
   const relationshipCount = architecture.data?.relationships.length ?? 0
+  const proposalComponentCount = overlay.extraComponents.filter(
+    (entry) => entry.overlay.presence === 'proposal',
+  ).length
+  const evidenceComponentCount = overlay.extraComponents.filter(
+    (entry) => entry.overlay.presence === 'ghost',
+  ).length
+  const [canvasMetrics, setCanvasMetrics] = useState<ArchitectureCanvasMetrics | null>(null)
+  const onCanvasMetricsChange = useCallback(
+    (metrics: ArchitectureCanvasMetrics) => setCanvasMetrics(metrics),
+    [],
+  )
+
+  // Ignore a metric from the previous snapshot for the one render between a
+  // refetch and the next canvas effect. A count is only meaningful when it
+  // describes the same reported model and the same element inventory.
+  const currentMetrics =
+    canvasMetrics !== null &&
+    canvasMetrics.reportedRelationshipCount === relationshipCount &&
+    canvasMetrics.totalElementCount === componentCount + overlay.extraComponents.length
+      ? canvasMetrics
+      : null
 
   // The legend is a key to what is drawn, so it lists only the kinds actually
   // reported. Deriving it here keeps the legend and the canvas reading from the
@@ -82,11 +106,46 @@ export function ArchitecturePane({
                 issue's: the words moved into the catalogue, the `_one`/`_other`
                 forms follow with the locale-aware formatting service.
               */}
-              <Badge variant="outline" className="text-2xs font-normal">
-                {t('pane.components', { count: componentCount })}
+              <Badge
+                variant="outline"
+                className="text-2xs font-normal"
+                data-testid="architecture-model-count"
+              >
+                {t('pane.modelComponents', { count: componentCount })}
               </Badge>
-              <Badge variant="outline" className="text-2xs font-normal">
-                {t('pane.relationships', { count: relationshipCount })}
+              {proposalComponentCount > 0 && (
+                <Badge
+                  variant="outline"
+                  className="text-2xs font-normal"
+                  data-testid="architecture-proposal-count"
+                >
+                  {t('pane.proposedComponents', { count: proposalComponentCount })}
+                </Badge>
+              )}
+              {evidenceComponentCount > 0 && (
+                <Badge
+                  variant="outline"
+                  className="text-2xs font-normal"
+                  data-testid="architecture-evidence-count"
+                >
+                  {t('pane.evidenceComponents', { count: evidenceComponentCount })}
+                </Badge>
+              )}
+              <Badge
+                variant="outline"
+                className="text-2xs font-normal"
+                title={t('pane.relationshipSummaryHint')}
+                data-testid="architecture-relationship-count"
+              >
+                {t('pane.reportedRelationships', { count: relationshipCount })}
+                {currentMetrics !== null && (
+                  <>
+                    {' · '}
+                    {t('pane.renderedConnections', {
+                      count: currentMetrics.visibleConnectionCount,
+                    })}
+                  </>
+                )}
               </Badge>
             </div>
           )
@@ -118,6 +177,7 @@ export function ArchitecturePane({
             model={model}
             selectedComponentId={selectedComponentId}
             onSelectComponent={onSelectComponent}
+            onMetricsChange={onCanvasMetricsChange}
           />
         )}
       </div>

--- a/frontend/src/components/workspace/PaneHeader.tsx
+++ b/frontend/src/components/workspace/PaneHeader.tsx
@@ -7,11 +7,18 @@ export interface PaneHeaderProps {
   /** Short, neutral subtitle — usually the id the pane is bound to. */
   subtitle?: ReactNode
   actions?: ReactNode
+  actionsClassName?: string
   className?: string
 }
 
 /** Shared header row of the three panes. Keeps the panes visually identical. */
-export function PaneHeader({ title, subtitle, actions, className }: PaneHeaderProps) {
+export function PaneHeader({
+  title,
+  subtitle,
+  actions,
+  actionsClassName,
+  className,
+}: PaneHeaderProps) {
   return (
     <div
       className={cn(
@@ -25,7 +32,11 @@ export function PaneHeader({ title, subtitle, actions, className }: PaneHeaderPr
           <span className="text-muted-foreground truncate text-xs">{subtitle}</span>
         )}
       </div>
-      {actions && <div className="ml-auto flex shrink-0 items-center gap-1">{actions}</div>}
+      {actions && (
+        <div className={cn('ml-auto flex shrink-0 items-center gap-1', actionsClassName)}>
+          {actions}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/i18n/architectureCounts.test.ts
+++ b/frontend/src/i18n/architectureCounts.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { createI18n } from './createI18n'
+
+describe('architecture count terminology', () => {
+  it.each([
+    ['de', 'Beziehungen innerhalb desselben eingeklappten Containers werden absichtlich nicht gezeichnet.'],
+    ['en', 'Relationships whose two ends are inside the same collapsed container are intentionally not drawn.'],
+  ] as const)('explains intentionally hidden internal relationships in %s', (language, sentence) => {
+    const t = createI18n({ language }).getFixedT(language, 'canvas')
+
+    expect(t('visibility.hint')).toContain(sentence)
+  })
+
+  it.each([
+    ['de', '1 Modellkomponente', '2 Modellkomponenten', '1 Vorschlag', '2 Vorschläge'],
+    ['en', '1 model component', '2 model components', '1 proposal', '2 proposals'],
+  ] as const)('keeps model and proposal counts distinct in %s', (
+    language,
+    modelOne,
+    modelMany,
+    proposalOne,
+    proposalMany,
+  ) => {
+    const t = createI18n({ language }).getFixedT(language, 'canvas')
+
+    expect(t('pane.modelComponents', { count: 1 })).toBe(modelOne)
+    expect(t('pane.modelComponents', { count: 2 })).toBe(modelMany)
+    expect(t('pane.proposedComponents', { count: 1 })).toBe(`+ ${proposalOne}`)
+    expect(t('pane.proposedComponents', { count: 2 })).toBe(`+ ${proposalMany}`)
+  })
+
+  it.each([
+    [
+      'de',
+      '1 von 1 Element sichtbar',
+      '10 von 29 Elementen sichtbar',
+      '1 gemeldete Beziehung',
+      '2 gemeldete Beziehungen',
+      '1 Verbindung dargestellt',
+      '2 Verbindungen dargestellt',
+    ],
+    [
+      'en',
+      '1 of 1 element visible',
+      '10 of 29 elements visible',
+      '1 reported relationship',
+      '2 reported relationships',
+      '1 connection rendered',
+      '2 connections rendered',
+    ],
+  ] as const)('formats visible and rendered counts in %s', (
+    language,
+    one,
+    many,
+    relationshipOne,
+    relationshipMany,
+    connectionOne,
+    connectionMany,
+  ) => {
+    const t = createI18n({ language }).getFixedT(language, 'canvas')
+
+    expect(t('visibility.summary', { count: 1, visible: 1, total: 1 })).toBe(one)
+    expect(t('visibility.summary', { count: 29, visible: 10, total: 29 })).toBe(many)
+    expect(t('pane.reportedRelationships', { count: 1 })).toBe(relationshipOne)
+    expect(t('pane.reportedRelationships', { count: 2 })).toBe(relationshipMany)
+    expect(t('pane.renderedConnections', { count: 1 })).toBe(connectionOne)
+    expect(t('pane.renderedConnections', { count: 2 })).toBe(connectionMany)
+  })
+})

--- a/frontend/src/i18n/locales/de/canvas.json
+++ b/frontend/src/i18n/locales/de/canvas.json
@@ -1,21 +1,21 @@
 {
   "a11y": {
     "agentsReporting": "{{agents}} melden dazu",
-    "bundleOf": "Sammelkante mit {{relationships}}",
+    "bundleOf": "Sammelkante mit {{relationships}}, dargestellte Verbindung",
     "collapsedNote": "eingeklappt, {{components}} verborgen",
     "componentRole": "Architekturkomponente",
     "containerRole": "Architekturcontainer",
     "contains": "Container mit {{components}}",
     "fitView": "Ansicht einpassen",
-    "fromTo": "Beziehung von {{source}} zu {{target}}",
+    "fromTo": "Gemeldete Beziehung von {{source}} zu {{target}}",
     "furtherRelationships": "und {{relationships}} weitere",
-    "ghostNote": "nicht mehr Teil des angewandten Architekturmodells",
+    "ghostNote": "nicht mehr Teil des angewandten Architekturmodells, nur noch als Beleg dargestellt",
     "handle": "Verbindungspunkt",
     "identifiedBy": "Komponenten-ID {{componentId}}",
     "inContainer": "in {{container}}",
     "noWorkState": "kein Änderungsstatus gemeldet",
     "proposalNote": "angekündigt, noch nicht Teil des angewandten Architekturmodells",
-    "relationshipRole": "Architekturbeziehung",
+    "relationshipRole": "Architekturbeziehung, dargestellte Verbindung",
     "rolledUpNote": "gemeldet für eine eingeklappte Komponente darin",
     "toggleInteractive": "Interaktivität umschalten",
     "zoomControls": "Zoomsteuerung des Architekturgraphen",
@@ -61,8 +61,8 @@
     "protocol": "Protokoll: {{value}}"
   },
   "graph": {
-    "edgeInstructions": "Enter oder Leertaste wählt diese Beziehung aus; bei einer Sammelkante klappt sie die enthaltenen Beziehungen auf und wieder zu. Escape hebt die Auswahl auf.",
-    "instructions": "Architekturgraph des Projekts. Mit der Tabulatortaste zwischen den Komponenten und Beziehungen wechseln. Enter oder Leertaste wählt die fokussierte Komponente aus und zeigt sie im Inspector; eine erneute Aktivierung hebt die Auswahl auf, Escape ebenfalls. Jede Komponente nennt ihren gemeldeten Namen, ihre Art, ob sie weitere Komponenten enthält, in welchem Container sie liegt und welchen Änderungsstatus ein Agent für sie gemeldet hat. Der Graph ist eine Beobachtung: das gemeldete Architekturmodell lässt sich hier nicht bearbeiten.",
+    "edgeInstructions": "Enter oder Leertaste wählt diese dargestellte Verbindung aus; bei einer Sammelkante klappt sie die enthaltenen gemeldeten Beziehungen auf und wieder zu. Escape hebt die Auswahl auf.",
+    "instructions": "Architekturgraph des Projekts. Mit der Tabulatortaste zwischen den Komponenten und den dargestellten Verbindungen wechseln. Enter oder Leertaste wählt die fokussierte Komponente aus und zeigt sie im Inspector; eine erneute Aktivierung hebt die Auswahl auf, Escape ebenfalls. Jede Komponente nennt ihren gemeldeten Namen, ihre Art, ob sie weitere Komponenten enthält, in welchem Container sie liegt und welchen Änderungsstatus ein Agent für sie gemeldet hat. Gemeldete Beziehungen können als eine gebündelte Verbindung dargestellt werden. Der Graph ist eine Beobachtung: das angewandte Architekturmodell lässt sich hier nicht bearbeiten.",
     "label": "Interaktiver Architekturgraph",
     "layouting": "Layout wird berechnet…",
     "minimapLabel": "Übersichtskarte der Architektur",
@@ -98,11 +98,20 @@
     "workStepRunning": "Arbeitsschritt läuft: {{title}}"
   },
   "pane": {
-    "components": "{{count}} Komponenten",
     "emptyDescription": "Das Modell erscheint, sobald ein Agent architecture.snapshot_published sendet.",
     "emptyTitle": "Noch kein Architekturmodell gemeldet",
+    "evidenceComponents_one": "+ {{count, number}} Komponente nur als Beleg",
+    "evidenceComponents_other": "+ {{count, number}} Komponenten nur als Beleg",
     "label": "Architekturfläche",
-    "relationships": "{{count}} Beziehungen",
+    "modelComponents_one": "{{count, number}} Modellkomponente",
+    "modelComponents_other": "{{count, number}} Modellkomponenten",
+    "proposedComponents_one": "+ {{count, number}} Vorschlag",
+    "proposedComponents_other": "+ {{count, number}} Vorschläge",
+    "relationshipSummaryHint": "Beziehungen sind die gemeldeten Aussagen des angewandten Modells. Verbindungen sind die aktuell dargestellten Linien; Einklappen, Anheben und Bündeln können mehrere Beziehungen als eine Verbindung zeigen.",
+    "reportedRelationships_one": "{{count, number}} gemeldete Beziehung",
+    "reportedRelationships_other": "{{count, number}} gemeldete Beziehungen",
+    "renderedConnections_one": "{{count, number}} Verbindung dargestellt",
+    "renderedConnections_other": "{{count, number}} Verbindungen dargestellt",
     "title": "Architektur"
   },
   "relationshipKind": {
@@ -145,8 +154,9 @@
     "showMinimap": "Übersichtskarte einblenden"
   },
   "visibility": {
-    "hint": "Tiefere Komponenten sind hinter ihrem Container eingeklappt, damit die oberen Ebenen lesbar bleiben. Aufklappen über das Dreieck am Container, über einen Deep Link oder über „Gesamtes Modell einpassen\".",
-    "summary": "{{visible}} von {{total}} Komponenten sichtbar"
+    "hint": "Tiefere Komponenten werden hinter ihrem Container eingeklappt, damit die oberen Ebenen lesbar bleiben. Verbindungen zu eingeklappten Komponenten werden auf den sichtbaren Container angehoben. Beziehungen innerhalb desselben eingeklappten Containers werden absichtlich nicht gezeichnet. Parallele gemeldete Beziehungen können als eine Sammelverbindung gebündelt werden. Aufklappen über das Dreieck am Container, über einen Deep Link oder über „Gesamtes Modell einpassen\".",
+    "summary_one": "{{visible, number}} von {{total, number}} Element sichtbar",
+    "summary_other": "{{visible, number}} von {{total, number}} Elementen sichtbar"
   },
   "workState": {
     "active": {

--- a/frontend/src/i18n/locales/en/canvas.json
+++ b/frontend/src/i18n/locales/en/canvas.json
@@ -1,21 +1,21 @@
 {
   "a11y": {
     "agentsReporting": "{{agents}} are reporting on it",
-    "bundleOf": "bundled edge with {{relationships}}",
+    "bundleOf": "bundled edge with {{relationships}}, rendered connection",
     "collapsedNote": "collapsed, {{components}} hidden",
     "componentRole": "architecture component",
     "containerRole": "architecture container",
     "contains": "container holding {{components}}",
     "fitView": "Fit the view",
-    "fromTo": "Relationship from {{source}} to {{target}}",
+    "fromTo": "Reported relationship from {{source}} to {{target}}",
     "furtherRelationships": "and {{relationships}} more",
-    "ghostNote": "no longer part of the applied architecture model",
+    "ghostNote": "no longer part of the applied architecture model, shown as evidence only",
     "handle": "Connection point",
     "identifiedBy": "component id {{componentId}}",
     "inContainer": "in {{container}}",
     "noWorkState": "no change status reported",
     "proposalNote": "announced, not part of the applied architecture model yet",
-    "relationshipRole": "architecture relationship",
+    "relationshipRole": "architecture relationship, rendered connection",
     "rolledUpNote": "reported for a collapsed component inside it",
     "toggleInteractive": "Toggle interactivity",
     "zoomControls": "Zoom controls of the architecture graph",
@@ -61,8 +61,8 @@
     "protocol": "Protocol: {{value}}"
   },
   "graph": {
-    "edgeInstructions": "Enter or Space selects this relationship; on a bundled edge it unfolds and folds the relationships it contains. Escape clears the selection.",
-    "instructions": "Architecture graph of the project. Use Tab to move between the components and the relationships. Enter or Space selects the focused component and shows it in the inspector; activating it again clears the selection, as does Escape. Every component names its reported name, its kind, whether it contains further components, which container it sits in, and what change status an agent reported for it. The graph is an observation: the reported architecture model cannot be edited here.",
+    "edgeInstructions": "Enter or Space selects this rendered connection; on a bundled edge it unfolds and folds the reported relationships it contains. Escape clears the selection.",
+    "instructions": "Architecture graph of the project. Use Tab to move between the components and the rendered connections. Enter or Space selects the focused component and shows it in the inspector; activating it again clears the selection, as does Escape. Every component names its reported name, its kind, whether it contains further components, which container it sits in, and what change status an agent reported for it. Reported relationships may be rendered as one bundled connection. The graph is an observation: the applied architecture model cannot be edited here.",
     "label": "Interactive architecture graph",
     "layouting": "Computing the layout…",
     "minimapLabel": "Overview map of the architecture",
@@ -98,11 +98,20 @@
     "workStepRunning": "Work step running: {{title}}"
   },
   "pane": {
-    "components": "{{count}} components",
     "emptyDescription": "The model appears as soon as an agent sends architecture.snapshot_published.",
     "emptyTitle": "No architecture model reported yet",
+    "evidenceComponents_one": "+ {{count, number}} component shown as evidence only",
+    "evidenceComponents_other": "+ {{count, number}} components shown as evidence only",
     "label": "Architecture surface",
-    "relationships": "{{count}} relationships",
+    "modelComponents_one": "{{count, number}} model component",
+    "modelComponents_other": "{{count, number}} model components",
+    "proposedComponents_one": "+ {{count, number}} proposal",
+    "proposedComponents_other": "+ {{count, number}} proposals",
+    "relationshipSummaryHint": "Relationships are reported statements of the applied model. Connections are the lines currently rendered; collapse, lifting and bundling can show several relationships as one connection.",
+    "reportedRelationships_one": "{{count, number}} reported relationship",
+    "reportedRelationships_other": "{{count, number}} reported relationships",
+    "renderedConnections_one": "{{count, number}} connection rendered",
+    "renderedConnections_other": "{{count, number}} connections rendered",
     "title": "Architecture"
   },
   "relationshipKind": {
@@ -145,8 +154,9 @@
     "showMinimap": "Show the overview map"
   },
   "visibility": {
-    "hint": "Deeper components are collapsed behind their container so the upper levels stay readable. Expand them through the triangle on the container, through a deep link or through “Fit the whole model”.",
-    "summary": "{{visible}} of {{total}} components visible"
+    "hint": "Deeper components are collapsed behind their container so the upper levels stay readable. Connections to collapsed components are lifted to the visible container. Relationships whose two ends are inside the same collapsed container are intentionally not drawn. Parallel reported relationships may be bundled into one connection. Expand them through the triangle on the container, through a deep link or through “Fit the whole model”.",
+    "summary_one": "{{visible, number}} of {{total, number}} element visible",
+    "summary_other": "{{visible, number}} of {{total, number}} elements visible"
   },
   "workState": {
     "active": {


### PR DESCRIPTION
Closes #61

## Umgesetzt
- Modell-, Proposal-/Beleg- und sichtbare Elemente terminologisch getrennt.
- Gemeldete Beziehungen und dargestellte Verbindungen getrennt ausgewiesen, inklusive Erklärung für Collapse, Lifting und Bundling.
- Deutsche und englische Singular-/Plural-, Zahlen- und Screenreader-Texte ergänzt.
- Unit-, Accessibility- und self-E2E-Abdeckung ergänzt.

## Entscheidung
Der self-E2E-Test prüft den tatsächlichen Fixture-Initialzustand (28 Modellkomponenten, 1 Vorschlag, 10 von 29 sichtbare Elemente). Die in der Issue-Beschreibung genannten 37/10 widersprechen der aktuellen Fixture (35/9) und wurden ohne Datenmodelländerung nicht künstlich erzwungen.

## Tests
- check:contract, check:locales, check:ui-strings, lint, typecheck, build
- Vitest: 47 Suites, 460 Tests
- Simulator self tests und E2E typecheck
- git diff --check

## Einschränkung
Der vollständige Playwright-Lauf wurde nicht ausgeführt, weil sein Global Setup docker compose down -v ausführt und damit Docker-Volumes destruktiv zurücksetzt.