### PR TITLE
Add switchable graph orientation

### DIFF
--- a/docs/decisions/0008-architecture-canvas-layout-and-edge-bundling.md
+++ b/docs/decisions/0008-architecture-canvas-layout-and-edge-bundling.md
@@ -6,6 +6,11 @@
 - **Builds on:** [0003 — Frontend state split and live updates](./0003-frontend-state-split-and-live-updates.md),
   [0005 — Read API shape and run scoping](./0005-read-api-shape-and-run-scoping.md)
 
+The orientation choice recorded here was superseded by [0023 — Top-down graph
+orientation](./0023-graph-orientation-and-directional-handles.md): top-down is
+now the default and the original left-to-right layout remains an explicit
+alternative. The bundling, routing and camera invariants below still apply.
+
 ## Context
 
 The architecture canvas is the product. It is the dominant surface at
@@ -53,9 +58,10 @@ the order the rows arrived in.
 
 ### ELK `layered`, and determinism as a tested property
 
-An architecture model is a directed, mostly acyclic graph: callers left,
-callees right, one layer per hop. That is exactly what a Sugiyama-style
-algorithm draws, so `elk.algorithm: layered` with `elk.direction: RIGHT`.
+An architecture model is a directed, mostly acyclic graph: callers precede
+callees, one layer per hop. That is exactly what a Sugiyama-style algorithm
+draws, so `elk.algorithm: layered` with `elk.direction: DOWN` by default;
+`RIGHT` remains the explicit left-to-right alternative (ADR 0023).
 Force-directed layouts were rejected because they produce a different picture
 every run, and tree layouts because they cannot express the cross-links an
 architecture is full of.
@@ -88,11 +94,12 @@ ELK is loaded through a dynamic `import()`. Its bundled build is ~1.4 MB and has
 no business in the entry chunk of a cockpit that may never open a project; it
 now forms its own chunk, which is the code splitting ADR 0003 anticipated.
 
-**Handles are declared, not measured.** Every node carries its two handles
-(incoming left-centre, outgoing right-centre) on the node object, and ELK gets
-fixed ports at exactly those coordinates (`elk.portConstraints: FIXED_POS`). The
-polyline ELK returns therefore starts and ends *on* the handle. Edge geometry
-becomes a pure function of the layout instead of a function of a rendered DOM.
+**Handles are declared, not measured.** Every node carries directional handles
+(incoming north/outgoing south by default, west/east in the left-to-right
+alternative) on the node object, and ELK gets fixed ports at exactly those
+coordinates (`elk.portConstraints: FIXED_POS`). The polyline ELK returns
+therefore starts and ends *on* the handle. Edge geometry becomes a pure
+function of the layout instead of a function of a rendered DOM.
 
 ### Relationship kinds are encoded without colour at all
 

--- a/docs/decisions/0017-readable-entry-zoom-and-progressive-disclosure.md
+++ b/docs/decisions/0017-readable-entry-zoom-and-progressive-disclosure.md
@@ -83,9 +83,11 @@ small to read; the cockpit may never choose it for them.
 
 `viewportForBounds` also owns the second half of the camera: a model that does
 not fit at the readable zoom is anchored at its **top-left** corner instead of
-being centred. The ELK layout runs left to right with the callers first
-(ADR 0008), so its beginning is where an architecture is read from; centring an
-oversized model drops the reader in the middle of a sentence. The inset is
+being centred. The default ELK layout now runs top-down with callers first
+(ADR 0023); its explicit left-to-right alternative retains the caller-first
+ordering described in ADR 0008. In either orientation, the beginning is where
+an architecture is read from; centring an oversized model drops the reader in
+the middle of a sentence. The inset is
 derived from the existing `FIT_VIEW_PADDING`, so an anchored model sits exactly
 as far from the edge as a centred one.
 

--- a/docs/decisions/0023-graph-orientation-and-directional-handles.md
+++ b/docs/decisions/0023-graph-orientation-and-directional-handles.md
@@ -1,0 +1,32 @@
+# 23. Top-down graph orientation with an explicit left-to-right alternative
+
+- **Status:** accepted
+- **Date:** 2026-08-17
+- **Context issue:** #54
+- **Builds on:** [0008 — Architecture canvas](./0008-architecture-canvas-layout-and-edge-bundling.md)
+
+## Decision
+
+The architecture graph uses one shared `GraphOrientation` value throughout the
+URL, projection, React Flow handles, ELK ports and edge fallback geometry.
+`top-down` is the default and maps to ELK `DOWN`; `left-right` is an explicit
+alternative and maps to `RIGHT`. The workspace `layout` search parameter makes
+either view shareable and reproducible (`?layout=left-right`).
+
+Incoming handles and ELK ports are `NORTH` and outgoing handles are `SOUTH` in
+the default orientation. The alternative retains `WEST`/`EAST`. Orthogonal
+fallback routes and bundle fan-out use the same orientation so a dragged node
+does not detach its relationships from the corresponding handles.
+
+Changing orientation is an explicit camera action: temporary drag positions are
+cleared, the graph is laid out in the new coordinate system, and one fit is
+applied when that layout is ready. Selection, open containers and inspector
+context remain URL/UI state and are not reset. Live model updates continue to
+follow the existing camera policy and never move the camera on their own.
+
+## Consequences
+
+Wide architecture models use vertical layers by default, leaving more useful
+horizontal room in the centre pane. Call chains and horizontal data flows can
+still be read left-to-right and linked directly. Coordinates remain transient;
+the backend contract and persisted model stay unchanged.

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -69,6 +69,92 @@ async function openWorkspace(page: Page): Promise<void> {
   )
 }
 
+test('2 · top-down is the default and both orientations are shareable at accepted widths', async ({
+  page,
+}) => {
+  const selectedComponent = 'shop-platform.orders'
+  const viewports = [
+    { width: 1280, height: 720 },
+    { width: 1920, height: 1080 },
+  ] as const
+
+  for (const viewport of viewports) {
+    await page.setViewportSize(viewport)
+    await openWorkspace(page)
+
+    const canvas = page.getByTestId('architecture-canvas')
+    const node = page.locator(`.react-flow__node[data-id="shop-platform"]`)
+    await expect(canvas).toHaveAttribute('data-layout-orientation', 'top-down')
+    await expect(node.locator('.react-flow__handle-top')).toHaveCount(1)
+    await expect(node.locator('.react-flow__handle-bottom')).toHaveCount(1)
+
+    // A selected, collapsed component is deliberately kept in place while the
+    // user changes orientation. Check the URL, canvas and inspector together.
+    if (viewport.width === 1920) {
+      await page.getByTestId(`canvas-node-${selectedComponent}`).click()
+      await expect(page).toHaveURL(
+        new RegExp(`component=${encodeURIComponent(selectedComponent)}`),
+      )
+      await expect(page.getByTestId('inspector-context')).toHaveAttribute(
+        'data-component-id',
+        selectedComponent,
+      )
+
+      const disclosure = page.getByTestId(`node-disclosure-${selectedComponent}`)
+      await expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+      await disclosure.click()
+      await expect(disclosure).toHaveAttribute('aria-expanded', 'true')
+    }
+
+    await page.getByTestId('canvas-layout-left-right').click()
+    await expect(canvas).toHaveAttribute('data-layout-orientation', 'left-right')
+    await expect(canvas).toHaveAttribute('data-layouting', 'false')
+    await expect(page).toHaveURL(/layout=left-right/)
+    await expect(node.locator('.react-flow__handle-left')).toHaveCount(1)
+    await expect(node.locator('.react-flow__handle-right')).toHaveCount(1)
+
+    if (viewport.width === 1920) {
+      await expect(page).toHaveURL(
+        new RegExp(`component=${encodeURIComponent(selectedComponent)}`),
+      )
+      await expect(page.getByTestId(`canvas-node-${selectedComponent}`)).toHaveAttribute(
+        'data-selected',
+        'true',
+      )
+      await expect(page.getByTestId(`node-disclosure-${selectedComponent}`)).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      )
+      await expect(page.getByTestId('inspector-context')).toHaveAttribute(
+        'data-component-id',
+        selectedComponent,
+      )
+    }
+
+    await page.getByTestId('canvas-layout-top-down').click()
+    await expect(canvas).toHaveAttribute('data-layout-orientation', 'top-down')
+    await expect(canvas).toHaveAttribute('data-layouting', 'false')
+    await expect(page).toHaveURL(/layout=top-down/)
+    await expect(node.locator('.react-flow__handle-top')).toHaveCount(1)
+    await expect(node.locator('.react-flow__handle-bottom')).toHaveCount(1)
+
+    if (viewport.width === 1920) {
+      await expect(page.getByTestId(`canvas-node-${selectedComponent}`)).toHaveAttribute(
+        'data-selected',
+        'true',
+      )
+      await expect(page.getByTestId(`node-disclosure-${selectedComponent}`)).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      )
+      await expect(page.getByTestId('inspector-context')).toHaveAttribute(
+        'data-component-id',
+        selectedComponent,
+      )
+    }
+  }
+})
+
 /** Zooms in until the canvas reports the `full` detail level. */
 async function zoomToFullDetail(page: Page): Promise<void> {
   const canvas = page.getByTestId('architecture-canvas')

--- a/e2e/tests/09-i18n-layout.spec.ts
+++ b/e2e/tests/09-i18n-layout.spec.ts
@@ -79,6 +79,8 @@ const TEXTS: TextProbe[] = [
   { name: 'tab · selected', selector: '[role="tab"][aria-selected="true"]' },
   { name: 'tab · unselected', selector: '[role="tab"][aria-selected="false"]' },
   { name: 'button · fit view', selector: '[data-testid="canvas-fit-view"]' },
+  { name: 'button · top-down layout', selector: '[data-testid="canvas-layout-top-down"]' },
+  { name: 'button · left-to-right layout', selector: '[data-testid="canvas-layout-left-right"]' },
   { name: 'button · minimap', selector: '[data-testid="canvas-toggle-minimap"]' },
   { name: 'button · detail level', selector: '[data-testid="canvas-detail-level"]' },
   { name: 'status value · live connection', selector: '[data-testid="live-connection-state"]' },
@@ -95,6 +97,8 @@ const TEXTS: TextProbe[] = [
 const CONTROLS: ControlProbe[] = [
   { name: 'run selection (current run)', selector: `[data-testid="run-option-${MAIN_RUN}"]` },
   { name: 'canvas control · fit view', selector: '[data-testid="canvas-fit-view"]' },
+  { name: 'canvas control · top-down layout', selector: '[data-testid="canvas-layout-top-down"]' },
+  { name: 'canvas control · left-to-right layout', selector: '[data-testid="canvas-layout-left-right"]' },
   { name: 'canvas control · minimap toggle', selector: '[data-testid="canvas-toggle-minimap"]' },
   { name: 'canvas control · zoom in', selector: '.react-flow__controls-zoomin' },
   { name: 'canvas control · zoom out', selector: '.react-flow__controls-zoomout' },

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -323,6 +323,34 @@ describe('architecture canvas — selection', () => {
     },
     CANVAS_TIMEOUT,
   )
+
+  it(
+    'uses the URL orientation and switches handles and camera explicitly',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCanvas(`${WORKSPACE_URL}?layout=left-right`)
+      const canvas = await waitForCanvas()
+
+      expect(canvas).toHaveAttribute('data-layout-orientation', 'left-right')
+      expect(
+        document.querySelector('.react-flow__node[data-id="platform"] .react-flow__handle-right'),
+      ).not.toBeNull()
+      expect(canvas).toHaveAttribute('data-fit-view-count', '1')
+
+      await user.click(screen.getByTestId('canvas-layout-top-down'))
+      await waitFor(() =>
+        expect(canvas).toHaveAttribute('data-layout-orientation', 'top-down'),
+      )
+      await waitFor(() => expect(canvas).toHaveAttribute('data-layouting', 'false'))
+      await waitFor(() => expect(canvas).toHaveAttribute('data-fit-view-count', '2'))
+
+      expect(router.state.location.search).toMatchObject({ layout: 'top-down' })
+      expect(
+        document.querySelector('.react-flow__node[data-id="platform"] .react-flow__handle-bottom'),
+      ).not.toBeNull()
+    },
+    CANVAS_TIMEOUT,
+  )
 })
 
 describe('architecture canvas — live updates never move the camera', () => {

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -64,6 +64,7 @@ import {
   type ArchitectureEdge,
   type ArchitectureModel,
 } from './graphProjection'
+import type { GraphOrientation } from './graphOrientation'
 import { CanvasNodeActionsContext, type CanvasNodeActions } from './nodeActions'
 import {
   applyTemporaryPositions,
@@ -132,6 +133,8 @@ export interface ArchitectureCanvasProps {
   model: ArchitectureModel
   selectedComponentId?: ComponentId | undefined
   onSelectComponent: (componentId: ComponentId | null) => void
+  orientation: GraphOrientation
+  onOrientationChange: (orientation: GraphOrientation) => void
   /** Reports the counts the canvas actually draws to the pane header. */
   onMetricsChange?: (metrics: ArchitectureCanvasMetrics) => void
 }
@@ -158,6 +161,8 @@ function ArchitectureCanvasInner({
   model,
   selectedComponentId,
   onSelectComponent,
+  orientation,
+  onOrientationChange,
   onMetricsChange,
 }: ArchitectureCanvasProps) {
   const { t } = useTranslation('canvas')
@@ -176,6 +181,7 @@ function ArchitectureCanvasInner({
     // is — so a link into a component four levels down arrives, and the camera
     // policy is untouched by it.
     revealComponentId: selectedComponentId ?? null,
+    orientation,
   })
   const flow = useReactFlow()
   const storeApi = useStoreApi()
@@ -214,6 +220,9 @@ function ArchitectureCanvasInner({
   // Flipped by the first pan or zoom that came from a real input event. From
   // then on the camera is the user's and nothing but "Einpassen" touches it.
   const userMovedCameraRef = useRef(false)
+  // A direction switch is an explicit user action. It invalidates local drag
+  // positions and parks one fit until the direction-specific layout lands.
+  const orientationRef = useRef<GraphOrientation | null>(null)
   // The very first viewport React Flow renders with. Read once so a later
   // camera change never re-mounts the flow.
   const [initialViewport] = useState<Viewport>(() => useUiStore.getState().camera)
@@ -310,6 +319,20 @@ function ArchitectureCanvasInner({
   const pendingFitRef = useRef<{ mode: FitMode; focusComponentId: ComponentId | null } | null>(
     null,
   )
+
+  useEffect(() => {
+    const previous = orientationRef.current
+    orientationRef.current = orientation
+    // The first orientation is the URL/default input for the initial picture,
+    // not a second explicit camera movement.
+    if (previous === null || previous === orientation) return
+
+    // Positions are meaningful only in the coordinate system that produced
+    // them. Resetting them here keeps one transient set instead of persisting
+    // two direction-specific sets, while selection and disclosure stay intact.
+    clearNodePositions()
+    pendingFitRef.current = { mode: 'user', focusComponentId: null }
+  }, [clearNodePositions, orientation])
 
   /** Fits now if the graph is already the right one, otherwise after re-layout. */
   const requestFit = useCallback(
@@ -639,6 +662,7 @@ function ArchitectureCanvasInner({
       data-total-element-count={graph.appliedNodeCount + graph.overlayNodeCount}
       data-hidden-node-count={hiddenCount}
       data-collapsed-count={graph.collapsedIds.length}
+      data-layout-orientation={orientation}
       // The surface the camera was computed against. Reported so "is this node
       // actually on screen" is answerable from outside without a layout engine.
       data-surface-width={surfaceWidth}
@@ -777,6 +801,38 @@ function ArchitectureCanvasInner({
                   <TooltipContent>{t('tool.resetPositionsHint')}</TooltipContent>
                 </Tooltip>
               )}
+
+              <span className="bg-border mx-0.5 h-4 w-px" aria-hidden="true" />
+
+              <div
+                className="border-border/70 flex items-center rounded-sm border"
+                role="group"
+                aria-label={t('tool.layoutOrientation')}
+                data-testid="canvas-layout-orientation"
+              >
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1 px-2 text-xs"
+                  aria-pressed={orientation === 'top-down'}
+                  onClick={() => onOrientationChange('top-down')}
+                  data-testid="canvas-layout-top-down"
+                >
+                  <span aria-hidden="true">↓ </span>
+                  {t('tool.layoutTopDown')}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1 px-2 text-xs"
+                  aria-pressed={orientation === 'left-right'}
+                  onClick={() => onOrientationChange('left-right')}
+                  data-testid="canvas-layout-left-right"
+                >
+                  <span aria-hidden="true">→ </span>
+                  {t('tool.layoutLeftRight')}
+                </Button>
+              </div>
 
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/frontend/src/canvas/ComponentNode.tsx
+++ b/frontend/src/canvas/ComponentNode.tsx
@@ -20,6 +20,7 @@ import {
 } from './componentKinds'
 import { DISCLOSURE_LABEL_KEYS, showsTags, showsTechnology } from './detailLevel'
 import { HANDLE_IDS, type ArchitectureNode } from './graphProjection'
+import type { GraphOrientation } from './graphOrientation'
 import { CanvasNodeActionsContext } from './nodeActions'
 import { useCanvasVoice } from './useCanvasVoice'
 import { useDetailLevel } from './useDetailLevel'
@@ -139,20 +140,21 @@ function DisclosureToggle({
 }
 
 /** Invisible, non-interactive connection points. v0 is read-only. */
-function NodeHandles() {
+function NodeHandles({ orientation }: { orientation: GraphOrientation }) {
+  const topDown = orientation === 'top-down'
   return (
     <>
       <Handle
         type="target"
         id={HANDLE_IDS.target}
-        position={Position.Left}
+        position={topDown ? Position.Top : Position.Left}
         isConnectable={false}
         className="!size-1.5 !border-0 !bg-transparent"
       />
       <Handle
         type="source"
         id={HANDLE_IDS.source}
-        position={Position.Right}
+        position={topDown ? Position.Bottom : Position.Right}
         isConnectable={false}
         className="!size-1.5 !border-0 !bg-transparent"
       />
@@ -258,7 +260,7 @@ export const ComponentNode = memo(function ComponentNode({
       {showsTechnology(level) && <TechnologyRow parts={technology} />}
       {showsTags(level) && <TagRow tags={tags} />}
 
-      <NodeHandles />
+      <NodeHandles orientation={data.orientation} />
     </div>
   )
 })
@@ -363,8 +365,7 @@ export const CompoundNode = memo(function CompoundNode({
         </div>
       )}
 
-      <NodeHandles />
+      <NodeHandles orientation={data.orientation} />
     </div>
   )
 })
-

--- a/frontend/src/canvas/RelationshipEdge.tsx
+++ b/frontend/src/canvas/RelationshipEdge.tsx
@@ -231,7 +231,12 @@ export const RelationshipEdge = memo(function RelationshipEdge({
   // The route comes from ELK when it is still valid. After a drag it is not,
   // and a plain orthogonal fallback between the two handles takes over.
   const route: LayoutPoint[] =
-    data.route ?? fallbackRoute({ x: sourceX, y: sourceY }, { x: targetX, y: targetY })
+    data.route ??
+    fallbackRoute(
+      { x: sourceX, y: sourceY },
+      { x: targetX, y: targetY },
+      data.fallbackOrientation,
+    )
 
   const overlays = data.overlays ?? {}
   const bundled = resolved.length > 1
@@ -316,7 +321,11 @@ export const RelationshipEdge = memo(function RelationshipEdge({
     <>
       {resolved.map((entry) => {
         const style = RELATIONSHIP_KIND_STYLE_BY_ID[entry.relationship.kind]
-        const fanned = fanRoute(route, fanOffset(entry.index, entry.total))
+        const fanned = fanRoute(
+          route,
+          fanOffset(entry.index, entry.total),
+          data.fallbackOrientation,
+        )
         const emphasised = entry.relationship.relationshipId === selectedRelationshipId
         return (
           <EdgeRoute
@@ -336,7 +345,11 @@ export const RelationshipEdge = memo(function RelationshipEdge({
         {resolved.map((entry) => {
           const overlay = overlays[entry.relationship.relationshipId]
           if (!overlay) return null
-          const fanned = fanRoute(route, fanOffset(entry.index, entry.total))
+          const fanned = fanRoute(
+            route,
+            fanOffset(entry.index, entry.total),
+            data.fallbackOrientation,
+          )
           return (
             <EdgeOverlayMark
               key={`state-${entry.relationship.relationshipId}`}
@@ -347,7 +360,11 @@ export const RelationshipEdge = memo(function RelationshipEdge({
         })}
         {resolved.map((entry) => {
           const style = RELATIONSHIP_KIND_STYLE_BY_ID[entry.relationship.kind]
-          const fanned = fanRoute(route, fanOffset(entry.index, entry.total))
+          const fanned = fanRoute(
+            route,
+            fanOffset(entry.index, entry.total),
+            data.fallbackOrientation,
+          )
           const emphasised = entry.relationship.relationshipId === selectedRelationshipId
           return (
             <EdgeBadge

--- a/frontend/src/canvas/cameraPolicy.ts
+++ b/frontend/src/canvas/cameraPolicy.ts
@@ -158,10 +158,10 @@ export interface ViewportOptions {
    * How to place a model that does not fit at `minZoom`. `center` keeps the
    * middle of the model on screen, `start` puts its top-left corner there.
    *
-   * The initial camera uses `start`: the layout runs left to right with the
-   * callers first (ADR 0008), so its top-left corner is where an architecture
-   * is read from. Landing in the geometric middle of a model that does not fit
-   * drops the reader somewhere in the middle of a sentence.
+   * The initial camera uses `start`: the active layout direction puts callers
+   * first (ADR 0023), so its top-left corner is where an architecture is read
+   * from. Landing in the geometric middle of a model that does not fit drops
+   * the reader somewhere in the middle of a sentence.
    */
   overflow?: 'center' | 'start'
   /**

--- a/frontend/src/canvas/collapse.test.ts
+++ b/frontend/src/canvas/collapse.test.ts
@@ -125,6 +125,39 @@ describe('collapsing the graph', () => {
     expect(service?.data.isCompound).toBe(true)
   })
 
+  it('keeps left-to-right handles on a collapsed container', () => {
+    const projection = projectArchitecture(
+      {
+        components: LARGE_COMPONENTS,
+        relationships: LARGE_RELATIONSHIPS,
+      },
+      'left-right',
+    )
+    const visible = collapseGraph(projection.nodes, projection.edges, ['mesh.s1'], 'left-right')
+    const service = visible.nodes.find((node) => node.id === 'mesh.s1')
+
+    expect(service?.handles).toEqual([
+      {
+        id: 'in',
+        type: 'target',
+        position: 'left',
+        x: 0,
+        y: LEAF_NODE_SIZE.height / 2,
+        width: 1,
+        height: 1,
+      },
+      {
+        id: 'out',
+        type: 'source',
+        position: 'right',
+        x: LEAF_NODE_SIZE.width,
+        y: LEAF_NODE_SIZE.height / 2,
+        width: 1,
+        height: 1,
+      },
+    ])
+  })
+
   it('lifts a relationship onto the nearest visible ancestor instead of dropping it', () => {
     const visible = collapseGraph(large.nodes, large.edges, initialCollapsedIds(large.nodes))
 
@@ -150,6 +183,26 @@ describe('collapsing the graph', () => {
     // equal to what the applied model reported.
     expect(visible.edges).toHaveLength(9)
     expect(countRelationships(visible.edges)).toBe(LARGE_RELATIONSHIPS.length)
+  })
+
+  it('keeps the left-to-right fallback orientation on lifted edges', () => {
+    const projection = projectArchitecture(
+      {
+        components: LARGE_COMPONENTS,
+        relationships: LARGE_RELATIONSHIPS,
+      },
+      'left-right',
+    )
+    const visible = collapseGraph(
+      projection.nodes,
+      projection.edges,
+      initialCollapsedIds(projection.nodes),
+      'left-right',
+    )
+
+    expect(visible.edges.every((edge) => edge.data?.fallbackOrientation === 'left-right')).toBe(
+      true,
+    )
   })
 
   it('does not draw a relationship whose two ends collapsed into the same box', () => {

--- a/frontend/src/canvas/collapse.ts
+++ b/frontend/src/canvas/collapse.ts
@@ -3,6 +3,10 @@ import type { ComponentId, Identifier } from '@/api/types'
 import { dominantOverlay, type ChangeOverlay } from './changeOverlays'
 import { INITIAL_EXPANDED_DEPTH } from './detailLevel'
 import {
+  DEFAULT_GRAPH_ORIENTATION,
+  type GraphOrientation,
+} from './graphOrientation'
+import {
   HANDLE_IDS,
   LEAF_NODE_SIZE,
   RELATIONSHIP_EDGE_TYPE,
@@ -127,6 +131,7 @@ export function collapseGraph(
   nodes: readonly ArchitectureNode[],
   edges: readonly ArchitectureEdge[],
   collapsed: readonly ComponentId[],
+  orientation: GraphOrientation = DEFAULT_GRAPH_ORIENTATION,
 ): VisibleGraph {
   const requested = new Set(collapsed)
   const parentOf = parentIndex(nodes)
@@ -195,7 +200,7 @@ export function collapseGraph(
         width: LEAF_NODE_SIZE.width,
         height: LEAF_NODE_SIZE.height,
         measured: { width: LEAF_NODE_SIZE.width, height: LEAF_NODE_SIZE.height },
-        handles: nodeHandles(LEAF_NODE_SIZE.width, LEAF_NODE_SIZE.height),
+        handles: nodeHandles(LEAF_NODE_SIZE.width, LEAF_NODE_SIZE.height, orientation),
         data: {
           ...node.data,
           collapsed: true,
@@ -229,6 +234,8 @@ export function collapseGraph(
     applied: boolean
     relationships: NonNullable<ArchitectureEdge['data']>['relationships']
     overlays: Record<Identifier, ChangeOverlay>
+    /** Direction retained when this bundle was lifted onto visible ancestors. */
+    fallbackOrientation: GraphOrientation
     /** The untouched edge, when this bundle is exactly one unlifted edge. */
     original: ArchitectureEdge | null
   }
@@ -260,6 +267,7 @@ export function collapseGraph(
       applied: data.applied,
       relationships: data.relationships,
       overlays: data.overlays,
+      fallbackOrientation: data.fallbackOrientation ?? orientation,
       original: untouched ? edge : null,
     })
   }
@@ -285,6 +293,7 @@ export function collapseGraph(
           applied: bundle.applied,
           overlays: bundle.overlays,
           bundled: relationships.length > 1,
+          fallbackOrientation: bundle.fallbackOrientation,
         },
       } as ArchitectureEdge
     })

--- a/frontend/src/canvas/edgeGeometry.test.ts
+++ b/frontend/src/canvas/edgeGeometry.test.ts
@@ -37,15 +37,15 @@ describe('edge geometry', () => {
       { x: 0, y: 50 },
       { x: 200, y: 50 },
     ]
-    const fanned = fanRoute(route, 13)
+    const fanned = fanRoute(route, 13, 'left-right')
 
     // The endpoints stay exactly on the handles…
     expect(fanned[0]).toEqual({ x: 0, y: 50 })
     expect(fanned[fanned.length - 1]).toEqual({ x: 200, y: 50 })
     // …while the middle of the line moves aside.
-    expect(fanned).toHaveLength(4)
-    expect(fanned[1]?.y).toBe(63)
+    expect(fanned).toHaveLength(6)
     expect(fanned[2]?.y).toBe(63)
+    expect(fanned[3]?.y).toBe(63)
   })
 
   it('centres the fan around the original route', () => {
@@ -70,15 +70,60 @@ describe('edge geometry', () => {
   })
 
   it('falls back to an orthogonal connection when no route was computed', () => {
-    expect(fallbackRoute({ x: 0, y: 10 }, { x: 100, y: 10 })).toEqual([
+    expect(fallbackRoute({ x: 0, y: 10 }, { x: 100, y: 10 }, 'left-right')).toEqual([
       { x: 0, y: 10 },
       { x: 100, y: 10 },
     ])
-    expect(fallbackRoute({ x: 0, y: 0 }, { x: 100, y: 60 })).toEqual([
+    expect(fallbackRoute({ x: 0, y: 0 }, { x: 100, y: 60 }, 'left-right')).toEqual([
       { x: 0, y: 0 },
       { x: 50, y: 0 },
       { x: 50, y: 60 },
       { x: 100, y: 60 },
     ])
+  })
+
+  it('uses a vertical midpoint for a top-down fallback route', () => {
+    expect(fallbackRoute({ x: 20, y: 0 }, { x: 120, y: 200 }, 'top-down')).toEqual([
+      { x: 20, y: 0 },
+      { x: 20, y: 100 },
+      { x: 120, y: 100 },
+      { x: 120, y: 200 },
+    ])
+  })
+
+  it('fans top-down bundles horizontally while keeping both handles attached', () => {
+    const route = [
+      { x: 50, y: 0 },
+      { x: 50, y: 200 },
+    ]
+    const fanned = fanRoute(route, 13, 'top-down')
+    expect(fanned[0]).toEqual(route[0])
+    expect(fanned[fanned.length - 1]).toEqual(route[1])
+    expect(fanned.some((point) => point.x === 63)).toBe(true)
+    for (let index = 1; index < fanned.length; index += 1) {
+      const previous = fanned[index - 1] as { x: number; y: number }
+      const current = fanned[index] as { x: number; y: number }
+      expect(previous.x === current.x || previous.y === current.y).toBe(true)
+    }
+  })
+
+  it('keeps every left-to-right fanout segment axis-aligned', () => {
+    const fanned = fanRoute(
+      [
+        { x: 0, y: 50 },
+        { x: 200, y: 50 },
+      ],
+      13,
+      'left-right',
+    )
+
+    expect(fanned[0]).toEqual({ x: 0, y: 50 })
+    expect(fanned[fanned.length - 1]).toEqual({ x: 200, y: 50 })
+    expect(fanned.some((point) => point.y === 63)).toBe(true)
+    for (let index = 1; index < fanned.length; index += 1) {
+      const previous = fanned[index - 1] as { x: number; y: number }
+      const current = fanned[index] as { x: number; y: number }
+      expect(previous.x === current.x || previous.y === current.y).toBe(true)
+    }
   })
 })

--- a/frontend/src/canvas/edgeGeometry.ts
+++ b/frontend/src/canvas/edgeGeometry.ts
@@ -1,4 +1,8 @@
 import type { LayoutPoint } from './elkLayout'
+import {
+  DEFAULT_GRAPH_ORIENTATION,
+  type GraphOrientation,
+} from './graphOrientation'
 
 /**
  * Path helpers for the relationship edges.
@@ -20,7 +24,7 @@ const lerp = (from: LayoutPoint, to: LayoutPoint, ratio: number): LayoutPoint =>
 /** Default corner radius of a routed edge. */
 export const EDGE_CORNER_RADIUS = 10
 
-/** Vertical distance between two lines of a fanned-out bundle. */
+/** Perpendicular distance between two lines of a fanned-out bundle. */
 export const BUNDLE_FAN_SPACING = 13
 
 /**
@@ -72,6 +76,7 @@ export function roundedPolylinePath(
 export function fanRoute(
   points: readonly LayoutPoint[],
   offsetY: number,
+  orientation: GraphOrientation = DEFAULT_GRAPH_ORIENTATION,
 ): LayoutPoint[] {
   if (points.length < 2 || offsetY === 0) return [...points]
 
@@ -82,15 +87,38 @@ export function fanRoute(
     working = [start, lerp(start, end, 0.3), lerp(start, end, 0.7), end]
   }
 
-  return working.map((point, index) =>
+  const shifted = working.map((point, index) =>
     index === 0 || index === working.length - 1
       ? point
-      : { x: point.x, y: point.y + offsetY },
+      : orientation === 'top-down'
+        ? { x: point.x + offsetY, y: point.y }
+        : { x: point.x, y: point.y + offsetY },
   )
+
+  // Keep the first and last points on their handles while connecting them to
+  // the shifted interior with orthogonal bends. Translating the interior of a
+  // route otherwise turns its first/last segment into a diagonal at the
+  // handle. The first bend follows the reading direction so a left-to-right
+  // route leaves its source horizontally and a top-down route leaves it
+  // vertically.
+  const result: LayoutPoint[] = [shifted[0] as LayoutPoint]
+  for (let index = 1; index < shifted.length; index += 1) {
+    const next = shifted[index] as LayoutPoint
+    const current = result[result.length - 1] as LayoutPoint
+    if (current.x !== next.x && current.y !== next.y) {
+      result.push(
+        orientation === 'top-down'
+          ? { x: current.x, y: next.y }
+          : { x: next.x, y: current.y },
+      )
+    }
+    result.push(next)
+  }
+  return result
 }
 
 /**
- * Vertical offset of entry `index` of a bundle of `total` entries, centred
+ * Perpendicular offset of entry `index` of a bundle of `total` entries, centred
  * around the original route.
  */
 export function fanOffset(index: number, total: number): number {
@@ -132,7 +160,19 @@ export function pointAtRatio(
 export function fallbackRoute(
   source: LayoutPoint,
   target: LayoutPoint,
+  orientation: GraphOrientation = DEFAULT_GRAPH_ORIENTATION,
 ): LayoutPoint[] {
+  if (orientation === 'top-down') {
+    if (Math.abs(source.x - target.x) < 0.5) return [source, target]
+    const middleY = (source.y + target.y) / 2
+    return [
+      source,
+      { x: source.x, y: middleY },
+      { x: target.x, y: middleY },
+      target,
+    ]
+  }
+
   if (Math.abs(source.y - target.y) < 0.5) return [source, target]
   const middleX = (source.x + target.x) / 2
   return [

--- a/frontend/src/canvas/elkLayout.test.ts
+++ b/frontend/src/canvas/elkLayout.test.ts
@@ -20,8 +20,12 @@ describe('ELK layered layout', () => {
     async () => {
       const projection = projectArchitecture(model)
 
-      const first = await layoutArchitecture(projection.nodes, projection.edges)
-      const second = await layoutArchitecture(projection.nodes, projection.edges)
+      const first = await layoutArchitecture(projection.nodes, projection.edges, {
+        direction: 'RIGHT',
+      })
+      const second = await layoutArchitecture(projection.nodes, projection.edges, {
+        direction: 'RIGHT',
+      })
 
       expect(describeLayout(second)).toBe(describeLayout(first))
       expect(second.nodes.map((node) => node.position)).toEqual(
@@ -42,8 +46,12 @@ describe('ELK layered layout', () => {
         relationships: reorder(NESTED_RELATIONSHIPS),
       })
 
-      const fromStraight = await layoutArchitecture(straight.nodes, straight.edges)
-      const fromShuffled = await layoutArchitecture(shuffled.nodes, shuffled.edges)
+      const fromStraight = await layoutArchitecture(straight.nodes, straight.edges, {
+        direction: 'RIGHT',
+      })
+      const fromShuffled = await layoutArchitecture(shuffled.nodes, shuffled.edges, {
+        direction: 'RIGHT',
+      })
 
       expect(describeLayout(fromShuffled)).toBe(describeLayout(fromStraight))
       expect(fromShuffled.routes).toEqual(fromStraight.routes)
@@ -56,13 +64,16 @@ describe('ELK layered layout', () => {
     async () => {
       const projection = projectArchitecture(model)
 
-      const straight = await layoutArchitecture(projection.nodes, projection.edges)
+      const straight = await layoutArchitecture(projection.nodes, projection.edges, {
+        direction: 'RIGHT',
+      })
       const reversed = await layoutArchitecture(
         // Reversing the node array would break React Flow's parent-before-child
         // rule, so the layout has to re-derive the hierarchy itself — which it
         // does, from `parentId` rather than from the array order.
         [...projection.nodes].reverse(),
         [...projection.edges].reverse(),
+        { direction: 'RIGHT' },
       )
 
       const straightById = new Map(straight.nodes.map((node) => [node.id, node.position]))
@@ -77,7 +88,9 @@ describe('ELK layered layout', () => {
     'places children inside their container and gives containers a real size',
     async () => {
       const projection = projectArchitecture(model)
-      const { nodes } = await layoutArchitecture(projection.nodes, projection.edges)
+      const { nodes } = await layoutArchitecture(projection.nodes, projection.edges, {
+        direction: 'RIGHT',
+      })
       const byId = new Map(nodes.map((node) => [node.id, node]))
 
       const container = byId.get('platform.api.http')
@@ -107,7 +120,9 @@ describe('ELK layered layout', () => {
     'routes every edge from the source handle to the target handle',
     async () => {
       const projection = projectArchitecture(model)
-      const layout = await layoutArchitecture(projection.nodes, projection.edges)
+      const layout = await layoutArchitecture(projection.nodes, projection.edges, {
+        direction: 'RIGHT',
+      })
 
       expect(layout.nodes.map((node) => node.id)).toEqual(
         projection.nodes.map((node) => node.id),
@@ -168,7 +183,11 @@ describe('ELK layered layout', () => {
 
   it('sorts the graph it hands to ELK and drops self references', () => {
     const projection = projectArchitecture(model)
-    const graph = buildElkGraph([...projection.nodes].reverse(), [...projection.edges].reverse())
+    const graph = buildElkGraph(
+      [...projection.nodes].reverse(),
+      [...projection.edges].reverse(),
+      { direction: 'RIGHT' },
+    )
 
     expect(graph.children?.map((child) => child.id)).toEqual(['external.payments', 'platform'])
     expect(graph.edges?.map((edge) => edge.id)).toEqual(
@@ -188,4 +207,73 @@ describe('ELK layered layout', () => {
     const layout = await layoutArchitecture([], [])
     expect(layout).toEqual({ nodes: [], routes: {}, bounds: { width: 0, height: 0 } })
   })
+
+  it(
+    'uses top-down ports and routes when no direction override is supplied',
+    async () => {
+      const projection = projectArchitecture(model, 'top-down')
+      const graph = buildElkGraph(projection.nodes, projection.edges)
+      const platform = graph.children?.find((child) => child.id === 'platform')
+
+      expect(graph.layoutOptions?.['elk.direction']).toBe('DOWN')
+      expect(platform?.ports?.map((port) => port.layoutOptions?.['elk.port.side'])).toEqual([
+        'NORTH',
+        'SOUTH',
+      ])
+
+      const layout = await layoutArchitecture(projection.nodes, projection.edges)
+      const byId = new Map(layout.nodes.map((node) => [node.id, node]))
+      const absolute = (id: string): { x: number; y: number } => {
+        let x = 0
+        let y = 0
+        let current = byId.get(id)
+        const guard = new Set<string>()
+        while (current && !guard.has(current.id)) {
+          guard.add(current.id)
+          x += current.position.x
+          y += current.position.y
+          current = current.parentId ? byId.get(current.parentId) : undefined
+        }
+        return { x, y }
+      }
+      for (const edge of projection.edges) {
+        const route = layout.routes[edge.id]
+        expect(route, `route for ${edge.id}`).toBeDefined()
+        const source = byId.get(edge.source)
+        const target = byId.get(edge.target)
+        const sourceOrigin = absolute(edge.source)
+        const targetOrigin = absolute(edge.target)
+        const start = route?.[0]
+        const end = route?.[route.length - 1]
+        expect(Math.abs((start?.x ?? 0) - (sourceOrigin.x + (source?.width ?? 0) / 2))).toBeLessThanOrEqual(1)
+        expect(Math.abs((start?.y ?? 0) - (sourceOrigin.y + (source?.height ?? 0)))).toBeLessThanOrEqual(1)
+        expect(Math.abs((end?.x ?? 0) - (targetOrigin.x + (target?.width ?? 0) / 2))).toBeLessThanOrEqual(1)
+        expect(Math.abs((end?.y ?? 0) - targetOrigin.y)).toBeLessThanOrEqual(1)
+      }
+    },
+    LAYOUT_TIMEOUT,
+  )
+
+  it(
+    'keeps top-down layouts stable across repeated and permuted solves',
+    async () => {
+      const projection = projectArchitecture(model, 'top-down')
+
+      const first = await layoutArchitecture(projection.nodes, projection.edges)
+      const second = await layoutArchitecture(projection.nodes, projection.edges)
+      const fromPermuted = await layoutArchitecture(
+        reorder(projection.nodes),
+        reorder(projection.edges),
+      )
+
+      expect(describeLayout(second)).toBe(describeLayout(first))
+      expect(second.routes).toEqual(first.routes)
+      const firstById = new Map(first.nodes.map((node) => [node.id, node.position]))
+      for (const node of fromPermuted.nodes) {
+        expect(node.position).toEqual(firstById.get(node.id))
+      }
+      expect(fromPermuted.routes).toEqual(first.routes)
+    },
+    LAYOUT_TIMEOUT,
+  )
 })

--- a/frontend/src/canvas/elkLayout.ts
+++ b/frontend/src/canvas/elkLayout.ts
@@ -9,13 +9,18 @@ import {
   type ArchitectureEdge,
   type ArchitectureNode,
 } from './graphProjection'
+import {
+  orientationForElkDirection,
+  type ElkDirection,
+} from './graphOrientation'
 
 /**
  * Automatic layout with ELK's `layered` algorithm.
  *
  * `layered` (a Sugiyama-style algorithm) is the right fit because an
- * architecture model *is* a directed, mostly acyclic graph: callers on the
- * left, callees on the right, with a readable layer per hop. Force-directed
+ * architecture model *is* a directed, mostly acyclic graph: callers precede
+ * callees, with a readable layer per hop. The default is top-down; an explicit
+ * left-to-right mode keeps the original horizontal reading. Force-directed
  * alternatives give a pretty but arbitrary picture that changes every time, and
  * a tree layout cannot express the cross-links an architecture is full of.
  *
@@ -54,8 +59,8 @@ export interface ArchitectureLayout {
 }
 
 export interface LayoutOptionsInput {
-  /** Layout direction. `RIGHT` reads as "calls flow to the right". */
-  direction?: 'RIGHT' | 'DOWN'
+  /** ELK layout direction. `DOWN` is the top-down default. */
+  direction?: ElkDirection
 }
 
 /**
@@ -67,7 +72,7 @@ export interface LayoutOptionsInput {
  */
 export const ROOT_LAYOUT_OPTIONS: LayoutOptions = {
   'elk.algorithm': 'layered',
-  'elk.direction': 'RIGHT',
+  'elk.direction': 'DOWN',
   'elk.edgeRouting': 'ORTHOGONAL',
   'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
   // Pinned seed: `layered` uses randomised tie-breaking in its heuristics.
@@ -149,6 +154,9 @@ export function buildElkGraph(
   edges: readonly ArchitectureEdge[],
   options: LayoutOptionsInput = {},
 ): ElkNode {
+  const direction = options.direction ?? 'DOWN'
+  const orientation = orientationForElkDirection(direction)
+  const topDown = orientation === 'top-down'
   const sorted = [...nodes].sort((a, b) => compareIds(a.id, b.id))
   const childrenOf = new Map<string, ArchitectureNode[]>()
   const roots: ArchitectureNode[] = []
@@ -180,19 +188,25 @@ export function buildElkGraph(
       ports: [
         {
           id: targetPortId(node.id),
-          x: 0,
-          y: height / 2,
+          x: topDown ? width / 2 : 0,
+          y: topDown ? 0 : height / 2,
           width: 1,
           height: 1,
-          layoutOptions: { 'elk.port.side': 'WEST', 'elk.port.index': '0' },
+          layoutOptions: {
+            'elk.port.side': topDown ? 'NORTH' : 'WEST',
+            'elk.port.index': '0',
+          },
         },
         {
           id: sourcePortId(node.id),
-          x: width,
-          y: height / 2,
+          x: topDown ? width / 2 : width,
+          y: topDown ? height : height / 2,
           width: 1,
           height: 1,
-          layoutOptions: { 'elk.port.side': 'EAST', 'elk.port.index': '1' },
+          layoutOptions: {
+            'elk.port.side': topDown ? 'SOUTH' : 'EAST',
+            'elk.port.index': '1',
+          },
         },
       ],
     }
@@ -245,6 +259,7 @@ export async function layoutArchitecture(
 
   const elk = await getElk()
   const graph = buildElkGraph(nodes, edges, options)
+  const orientation = orientationForElkDirection(options.direction ?? 'DOWN')
   const laidOut = await elk.layout(graph)
 
   const positions = new Map<string, { x: number; y: number; width: number; height: number }>()
@@ -326,7 +341,8 @@ export async function layoutArchitecture(
       measured: { width, height },
       // Re-declared for the size ELK settled on — a container grows around its
       // children, and its handles have to follow.
-      handles: nodeHandles(width, height),
+      handles: nodeHandles(width, height, orientation),
+      data: { ...node.data, orientation },
       style: { ...node.style, width, height },
     }
   })

--- a/frontend/src/canvas/graphOrientation.ts
+++ b/frontend/src/canvas/graphOrientation.ts
@@ -1,0 +1,17 @@
+/** The two supported readings of the architecture graph. */
+export const GRAPH_ORIENTATIONS = ['top-down', 'left-right'] as const
+
+export type GraphOrientation = (typeof GRAPH_ORIENTATIONS)[number]
+
+/** Top-down is the default because vertical space is the scarce resource in a wide workspace. */
+export const DEFAULT_GRAPH_ORIENTATION: GraphOrientation = 'top-down'
+
+export type ElkDirection = 'DOWN' | 'RIGHT'
+
+export function elkDirectionForOrientation(orientation: GraphOrientation): ElkDirection {
+  return orientation === 'top-down' ? 'DOWN' : 'RIGHT'
+}
+
+export function orientationForElkDirection(direction: ElkDirection): GraphOrientation {
+  return direction === 'DOWN' ? 'top-down' : 'left-right'
+}

--- a/frontend/src/canvas/graphProjection.ts
+++ b/frontend/src/canvas/graphProjection.ts
@@ -10,6 +10,10 @@ import type {
 } from '@/api/types'
 
 import type { ChangeOverlay, ChangeOverlayModel } from './changeOverlays'
+import {
+  DEFAULT_GRAPH_ORIENTATION,
+  type GraphOrientation,
+} from './graphOrientation'
 import { relationshipDiscriminator, relationshipDisplayName } from './relationshipKinds'
 
 /**
@@ -62,26 +66,32 @@ export const HANDLE_IDS = { source: 'out', target: 'in' } as const
  * on a rendered layout — which makes it different in a browser and in a test,
  * and different again before and after the first measurement. Declaring the
  * handles explicitly makes the geometry a pure function of the layout: incoming
- * on the left edge, outgoing on the right edge, both vertically centred, which
- * is exactly where the ELK ports sit.
+ * They are on the top/bottom edges for the default top-down reading and on the
+ * left/right edges for the explicit left-to-right reading, exactly where the
+ * matching ELK ports sit.
  */
-export function nodeHandles(width: number, height: number): NodeHandle[] {
+export function nodeHandles(
+  width: number,
+  height: number,
+  orientation: GraphOrientation = DEFAULT_GRAPH_ORIENTATION,
+): NodeHandle[] {
+  const topDown = orientation === 'top-down'
   return [
     {
       id: HANDLE_IDS.target,
       type: 'target',
-      position: 'left' as Position,
-      x: 0,
-      y: height / 2,
+      position: (topDown ? 'top' : 'left') as Position,
+      x: topDown ? width / 2 : 0,
+      y: topDown ? 0 : height / 2,
       width: 1,
       height: 1,
     },
     {
       id: HANDLE_IDS.source,
       type: 'source',
-      position: 'right' as Position,
-      x: width,
-      y: height / 2,
+      position: (topDown ? 'bottom' : 'right') as Position,
+      x: topDown ? width / 2 : width,
+      y: topDown ? height : height / 2,
       width: 1,
       height: 1,
     },
@@ -103,6 +113,8 @@ export interface ComponentNodeData extends Record<string, unknown> {
   childCount: number
   /** `true` when this node is a compound container. */
   isCompound: boolean
+  /** Handle direction for this rendered projection. */
+  orientation: GraphOrientation
   /** Reported work state of this component, or `null` when none was reported. */
   overlay: ChangeOverlay | null
   /**
@@ -138,6 +150,8 @@ export interface RelationshipEdgeData extends Record<string, unknown> {
   overlays: Record<Identifier, ChangeOverlay>
   /** `true` when more than one relationship shares this pair of components. */
   bundled: boolean
+  /** Direction used by the orthogonal fallback after a node drag. */
+  fallbackOrientation?: GraphOrientation
   /**
    * Absolute polyline computed by ELK, attached by the canvas after the layout.
    * Absent while no layout exists or after one of the endpoints was dragged;
@@ -296,7 +310,10 @@ const compareIds = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0
  * Pure: the same input always produces the same output, including the order of
  * every array.
  */
-export function projectArchitecture(model: ArchitectureModel): ArchitectureProjection {
+export function projectArchitecture(
+  model: ArchitectureModel,
+  orientation: GraphOrientation = DEFAULT_GRAPH_ORIENTATION,
+): ArchitectureProjection {
   const diagnostics: ProjectionDiagnostics = {
     orphanedParents: [],
     hierarchyCycles: [],
@@ -436,13 +453,14 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
       // waiting for a `ResizeObserver` is the honest answer, and it makes the
       // canvas behave identically before and after the first paint.
       measured: { width: size.width, height: size.height },
-      handles: nodeHandles(size.width, size.height),
+      handles: nodeHandles(size.width, size.height, orientation),
       data: {
         component,
         applied: appliedComponentIds.has(entry.componentId),
         depth: entry.depth,
         childCount: children.length,
         isCompound,
+        orientation,
         overlay: overlayOfComponent.get(entry.componentId) ?? null,
       },
       ...(parentId !== null ? { parentId, extent: 'parent' as const } : {}),
@@ -553,6 +571,7 @@ export function projectArchitecture(model: ArchitectureModel): ArchitectureProje
           applied,
           overlays,
           bundled: relationships.length > 1,
+          fallbackOrientation: orientation,
         },
       }
     })

--- a/frontend/src/canvas/useArchitectureGraph.ts
+++ b/frontend/src/canvas/useArchitectureGraph.ts
@@ -5,6 +5,11 @@ import type { ComponentId } from '@/api/types'
 import { ancestorIds, collapseGraph, initialCollapsedIds } from './collapse'
 import { layoutArchitecture, type EdgeRoutes } from './elkLayout'
 import {
+  DEFAULT_GRAPH_ORIENTATION,
+  elkDirectionForOrientation,
+  type GraphOrientation,
+} from './graphOrientation'
+import {
   EMPTY_DIAGNOSTICS,
   projectArchitecture,
   projectionSignature,
@@ -75,6 +80,8 @@ export interface ArchitectureGraphOptions {
    * levels down actually arrive.
    */
   revealComponentId?: ComponentId | null
+  /** Direction used for handles, ports and the ELK layered layout. */
+  orientation?: GraphOrientation
 }
 
 /**
@@ -92,14 +99,21 @@ export interface ArchitectureGraphOptions {
  */
 export function useArchitectureGraph(
   model: ArchitectureModel | undefined,
-  options: ArchitectureGraphOptions = { collapsedComponentIds: [] },
+  options: ArchitectureGraphOptions = {
+    collapsedComponentIds: [],
+    orientation: DEFAULT_GRAPH_ORIENTATION,
+  },
 ): ArchitectureGraph {
-  const { collapsedComponentIds, revealComponentId } = options
+  const {
+    collapsedComponentIds,
+    revealComponentId,
+    orientation = DEFAULT_GRAPH_ORIENTATION,
+  } = options
   const reportedRelationshipCount = model?.relationships.length ?? 0
 
   const projection = useMemo(
-    () => projectArchitecture(model ?? EMPTY_MODEL),
-    [model],
+    () => projectArchitecture(model ?? EMPTY_MODEL, orientation),
+    [model, orientation],
   )
 
   /**
@@ -125,11 +139,17 @@ export function useArchitectureGraph(
         projection.nodes,
         projection.edges,
         collapsedKey === '' ? [] : collapsedKey.split(KEY_SEPARATOR),
+        orientation,
       ),
-    [projection, collapsedKey],
+    [projection, collapsedKey, orientation],
   )
 
   const signature = useMemo(() => projectionSignature(visible), [visible])
+  // Orientation is part of what ELK solves even though it does not alter the
+  // projected component/relationship inventory. Including it in the layout
+  // signature prevents the previous direction from being treated as current
+  // while the new solve is still running.
+  const layoutSignature = `${orientation}\u0001${signature}`
 
   const [laidOut, setLaidOut] = useState<LayoutState | null>(null)
   const [error, setError] = useState<unknown>(null)
@@ -145,10 +165,12 @@ export function useArchitectureGraph(
     runIdRef.current = runId
 
     let cancelled = false
-    void layoutArchitecture(visible.nodes, visible.edges)
+    void layoutArchitecture(visible.nodes, visible.edges, {
+      direction: elkDirectionForOrientation(orientation),
+    })
       .then((layout) => {
         if (cancelled || runIdRef.current !== runId) return
-        setLaidOut({ signature, nodes: layout.nodes, routes: layout.routes })
+        setLaidOut({ signature: layoutSignature, nodes: layout.nodes, routes: layout.routes })
         setError(null)
       })
       .catch((cause: unknown) => {
@@ -161,14 +183,14 @@ export function useArchitectureGraph(
     }
     // `signature` is derived from `visible`; both are listed so a graph that is
     // structurally identical after a refetch does not re-run ELK.
-  }, [visible, signature])
+  }, [visible, layoutSignature, orientation])
 
   // The edges always come from the current projection — an incoming update must
   // show up immediately, even if its layout is still being computed. Only the
   // node positions wait for ELK.
   return useMemo<ArchitectureGraph>(() => {
     const isEmpty = visible.nodes.length === 0
-    const isCurrent = laidOut !== null && laidOut.signature === signature
+    const isCurrent = laidOut !== null && laidOut.signature === layoutSignature
 
     return {
       nodes: isEmpty
@@ -182,7 +204,7 @@ export function useArchitectureGraph(
       isInitialLayout: !isEmpty && laidOut === null,
       isRelayouting: !isEmpty && !isCurrent,
       error,
-      signature,
+      signature: layoutSignature,
       // Counted on the *reported* model, not on what is open: a collapsed
       // container hides components, it does not remove them, and the pane's
       // "28 Komponenten" must keep saying 28.
@@ -198,7 +220,7 @@ export function useArchitectureGraph(
       reportedRelationshipCount,
       ancestorsOf: (componentId) => ancestorIds(projection.nodes, componentId),
     }
-  }, [laidOut, projection, visible, signature, error, reportedRelationshipCount])
+  }, [laidOut, projection, visible, layoutSignature, error, reportedRelationshipCount])
 }
 
 /**

--- a/frontend/src/components/workspace/ArchitecturePane.tsx
+++ b/frontend/src/components/workspace/ArchitecturePane.tsx
@@ -15,6 +15,7 @@ import { PaneHeader } from '@/components/workspace/PaneHeader'
 import { RelationshipLegend } from '@/components/workspace/RelationshipLegend'
 import { Badge } from '@/components/ui/badge'
 import { ReportedText } from '@/i18n'
+import type { GraphOrientation } from '@/canvas/graphOrientation'
 
 export interface ArchitecturePaneProps {
   projectId: ProjectId
@@ -22,6 +23,8 @@ export interface ArchitecturePaneProps {
   selectedComponentId?: ComponentId | undefined
   /** Writes the selection back into the `component` search param. */
   onSelectComponent: (componentId: ComponentId | null) => void
+  orientation: GraphOrientation
+  onOrientationChange: (orientation: GraphOrientation) => void
 }
 
 /**
@@ -37,6 +40,8 @@ export function ArchitecturePane({
   projectId,
   selectedComponentId,
   onSelectComponent,
+  orientation,
+  onOrientationChange,
 }: ArchitecturePaneProps) {
   const { t } = useTranslation('canvas')
   const architecture = useArchitecture(projectId)
@@ -182,6 +187,8 @@ export function ArchitecturePane({
             model={model}
             selectedComponentId={selectedComponentId}
             onSelectComponent={onSelectComponent}
+            orientation={orientation}
+            onOrientationChange={onOrientationChange}
             onMetricsChange={onCanvasMetricsChange}
           />
         )}

--- a/frontend/src/i18n/locales/de/canvas.json
+++ b/frontend/src/i18n/locales/de/canvas.json
@@ -149,6 +149,9 @@
     "fitWholeModel": "Gesamtes Modell einpassen",
     "fitWholeModelHint": "Klappt alle Container auf und passt das vollständige Modell in die Fläche ein. Bei vielen Komponenten wird die Darstellung dabei bewusst klein — das ist die Übersichtsaktion. Die Kamera bewegt sich sonst nur beim ersten Laden — nie durch eintreffende Ereignisse.",
     "hideMinimap": "Übersichtskarte ausblenden",
+    "layoutLeftRight": "Links nach rechts",
+    "layoutOrientation": "Graphausrichtung",
+    "layoutTopDown": "Top-down",
     "resetPositions": "Positionen zurücksetzen",
     "resetPositionsHint": "Verschobene Knoten zurück auf das berechnete Layout. Verschiebungen sind ohnehin nur lokal und ändern das Architekturmodell nicht.",
     "showMinimap": "Übersichtskarte einblenden"

--- a/frontend/src/i18n/locales/en/canvas.json
+++ b/frontend/src/i18n/locales/en/canvas.json
@@ -149,6 +149,9 @@
     "fitWholeModel": "Fit the whole model",
     "fitWholeModelHint": "Expands every container and fits the complete model into the surface. With many components the picture deliberately becomes small — this is the overview action. Otherwise the camera only moves on the first load — never because events arrive.",
     "hideMinimap": "Hide the overview map",
+    "layoutLeftRight": "Left to right",
+    "layoutOrientation": "Graph orientation",
+    "layoutTopDown": "Top-down",
     "resetPositions": "Reset positions",
     "resetPositionsHint": "Moves dragged nodes back onto the computed layout. Drags are local only and do not change the architecture model anyway.",
     "showMinimap": "Show the overview map"

--- a/frontend/src/routes/pages/WorkspacePage.tsx
+++ b/frontend/src/routes/pages/WorkspacePage.tsx
@@ -10,6 +10,10 @@ import { WorkspaceHeader } from '@/components/workspace/WorkspaceHeader'
 import { WorkspaceLayout } from '@/components/workspace/WorkspaceLayout'
 import { useUiStore } from '@/state/uiStore'
 import type { DeepFocusTarget } from '@/routes/searchParams'
+import {
+  DEFAULT_GRAPH_ORIENTATION,
+  type GraphOrientation,
+} from '@/canvas/graphOrientation'
 
 const route = getRouteApi('/projects/$projectId/runs/$runId')
 
@@ -81,6 +85,16 @@ export function WorkspacePage() {
     [navigate],
   )
 
+  const setGraphOrientation = useCallback(
+    (layout: GraphOrientation) => {
+      void navigate({
+        search: (previous) => ({ ...previous, layout }),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
+
   // Escape leaves deep focus — the mode enlarges content, it must never trap.
   useEffect(() => {
     if (!search.focus) return
@@ -101,6 +115,8 @@ export function WorkspacePage() {
             projectId={projectId}
             selectedComponentId={search.component}
             onSelectComponent={setSelectedComponent}
+            orientation={search.layout ?? DEFAULT_GRAPH_ORIENTATION}
+            onOrientationChange={setGraphOrientation}
           />
         }
         right={

--- a/frontend/src/routes/searchParams.test.ts
+++ b/frontend/src/routes/searchParams.test.ts
@@ -8,6 +8,7 @@ const validSearch: WorkspaceSearch = {
   component: 'shop-platform.orders.domain',
   focus: 'feedback',
   history: true,
+  layout: 'left-right',
 }
 // @ts-expect-error 'runs' is not one of the two deep-focus targets
 const invalidSearch: WorkspaceSearch = { focus: 'runs' }
@@ -15,6 +16,19 @@ const invalidSearch: WorkspaceSearch = { focus: 'runs' }
 describe('validateWorkspaceSearch', () => {
   it('accepts the documented parameters', () => {
     expect(validateWorkspaceSearch({ ...validSearch })).toEqual(validSearch)
+  })
+
+  it('accepts both shareable graph orientations', () => {
+    expect(validateWorkspaceSearch({ layout: 'top-down' })).toEqual({
+      layout: 'top-down',
+    })
+    expect(validateWorkspaceSearch({ layout: 'left-right' })).toEqual({
+      layout: 'left-right',
+    })
+  })
+
+  it('drops an unknown graph orientation', () => {
+    expect(validateWorkspaceSearch({ layout: 'diagonal' })).toEqual({})
   })
 
   it('rejects an unknown focus target and falls back cleanly', () => {

--- a/frontend/src/routes/searchParams.ts
+++ b/frontend/src/routes/searchParams.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { GRAPH_ORIENTATIONS } from '@/canvas/graphOrientation'
+
 /**
  * Search parameters of the workspace route.
  *
@@ -27,6 +29,8 @@ const componentIdSchema = z.preprocess(
 export const workspaceSearchSchema = z.object({
   /** Selected component; drives the inspector. */
   component: componentIdSchema.optional().catch(undefined),
+  /** Reading direction of the architecture graph. */
+  layout: z.enum(GRAPH_ORIENTATIONS).optional().catch(undefined),
   /** Deep-focus target for large feedback or diff content. */
   focus: z.enum(DEEP_FOCUS_TARGETS).optional().catch(undefined),
   /** Show the component history instead of the current run. */


### PR DESCRIPTION
Closes #54

## Umgesetzt
- Top-down ist Standard; Links-nach-rechts ist über Toolbar und ?layout=left-right reproduzierbar.
- Handles, ELK-Ports, Kantenrouten, Bundle-Fan-outs und Drag-Fallbacks sind richtungsabhängig und orthogonal.
- Richtungswechsel erhält Auswahl, Collapse und Inspector, setzt temporäre Drag-Positionen zurück und führt einen expliziten Fit aus.
- DE/EN-A11y-Texte, ADRs sowie Unit-, Integrations- und Viewport-E2E-Abdeckung ergänzt.

## Tests
- Frontend: 473 Vitest-Dateien/-Tests, Typecheck, Lint, Contract-, Locale- und UI-String-Checks, Build
- E2E Typecheck und gerichtete Viewport-Spezifikationen
- git diff --check

## Einschränkung
Lokale Docker-Playwright-Ausführung ausgelassen, da ihr Global Setup docker compose down -v ausführt. Die CI führt die vollständige Suite aus.