### PR TITLE
Improve relationship labels and inspection

### DIFF
--- a/docs/decisions/0023-relationship-selection-and-progressive-labels.md
+++ b/docs/decisions/0023-relationship-selection-and-progressive-labels.md
@@ -1,0 +1,41 @@
+# 23. Relationship selection is a typed deep link and labels are progressive
+
+- **Status:** accepted
+- **Date:** 2026-08-17
+- **Context issue:** #57
+- **Builds on:** [0008 — Architecture canvas layout and edge bundling](./0008-architecture-canvas-layout-and-edge-bundling.md),
+  [0012 — Component inspector and markdown safety](./0012-component-inspector-and-markdown-safety.md),
+  [0018 — Accessible architecture nodes](./0018-accessible-architecture-nodes.md)
+
+## Context
+
+Relationship labels are drawn on the route midpoint. Full reported channel,
+operation and protocol text makes the default canvas unreadable in dense models,
+while the existing relationship selection lived only in transient UI state and
+had no inspector context.
+
+## Decision
+
+The workspace uses a validated `relationship` search parameter as the
+authoritative relationship selection, parallel to `component`. Selecting a
+relationship clears component selection; reloading the URL therefore restores
+the same inspector and opens both endpoint paths when needed. Bundles continue
+to represent several relationships and only expand/collapse; they never select
+an arbitrary member.
+
+Normal route labels show the kind abbreviation and only a bounded discriminator
+(`24` characters or fewer). The full reported detail remains available through
+the label title, keyboard focus, selection and the relationship inspector.
+The inspector reads the existing architecture and overlay read models without
+changing the API contract and lists endpoints, reported fields, change state,
+reporting agents and bundle members. Selected endpoints are ring-marked and
+unrelated connections are dimmed; self-references use a loop route so a label
+cannot sit inside its node.
+
+## Trade-offs
+
+The relationship inspector performs the same cached architecture query as the
+architecture pane, but TanStack Query deduplicates it and avoids introducing a
+new endpoint or contract shape. Long labels are less immediately visible on
+the canvas, but the title, focus state and inspector keep all reported text
+reachable without sacrificing the default graph's scanability.

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -364,7 +364,14 @@ test('2 · selecting one relationship is a reproducible URL and inspector contex
   const inspector = page.getByTestId('inspector-relationship-context')
   await expect(inspector).toBeVisible()
   await expect(inspector).toContainText('rel-orders-publishes-order-created')
-  await expect(page.getByTestId('inspector-relationship-bundle')).toBeVisible()
+  // This is the single publisher -> topic relationship. The other two
+  // `orders.order.created` relationships terminate at different consumers, so
+  // the ordered-endpoint bundling rule does not make them inspector siblings.
+  await expect(inspector).toContainText('NATS · orders.order.created')
+  await expect(inspector).toContainText('Orders Service')
+  await expect(inspector).toContainText('publishes')
+  await expect(inspector).toContainText('NATS')
+  await expect(page.getByTestId('inspector-relationship-bundle')).not.toBeAttached()
 
   // Escape clears the typed selection while the canvas remains the focused
   // interaction surface, so the next keyboard action has a stable target.

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -349,6 +349,29 @@ test('2 · every relationship kind is drawn, and every reported NATS topic stays
   )
 })
 
+test('2 · selecting one relationship is a reproducible URL and inspector context', async ({
+  page,
+}) => {
+  await openWorkspace(page)
+  await showWholeModel(page)
+  await zoomToFullDetail(page)
+
+  const label = page.getByTestId('edge-label-rel-orders-publishes-order-created')
+  await expect(label).toBeVisible()
+  await label.click()
+
+  await expect(page).toHaveURL(/relationship=rel-orders-publishes-order-created/)
+  const inspector = page.getByTestId('inspector-relationship-context')
+  await expect(inspector).toBeVisible()
+  await expect(inspector).toContainText('rel-orders-publishes-order-created')
+  await expect(page.getByTestId('inspector-relationship-bundle')).toBeVisible()
+
+  // Escape clears the typed selection while the canvas remains the focused
+  // interaction surface, so the next keyboard action has a stable target.
+  await page.keyboard.press('Escape')
+  await expect(page).not.toHaveURL(/relationship=/)
+})
+
 test('2 · the self run keeps 28 model components apart from its open proposal at initial depth', async ({
   page,
 }) => {

--- a/frontend/src/canvas/ArchitectureAccessibility.test.tsx
+++ b/frontend/src/canvas/ArchitectureAccessibility.test.tsx
@@ -247,6 +247,40 @@ describe('accessible architecture graph — every node arrives named', () => {
 
 describe('accessible architecture graph — selection by keyboard alone', () => {
   it(
+    'selects a single relationship with Enter and preserves edge focus',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderGraph()
+      await waitForCanvas()
+
+      const edge = document.querySelector<HTMLElement>(
+        '.react-flow__edge[data-id="rel:platform.api.http.router~>platform.core.orders"]',
+      )
+      expect(edge).not.toBeNull()
+      edge?.focus()
+      await user.keyboard('{Enter}')
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ relationship: 'r-01' }),
+      )
+      expect(await screen.findByTestId('inspector-relationship-context')).toHaveAttribute(
+        'data-relationship-id',
+        'r-01',
+      )
+      await waitFor(() => {
+        expect(edge).toHaveAttribute('aria-current', 'true')
+        expect(nodeElement('platform.api.http.router')).toHaveAttribute(
+          'aria-current',
+          'true',
+        )
+        expect(nodeElement('platform.core.orders')).toHaveAttribute('aria-current', 'true')
+      })
+      expect(document.activeElement).toBe(edge)
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
     'selects with Enter, writes the URL and hands the component to the inspector',
     async () => {
       const user = userEvent.setup()

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -218,6 +218,36 @@ describe('architecture canvas — colour-independent relationship kinds', () => 
 
 describe('architecture canvas — edge bundling stays resolvable', () => {
   it(
+    'selects a single relationship from its line in the overview',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCanvas()
+      const canvas = await waitForCanvas()
+
+      // The initial fit intentionally stays readable. Explicitly fitting the
+      // whole model gives this test the actual overview interaction state.
+      await user.click(screen.getByTestId('canvas-fit-view'))
+      await waitFor(() => expect(canvas).toHaveAttribute('data-detail-level', 'overview'))
+
+      // Individual labels stay hidden at overview so the graph does not become
+      // a wall of long reported values. The line itself remains the hit target.
+      expect(screen.queryByTestId('edge-label-r-01')).not.toBeInTheDocument()
+      await user.click(
+        screen.getByTestId('edge-path-rel:platform.api.http.router~>platform.core.orders'),
+      )
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ relationship: 'r-01' }),
+      )
+      expect(await screen.findByTestId('inspector-relationship-context')).toHaveAttribute(
+        'data-relationship-id',
+        'r-01',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
     'bundles the three NATS topics and makes each of them reachable by clicking',
     async () => {
       const user = userEvent.setup()
@@ -274,6 +304,116 @@ describe('architecture canvas — edge bundling stays resolvable', () => {
       await user.click(screen.getByTestId('edge-label-r-06'))
 
       expect(useUiStore.getState().selectedRelationshipId).toBe('r-06')
+      await waitFor(() => {
+        expect(screen.getByTestId('edge-path-r-06')).not.toHaveClass('opacity-25')
+        expect(screen.getByTestId('edge-path-r-05')).toHaveClass('opacity-25')
+        expect(screen.getByTestId('edge-path-r-07')).toHaveClass('opacity-25')
+        expect(screen.getByTestId('edge-label-r-06')).not.toHaveClass('opacity-25')
+        expect(screen.getByTestId('edge-label-r-05')).toHaveClass('opacity-25')
+        expect(screen.getByTestId('edge-label-r-06')).toHaveAttribute('aria-current', 'true')
+        expect(screen.getByTestId('edge-label-r-05')).not.toHaveAttribute('aria-current')
+      })
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'writes an individual relationship selection to the URL and inspector',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCanvas()
+      await waitForCanvas()
+
+      await user.click(await screen.findByTestId(`edge-bundle-${BUNDLE_EDGE_ID}`))
+      await user.click(screen.getByTestId('edge-label-r-06'))
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ relationship: 'r-06' }),
+      )
+      expect(await screen.findByTestId('inspector-relationship-context')).toHaveAttribute(
+        'data-relationship-id',
+        'r-06',
+      )
+      expect(screen.getByTestId('inspector-relationship-bundle')).toHaveTextContent(
+        'NATS · orders.cancelled',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'restores a relationship selection from a deep link without selecting a component',
+    async () => {
+      const { router } = renderCanvas(`${WORKSPACE_URL}?relationship=r-06`)
+      await waitForCanvas()
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ relationship: 'r-06' }),
+      )
+      expect(await screen.findByTestId('inspector-relationship-context')).toBeInTheDocument()
+      expect(useUiStore.getState().selectedComponentId).toBeNull()
+      expect(useUiStore.getState().selectedRelationshipId).toBe('r-06')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'keeps the canvas undimmed for a valid-looking but missing relationship id',
+    async () => {
+      const { router } = renderCanvas(`${WORKSPACE_URL}?relationship=not-in-snapshot`)
+      await waitForCanvas()
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({
+          relationship: 'not-in-snapshot',
+        }),
+      )
+      expect(await screen.findByTestId('inspector-relationship-context')).toHaveTextContent(
+        'nicht im aktuellen Architektur-Snapshot',
+      )
+      expect(
+        screen.getByTestId('edge-path-rel:platform.api.http.router~>platform.core.orders'),
+      ).not.toHaveClass('opacity-25')
+      expect(screen.getByTestId('canvas-node-platform.db')).not.toHaveAttribute(
+        'data-relationship-selected',
+        'true',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'does not resurrect a stale store relationship when the URL has no selection',
+    async () => {
+      useUiStore.getState().setSelectedRelationshipId('r-06')
+      const { router } = renderCanvas()
+      await waitForCanvas()
+
+      expect(router.state.location.search).toEqual({})
+      expect(
+        screen.getByTestId('edge-path-rel:platform.api.http.router~>platform.core.orders'),
+      ).not.toHaveClass('opacity-25')
+      expect(
+        screen.getByTestId('edge-path-rel:platform.core.orders~>platform.bus'),
+      ).not.toHaveClass('opacity-25')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'clears a selected relationship when Escape is pressed on the folded bundle control',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCanvas(`${WORKSPACE_URL}?relationship=r-06`)
+      await waitForCanvas()
+
+      const bundle = await screen.findByTestId(`edge-bundle-${BUNDLE_EDGE_ID}`)
+      act(() => bundle.focus())
+      await user.keyboard('{Escape}')
+
+      await waitFor(() => expect(router.state.location.search).toEqual({}))
+      expect(useUiStore.getState().selectedRelationshipId).toBeNull()
+      expect(document.activeElement).toBe(bundle)
     },
     CANVAS_TIMEOUT,
   )

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -161,6 +161,34 @@ describe('architecture canvas — rendering', () => {
     },
     CANVAS_TIMEOUT,
   )
+
+  it(
+    'keeps a nested edge label above its own SVG hit path',
+    async () => {
+      renderCanvas()
+      await waitForCanvas()
+
+      const label = await screen.findByTestId(`edge-bundle-${BUNDLE_EDGE_ID}`)
+      const edgeGroup = document.querySelector<SVGGElement>(
+        `.react-flow__edge[data-id="${BUNDLE_EDGE_ID}"]`,
+      )
+      const edgeSvg = edgeGroup?.closest('svg')
+      const renderer = document.querySelector<HTMLElement>(
+        '.react-flow__edgelabel-renderer',
+      )
+
+      expect(edgeSvg).not.toBeNull()
+      expect(renderer).not.toBeNull()
+      // The portal stays unstacked. The label itself carries the contextual
+      // z-index, so a deeper parent chain cannot put its transparent SVG hit
+      // path in front of the button.
+      expect(renderer).not.toHaveStyle({ zIndex: '1' })
+      expect(Number(label.style.zIndex)).toBeGreaterThan(
+        Number(edgeSvg?.style.zIndex ?? 0),
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
 })
 
 describe('architecture canvas — colour-independent relationship kinds', () => {

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -291,6 +291,9 @@ describe('architecture canvas — edge bundling stays resolvable', () => {
 
       // Unfolding it is an interaction on the canvas, available at any zoom.
       await user.click(bundle)
+      // Opening a bundle is a disclosure action, not an implicit selection of
+      // whichever relationship happens to be first in its list.
+      expect(useUiStore.getState().selectedRelationshipId).toBeNull()
 
       // Every single topic is now individually addressable, labelled with its
       // own channel — the bundle was a rendering, never a merge.

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -10,6 +10,7 @@ import {
   useReactFlow,
   useStore,
   useStoreApi,
+  type EdgeMouseHandler,
   type NodeMouseHandler,
   type OnNodeDrag,
   type Viewport,
@@ -30,7 +31,7 @@ import { useTranslation } from 'react-i18next'
 
 import '@xyflow/react/dist/style.css'
 
-import type { ComponentId, ProjectId } from '@/api/types'
+import type { ComponentId, Identifier, ProjectId } from '@/api/types'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useUiStore } from '@/state/uiStore'
@@ -132,9 +133,11 @@ export interface ArchitectureCanvasProps {
   projectId: ProjectId
   model: ArchitectureModel
   selectedComponentId?: ComponentId | undefined
+  selectedRelationshipId?: Identifier | null | undefined
   onSelectComponent: (componentId: ComponentId | null) => void
   orientation: GraphOrientation
   onOrientationChange: (orientation: GraphOrientation) => void
+  onSelectRelationship?: (relationshipId: Identifier | null) => void
   /** Reports the counts the canvas actually draws to the pane header. */
   onMetricsChange?: (metrics: ArchitectureCanvasMetrics) => void
 }
@@ -160,10 +163,12 @@ function ArchitectureCanvasInner({
   projectId,
   model,
   selectedComponentId,
+  selectedRelationshipId,
   onSelectComponent,
   orientation,
   onOrientationChange,
   onMetricsChange,
+  onSelectRelationship,
 }: ArchitectureCanvasProps) {
   const { t } = useTranslation('canvas')
   // The words *and* the counted nouns the accessible names are built from —
@@ -174,6 +179,17 @@ function ArchitectureCanvasInner({
   const setCollapsedComponentIds = useUiStore((state) => state.setCollapsedComponentIds)
   const setComponentCollapsed = useUiStore((state) => state.setComponentCollapsed)
 
+  const relationshipRevealIds = useMemo(() => {
+    if (!selectedRelationshipId) return [] as ComponentId[]
+    const relationship = [
+      ...model.relationships,
+      ...(model.overlay?.extraRelationships ?? []).map((entry) => entry.relationship),
+    ].find((entry) => entry.relationshipId === selectedRelationshipId)
+    return relationship
+      ? [relationship.sourceComponentId, relationship.targetComponentId]
+      : []
+  }, [model, selectedRelationshipId])
+
   const graph = useArchitectureGraph(model, {
     collapsedComponentIds,
     // A deep link is a statement about *what to look at*. Opening the
@@ -182,6 +198,7 @@ function ArchitectureCanvasInner({
     // policy is untouched by it.
     revealComponentId: selectedComponentId ?? null,
     orientation,
+    revealComponentIds: relationshipRevealIds,
   })
   const flow = useReactFlow()
   const storeApi = useStoreApi()
@@ -195,8 +212,32 @@ function ArchitectureCanvasInner({
   const setMinimapVisible = useUiStore((state) => state.setMinimapVisible)
   const clearExpandedEdges = useUiStore((state) => state.clearExpandedEdges)
   const toggleEdgeExpanded = useUiStore((state) => state.toggleEdgeExpanded)
-  const selectedRelationshipId = useUiStore((state) => state.selectedRelationshipId)
-  const setSelectedRelationshipId = useUiStore((state) => state.setSelectedRelationshipId)
+  const storedSelectedRelationshipId = useUiStore((state) => state.selectedRelationshipId)
+  const setStoredSelectedRelationshipId = useUiStore(
+    (state) => state.setSelectedRelationshipId,
+  )
+  // Workspace selection is URL-backed. The store fallback keeps the canvas
+  // useful in isolated renders while the URL effect is catching up.
+  const activeSelectedRelationshipId = onSelectRelationship
+    ? (selectedRelationshipId !== undefined ? selectedRelationshipId : null)
+    : (selectedRelationshipId !== undefined
+      ? selectedRelationshipId
+      : storedSelectedRelationshipId)
+
+  // A syntactically valid URL id may still be absent from this snapshot (or
+  // point at a dangling relationship that projection cannot draw). Keep that
+  // useful not-found inspector state, but never treat it as a visual selection:
+  // otherwise every rendered edge would be dimmed with nothing to highlight.
+  const visualSelectedRelationshipId = useMemo(() => {
+    if (activeSelectedRelationshipId === null) return null
+    return graph.edges.some((edge) =>
+      edge.data?.relationships.some(
+        (relationship) => relationship.relationshipId === activeSelectedRelationshipId,
+      ),
+    )
+      ? activeSelectedRelationshipId
+      : null
+  }, [activeSelectedRelationshipId, graph.edges])
 
   // The size of the drawing surface, as React Flow measures it. Subscribing
   // here is what lets the initial fit wait for the three panes to settle
@@ -231,12 +272,38 @@ function ArchitectureCanvasInner({
   // names describe exactly the boxes that are drawn — a component behind a
   // closed container is not a tab stop and is not named as one.
   const nodes = useMemo(
-    () =>
-      withNodeAccessibility(
-        applyTemporaryPositions(graph.nodes, nodePositions, selectedComponentId ?? null),
-        voice,
-      ),
-    [graph.nodes, nodePositions, selectedComponentId, voice],
+    () => {
+      const relatedNodeIds = new Set(
+        visualSelectedRelationshipId === null
+          ? []
+          : graph.edges.flatMap((edge) =>
+              edge.data?.relationships.some(
+                (relationship) =>
+                  relationship.relationshipId === visualSelectedRelationshipId,
+              )
+                ? [edge.source, edge.target]
+                : [],
+            ),
+      )
+      const positioned = applyTemporaryPositions(
+        graph.nodes,
+        nodePositions,
+        selectedComponentId ?? null,
+      ).map((node) =>
+        relatedNodeIds.has(node.id)
+          ? { ...node, data: { ...node.data, relationshipSelected: true } }
+          : node,
+      )
+      return withNodeAccessibility(positioned, voice)
+    },
+    [
+      graph.edges,
+      graph.nodes,
+      nodePositions,
+      selectedComponentId,
+      visualSelectedRelationshipId,
+      voice,
+    ],
   )
 
   /**
@@ -435,14 +502,66 @@ function ArchitectureCanvasInner({
       if (!edge.data) return edge
       return { ...edge, data: { ...edge.data, ...(route ? { route } : {}) } }
     })
-    return withEdgeAccessibility(routed, nodeNames, voice)
-  }, [graph.edges, graph.routes, nodePositions, nodeNames, voice])
+    return withEdgeAccessibility(
+      routed,
+      nodeNames,
+      voice,
+      visualSelectedRelationshipId,
+    ).map((edge) => ({
+      ...edge,
+      ...(edge.data
+        ? {
+            data: {
+              ...edge.data,
+              selectedRelationshipId: visualSelectedRelationshipId,
+              onSelectRelationship:
+                onSelectRelationship ?? setStoredSelectedRelationshipId,
+            },
+          }
+        : {}),
+    }))
+  }, [
+    graph.edges,
+    graph.routes,
+    nodePositions,
+    nodeNames,
+    onSelectRelationship,
+    setStoredSelectedRelationshipId,
+    visualSelectedRelationshipId,
+    voice,
+  ])
 
   const onNodeClick = useCallback<NodeMouseHandler>(
     (_event, node) => {
       onSelectComponent(node.id === selectedComponentId ? null : node.id)
     },
     [onSelectComponent, selectedComponentId],
+  )
+
+  /**
+   * The path is the hit target in overview, where an individual relationship
+   * deliberately has no label. Bundles remain a disclosure action: the path
+   * opens them, while their expanded labels select one member at a time.
+   */
+  const onEdgeClick = useCallback<EdgeMouseHandler<ArchitectureEdge>>(
+    (_event, edge) => {
+      const relationships = edge.data?.relationships ?? []
+      if (relationships.length > 1) {
+        toggleEdgeExpanded(edge.id)
+        return
+      }
+      const only = relationships[0]
+      if (!only) return
+      ;(onSelectRelationship ?? setStoredSelectedRelationshipId)(
+        only.relationshipId === visualSelectedRelationshipId ? null : only.relationshipId,
+      )
+    },
+    [
+      onSelectRelationship,
+      setStoredSelectedRelationshipId,
+      toggleEdgeExpanded,
+      visualSelectedRelationshipId,
+    ],
   )
 
   // Temporary, local, never persisted and never sent anywhere.
@@ -535,12 +654,12 @@ function ArchitectureCanvasInner({
       const edgeId = edgeElement.getAttribute('data-id')
       if (edgeId === null) return
       if (!ACTIVATION_KEYS.has(event.key) && event.key !== 'Escape') return
-      if (event.key === 'Escape' && selectedRelationshipId === null) return
+      if (event.key === 'Escape' && activeSelectedRelationshipId === null) return
 
       event.preventDefault()
       event.stopPropagation()
       if (event.key === 'Escape') {
-        setSelectedRelationshipId(null)
+        ;(onSelectRelationship ?? setStoredSelectedRelationshipId)(null)
         return
       }
       const edge = edges.find((candidate) => candidate.id === edgeId)
@@ -551,16 +670,17 @@ function ArchitectureCanvasInner({
       }
       const only = relationships[0]
       if (!only) return
-      setSelectedRelationshipId(
-        only.relationshipId === selectedRelationshipId ? null : only.relationshipId,
+      ;(onSelectRelationship ?? setStoredSelectedRelationshipId)(
+        only.relationshipId === activeSelectedRelationshipId ? null : only.relationshipId,
       )
     },
     [
       edges,
       onSelectComponent,
       selectedComponentId,
-      selectedRelationshipId,
-      setSelectedRelationshipId,
+      activeSelectedRelationshipId,
+      onSelectRelationship,
+      setStoredSelectedRelationshipId,
       toggleEdgeExpanded,
     ],
   )
@@ -685,6 +805,7 @@ function ArchitectureCanvasInner({
           minZoom={MIN_ZOOM}
           maxZoom={MAX_ZOOM}
           onNodeClick={onNodeClick}
+          onEdgeClick={onEdgeClick}
           onNodeDragStop={onNodeDragStop}
           onMoveStart={onMoveStart}
           onMove={onMove}

--- a/frontend/src/canvas/ChangeOverlays.test.tsx
+++ b/frontend/src/canvas/ChangeOverlays.test.tsx
@@ -724,6 +724,12 @@ describe('live change overlays — relationship metrics stay current', () => {
           '8 gemeldete Beziehungen · 7 Verbindungen dargestellt',
         ),
       )
+
+      const mark = screen.getByTestId('overlay-mark-relationship-r-10')
+      expect(mark).toHaveAttribute('data-work-state', 'planned')
+      // The state badge is explanatory only. It must remain visible and
+      // accessible without intercepting the edge's selection/bundle hit area.
+      expect(mark.parentElement).toHaveClass('pointer-events-none')
     },
     CANVAS_TIMEOUT,
   )

--- a/frontend/src/canvas/ComponentNode.tsx
+++ b/frontend/src/canvas/ComponentNode.tsx
@@ -218,7 +218,7 @@ export const ComponentNode = memo(function ComponentNode({
 }: NodeProps<ArchitectureNode>) {
   const { t } = useTranslation('canvas')
   const level = useDetailLevel()
-  const { component, overlay, applied } = data
+  const { component, overlay, applied, relationshipSelected } = data
   const kind = componentKindStyle(component.kind)
   const Icon = kind.icon
   const technology = technologyParts(component.technology)
@@ -235,12 +235,14 @@ export const ComponentNode = memo(function ComponentNode({
         'hover:border-muted-foreground/60',
         box.className,
         selected && 'ring-ring border-ring/70 ring-2',
+        relationshipSelected && !selected && 'ring-ring/60 border-ring/60 ring-1',
       )}
       style={box.style}
       data-testid={`canvas-node-${component.componentId}`}
       data-component-id={component.componentId}
       data-detail-level={level}
       data-selected={selected ? 'true' : 'false'}
+      data-relationship-selected={relationshipSelected ? 'true' : 'false'}
       {...box.attributes}
     >
       <div className="flex items-start gap-1.5">
@@ -272,8 +274,15 @@ export const CompoundNode = memo(function CompoundNode({
   const { t } = useTranslation('canvas')
   const { t: tCommon } = useTranslation('common')
   const level = useDetailLevel()
-  const { component, childCount, overlay, applied, collapsed, hiddenDescendantCount } =
-    data
+  const {
+    component,
+    childCount,
+    overlay,
+    applied,
+    collapsed,
+    hiddenDescendantCount,
+    relationshipSelected,
+  } = data
   const kind = componentKindStyle(component.kind)
   const Icon = kind.icon
   const technology = technologyParts(component.technology)
@@ -292,6 +301,7 @@ export const CompoundNode = memo(function CompoundNode({
           'bg-card/95 shadow-[4px_4px_0_-1px_var(--card),4px_4px_0_var(--border)]',
         box.className,
         selected && 'ring-ring border-ring/70 ring-2',
+        relationshipSelected && !selected && 'ring-ring/60 border-ring/60 ring-1',
       )}
       style={box.style}
       data-testid={`canvas-node-${component.componentId}`}
@@ -299,6 +309,7 @@ export const CompoundNode = memo(function CompoundNode({
       data-detail-level={level}
       data-compound="true"
       data-selected={selected ? 'true' : 'false'}
+      data-relationship-selected={relationshipSelected ? 'true' : 'false'}
       {...(collapsed
         ? {
             'data-collapsed': 'true',

--- a/frontend/src/canvas/RelationshipEdge.tsx
+++ b/frontend/src/canvas/RelationshipEdge.tsx
@@ -1,6 +1,6 @@
 import { EdgeLabelRenderer, type EdgeProps } from '@xyflow/react'
 import type { TFunction } from 'i18next'
-import { memo, type ReactNode } from 'react'
+import { memo, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { Relationship } from '@/api/types'
@@ -17,6 +17,7 @@ import {
   fanRoute,
   pointAtRatio,
   roundedPolylinePath,
+  selfLoopRoute,
 } from './edgeGeometry'
 import type { LayoutPoint } from './elkLayout'
 import { resolveRelationships, type ArchitectureEdge } from './graphProjection'
@@ -25,6 +26,7 @@ import {
   RELATIONSHIP_KIND_STYLE_BY_ID,
   markerUrl,
   reported,
+  shortRelationshipDiscriminator,
 } from './relationshipKinds'
 import { useDetailLevel } from './useDetailLevel'
 
@@ -39,8 +41,9 @@ import { useDetailLevel } from './useDetailLevel'
  * * folded (low zoom, default): one line plus a badge with the count, and the
  *   kinds it contains,
  * * unfolded (high zoom, or after a click on the badge): one line per
- *   relationship, each labelled with what identifies it — the topic name for a
- *   NATS topic, the operation for a call.
+ *   relationship, each labelled with a bounded identifier — the topic name for
+ *   a NATS topic, the operation for a call. Full reported text stays on the
+ *   title, focus state, selection and relationship inspector.
  *
  * That is what makes the bundling reversible: no zoom level and no interaction
  * can make a single reported topic unreachable.
@@ -56,6 +59,8 @@ interface EdgeRouteProps {
   kind?: string
   /** Reported work state of this line, if any. */
   overlay?: ChangeOverlay | null
+  /** Dim lines unrelated to the selected relationship. */
+  dimmed?: boolean
 }
 
 /**
@@ -77,6 +82,7 @@ function EdgeRoute({
   testId,
   kind,
   overlay = null,
+  dimmed = false,
 }: EdgeRouteProps) {
   const path = roundedPolylinePath(points)
   if (path === '') return null
@@ -92,6 +98,7 @@ function EdgeRoute({
           stroke="transparent"
           strokeWidth={14}
           className="react-flow__edge-interaction"
+          opacity={dimmed ? 0.25 : 1}
         />
       )}
       {state && (
@@ -108,6 +115,7 @@ function EdgeRoute({
           data-testid={testId ? `${testId}-state` : undefined}
           data-work-state={overlay?.state}
           data-state-dasharray={state.strokeDasharray}
+          opacity={dimmed ? 0.25 : 1}
         />
       )}
       <path
@@ -121,6 +129,7 @@ function EdgeRoute({
         className={cn(
           'transition-colors duration-150',
           !state && (emphasised ? 'text-ring' : 'text-muted-foreground'),
+          dimmed && 'opacity-25',
         )}
         data-testid={testId}
         data-relationship-kind={kind}
@@ -140,6 +149,10 @@ function EdgeBadge({
   title,
   testId,
   emphasised,
+  detail,
+  shortDetail,
+  dimmed = false,
+  onEscape,
 }: {
   point: LayoutPoint
   children: ReactNode
@@ -147,13 +160,23 @@ function EdgeBadge({
   title?: string
   testId?: string
   emphasised?: boolean
+  /** Full reported discriminator, shown on focus and selection. */
+  detail?: string | null
+  /** Bounded discriminator shown in the normal canvas state. */
+  shortDetail?: string | null
+  /** Dim badges on edges unrelated to the active selection. */
+  dimmed?: boolean
+  /** Clear selection without moving keyboard focus away from the badge. */
+  onEscape?: () => void
 }) {
+  const [focused, setFocused] = useState(false)
   const className = cn(
     'pointer-events-auto rounded-sm border px-1 py-px font-mono text-[10px] leading-tight whitespace-nowrap',
     emphasised
       ? 'border-ring/70 bg-popover text-foreground'
       : 'border-border bg-popover/95 text-muted-foreground',
     onClick && 'hover:border-muted-foreground cursor-pointer',
+    dimmed && 'opacity-25',
   )
   const style = {
     position: 'absolute' as const,
@@ -166,11 +189,33 @@ function EdgeBadge({
         type="button"
         style={style}
         className={className}
-        onClick={onClick}
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation()
+          onClick()
+        }}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        onKeyDown={(event) => {
+          if (event.key !== 'Escape' || !onEscape) return
+          event.preventDefault()
+          event.stopPropagation()
+          onEscape()
+        }}
         title={title}
+        aria-current={emphasised ? 'true' : undefined}
+        aria-label={
+          detail
+            ? `${children} · ${detail}`
+            : typeof children === 'string'
+              ? children
+              : undefined
+        }
         data-testid={testId}
       >
         {children}
+        {detail &&
+          (focused || emphasised ? ` · ${detail}` : shortDetail ? ` · ${shortDetail}` : '')}
       </button>
     )
   }
@@ -191,9 +236,11 @@ function EdgeBadge({
 function EdgeOverlayMark({
   point,
   overlay,
+  dimmed = false,
 }: {
   point: LayoutPoint
   overlay: ChangeOverlay
+  dimmed?: boolean
 }) {
   return (
     <span
@@ -201,7 +248,7 @@ function EdgeOverlayMark({
         position: 'absolute',
         transform: `translate(-50%, -50%) translate(${point.x}px, ${point.y}px)`,
       }}
-      className="pointer-events-auto"
+      className={cn('pointer-events-auto', dimmed && 'opacity-25')}
     >
       <ChangeOverlayMark overlay={overlay} />
     </span>
@@ -220,10 +267,17 @@ export const RelationshipEdge = memo(function RelationshipEdge({
   const level = useDetailLevel()
   const expandedEdgeIds = useUiStore((state) => state.expandedEdgeIds)
   const toggleEdgeExpanded = useUiStore((state) => state.toggleEdgeExpanded)
-  const selectedRelationshipId = useUiStore((state) => state.selectedRelationshipId)
+  const storedSelectedRelationshipId = useUiStore((state) => state.selectedRelationshipId)
   const setSelectedRelationshipId = useUiStore((state) => state.setSelectedRelationshipId)
 
   if (!data) return null
+
+  // `null` is an explicit URL-backed deselection. Only an omitted field means
+  // that an isolated edge render should consult the local store.
+  const selectedRelationshipId =
+    data.selectedRelationshipId !== undefined
+      ? data.selectedRelationshipId
+      : storedSelectedRelationshipId
 
   const resolved = resolveRelationships(data.relationships)
   if (resolved.length === 0) return null
@@ -232,15 +286,24 @@ export const RelationshipEdge = memo(function RelationshipEdge({
   // and a plain orthogonal fallback between the two handles takes over.
   const route: LayoutPoint[] =
     data.route ??
-    fallbackRoute(
-      { x: sourceX, y: sourceY },
-      { x: targetX, y: targetY },
-      data.fallbackOrientation,
-    )
+    (data.sourceComponentId === data.targetComponentId
+      ? selfLoopRoute({ x: sourceX, y: sourceY }, { x: targetX, y: targetY })
+      : fallbackRoute(
+          { x: sourceX, y: sourceY },
+          { x: targetX, y: targetY },
+          data.fallbackOrientation,
+        ))
 
   const overlays = data.overlays ?? {}
   const bundled = resolved.length > 1
   const unfolded = bundled && (unfoldsBundles(level) || expandedEdgeIds.includes(id))
+  const selectedEntry = resolved.find(
+    (entry) => entry.relationship.relationshipId === selectedRelationshipId,
+  )
+  const related = selectedEntry !== undefined
+  const hasSelection = selectedRelationshipId !== null
+  const dimmed = hasSelection && !related
+  const selectRelationship = data.onSelectRelationship ?? setSelectedRelationshipId
 
   if (!bundled || !unfolded) {
     const edgeOverlay = dominantOverlay(Object.values(overlays))
@@ -248,8 +311,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
     const onlyKind = kinds.length === 1 ? kinds[0] : null
     const style = onlyKind ? RELATIONSHIP_KIND_STYLE_BY_ID[onlyKind] : null
     const single = resolved.length === 1 ? (resolved[0] ?? null) : null
-    const emphasised =
-      single !== null && single.relationship.relationshipId === selectedRelationshipId
+    const emphasised = related
 
     const badgePoint = pointAtRatio(route, 0.5)
     const badgeLabel = bundled
@@ -261,7 +323,10 @@ export const RelationshipEdge = memo(function RelationshipEdge({
                 .join('/')
         }`
       : (style?.abbreviation ?? '')
-    const discriminator = single?.discriminator
+    const discriminator = single?.discriminator ?? null
+    const shortDiscriminator = single
+      ? shortRelationshipDiscriminator(single.relationship)
+      : null
 
     return (
       <>
@@ -273,11 +338,16 @@ export const RelationshipEdge = memo(function RelationshipEdge({
           interactive
           testId={`edge-path-${id}`}
           overlay={edgeOverlay}
+          dimmed={dimmed}
           {...(onlyKind ? { kind: onlyKind } : {})}
         />
         <EdgeLabelRenderer>
           {edgeOverlay && (
-            <EdgeOverlayMark point={pointAtRatio(route, 0.74)} overlay={edgeOverlay} />
+            <EdgeOverlayMark
+              point={pointAtRatio(route, 0.74)}
+              overlay={edgeOverlay}
+              dimmed={dimmed}
+            />
           )}
           {bundled ? (
             <EdgeBadge
@@ -289,6 +359,8 @@ export const RelationshipEdge = memo(function RelationshipEdge({
                 relationships: resolved.map((entry) => entry.displayName).join(', '),
               })}
               testId={`edge-bundle-${id}`}
+              dimmed={dimmed}
+              {...(hasSelection ? { onEscape: () => selectRelationship(null) } : {})}
             >
               {badgeLabel} ▸
             </EdgeBadge>
@@ -298,16 +370,21 @@ export const RelationshipEdge = memo(function RelationshipEdge({
               <EdgeBadge
                 point={badgePoint}
                 onClick={() =>
-                  setSelectedRelationshipId(
+                  selectRelationship(
                     emphasised ? null : single.relationship.relationshipId,
                   )
                 }
                 title={relationshipTitle(single.relationship, t)}
                 testId={`edge-label-${single.relationship.relationshipId}`}
                 {...(emphasised ? { emphasised: true } : {})}
+                detail={discriminator}
+                shortDetail={shortDiscriminator}
+                dimmed={dimmed}
+                {...(selectedRelationshipId !== null
+                  ? { onEscape: () => selectRelationship(null) }
+                  : {})}
               >
                 {badgeLabel}
-                {discriminator ? ` · ${discriminator}` : ''}
               </EdgeBadge>
             )
           )}
@@ -327,6 +404,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
           data.fallbackOrientation,
         )
         const emphasised = entry.relationship.relationshipId === selectedRelationshipId
+        const entryDimmed = hasSelection && !emphasised
         return (
           <EdgeRoute
             key={entry.relationship.relationshipId}
@@ -338,6 +416,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
             testId={`edge-path-${entry.relationship.relationshipId}`}
             kind={entry.relationship.kind}
             overlay={overlays[entry.relationship.relationshipId] ?? null}
+            dimmed={entryDimmed}
           />
         )
       })}
@@ -355,6 +434,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
               key={`state-${entry.relationship.relationshipId}`}
               point={pointAtRatio(fanned, 0.74)}
               overlay={overlay}
+              dimmed={hasSelection && entry.relationship.relationshipId !== selectedRelationshipId}
             />
           )
         })}
@@ -366,21 +446,29 @@ export const RelationshipEdge = memo(function RelationshipEdge({
             data.fallbackOrientation,
           )
           const emphasised = entry.relationship.relationshipId === selectedRelationshipId
+          const entryDimmed = hasSelection && !emphasised
+          const discriminator = entry.discriminator
+          const shortDiscriminator = shortRelationshipDiscriminator(entry.relationship)
           return (
             <EdgeBadge
               key={entry.relationship.relationshipId}
               point={pointAtRatio(fanned, 0.5)}
               onClick={() =>
-                setSelectedRelationshipId(
+                selectRelationship(
                   emphasised ? null : entry.relationship.relationshipId,
                 )
               }
               title={relationshipTitle(entry.relationship, t)}
               testId={`edge-label-${entry.relationship.relationshipId}`}
               {...(emphasised ? { emphasised: true } : {})}
+              detail={discriminator}
+              shortDetail={shortDiscriminator}
+              dimmed={entryDimmed}
+              {...(hasSelection
+                ? { onEscape: () => selectRelationship(null) }
+                : {})}
             >
               {style?.abbreviation ?? entry.relationship.kind}
-              {entry.discriminator ? ` · ${entry.discriminator}` : ''}
             </EdgeBadge>
           )
         })}
@@ -389,6 +477,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
           onClick={() => toggleEdgeExpanded(id)}
           title={t('edge.bundleCollapse')}
           testId={`edge-collapse-${id}`}
+          dimmed={dimmed}
         >
           ▾ {resolved.length}
         </EdgeBadge>

--- a/frontend/src/canvas/RelationshipEdge.tsx
+++ b/frontend/src/canvas/RelationshipEdge.tsx
@@ -1,4 +1,4 @@
-import { EdgeLabelRenderer, type EdgeProps } from '@xyflow/react'
+import { EdgeLabelRenderer, useStore, type EdgeProps } from '@xyflow/react'
 import type { TFunction } from 'i18next'
 import { memo, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -145,6 +145,7 @@ function EdgeRoute({
 function EdgeBadge({
   point,
   children,
+  zIndex,
   onClick,
   title,
   testId,
@@ -156,6 +157,8 @@ function EdgeBadge({
 }: {
   point: LayoutPoint
   children: ReactNode
+  /** Keep this label above the SVG edge that owns it, including sub-flows. */
+  zIndex: number
   onClick?: () => void
   title?: string
   testId?: string
@@ -180,6 +183,7 @@ function EdgeBadge({
   )
   const style = {
     position: 'absolute' as const,
+    zIndex,
     transform: `translate(-50%, -50%) translate(${point.x}px, ${point.y}px)`,
   }
 
@@ -236,19 +240,23 @@ function EdgeBadge({
 function EdgeOverlayMark({
   point,
   overlay,
+  zIndex,
   dimmed = false,
 }: {
   point: LayoutPoint
   overlay: ChangeOverlay
+  /** Keep the visual mark above its edge without intercepting edge input. */
+  zIndex: number
   dimmed?: boolean
 }) {
   return (
     <span
       style={{
         position: 'absolute',
+        zIndex,
         transform: `translate(-50%, -50%) translate(${point.x}px, ${point.y}px)`,
       }}
-      className={cn('pointer-events-auto', dimmed && 'opacity-25')}
+      className={cn('pointer-events-none', dimmed && 'opacity-25')}
     >
       <ChangeOverlayMark overlay={overlay} />
     </span>
@@ -258,12 +266,45 @@ function EdgeOverlayMark({
 export const RelationshipEdge = memo(function RelationshipEdge({
   id,
   data,
+  selected,
+  source,
+  target,
   sourceX,
   sourceY,
   targetX,
   targetY,
 }: EdgeProps<ArchitectureEdge>) {
   const { t } = useTranslation('canvas')
+  /**
+   * React Flow puts all HTML edge labels in one portal, while each edge SVG
+   * receives a z-index derived from its parent-node nesting. Give each label
+   * the same contextual z-index plus one so a deep sub-flow cannot cover its
+   * own interactive label. Keeping this on the label itself leaves the portal
+   * unstacked, so nodes and React Flow controls retain their normal layering.
+   */
+  const edgeLabelZIndex = useStore((state) => {
+    const edge = state.edgeLookup.get(id)
+    const sourceNode = state.nodeLookup.get(source)
+    const targetNode = state.nodeLookup.get(target)
+
+    if (!sourceNode || !targetNode) return 1
+    if (state.zIndexMode === 'manual') return (edge?.zIndex ?? 0) + 1
+
+    const edgeZ =
+      (state.elevateEdgesOnSelect && (edge?.selected ?? selected)
+        ? (edge?.zIndex ?? 0) + 1000
+        : edge?.zIndex ?? 0)
+    const sourceZ =
+      sourceNode.parentId || (state.elevateEdgesOnSelect && sourceNode.selected)
+        ? sourceNode.internals.z
+        : 0
+    const targetZ =
+      targetNode.parentId || (state.elevateEdgesOnSelect && targetNode.selected)
+        ? targetNode.internals.z
+        : 0
+
+    return edgeZ + Math.max(sourceZ, targetZ) + 1
+  })
   const level = useDetailLevel()
   const expandedEdgeIds = useUiStore((state) => state.expandedEdgeIds)
   const toggleEdgeExpanded = useUiStore((state) => state.toggleEdgeExpanded)
@@ -346,12 +387,14 @@ export const RelationshipEdge = memo(function RelationshipEdge({
             <EdgeOverlayMark
               point={pointAtRatio(route, 0.74)}
               overlay={edgeOverlay}
+              zIndex={edgeLabelZIndex}
               dimmed={dimmed}
             />
           )}
           {bundled ? (
             <EdgeBadge
               point={badgePoint}
+              zIndex={edgeLabelZIndex}
               onClick={() => toggleEdgeExpanded(id)}
               // The display names are built from reported values; they are
               // interpolated into our sentence, never rewritten.
@@ -369,6 +412,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
             single && (
               <EdgeBadge
                 point={badgePoint}
+                zIndex={edgeLabelZIndex}
                 onClick={() =>
                   selectRelationship(
                     emphasised ? null : single.relationship.relationshipId,
@@ -434,6 +478,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
               key={`state-${entry.relationship.relationshipId}`}
               point={pointAtRatio(fanned, 0.74)}
               overlay={overlay}
+              zIndex={edgeLabelZIndex}
               dimmed={hasSelection && entry.relationship.relationshipId !== selectedRelationshipId}
             />
           )
@@ -453,6 +498,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
             <EdgeBadge
               key={entry.relationship.relationshipId}
               point={pointAtRatio(fanned, 0.5)}
+              zIndex={edgeLabelZIndex}
               onClick={() =>
                 selectRelationship(
                   emphasised ? null : entry.relationship.relationshipId,
@@ -474,6 +520,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
         })}
         <EdgeBadge
           point={pointAtRatio(route, 0.12)}
+          zIndex={edgeLabelZIndex}
           onClick={() => toggleEdgeExpanded(id)}
           title={t('edge.bundleCollapse')}
           testId={`edge-collapse-${id}`}

--- a/frontend/src/canvas/canvasAccessibility.test.ts
+++ b/frontend/src/canvas/canvasAccessibility.test.ts
@@ -311,6 +311,27 @@ describe('canvas accessibility — the full node name', () => {
     ).not.toHaveProperty('aria-current')
   })
 
+  it('marks both endpoint rings as current for a relationship selection', () => {
+    const nodes = withNodeAccessibility(
+      nodesOf(NESTED_COMPONENTS).map((node) =>
+        node.id === 'platform.api.http.router' || node.id === 'platform.core.orders'
+          ? { ...node, data: { ...node.data, relationshipSelected: true } }
+          : node,
+      ),
+      voice,
+    )
+
+    expect(
+      nodes.find((node) => node.id === 'platform.api.http.router')?.domAttributes,
+    ).toHaveProperty('aria-current', true)
+    expect(
+      nodes.find((node) => node.id === 'platform.core.orders')?.domAttributes,
+    ).toHaveProperty('aria-current', true)
+    expect(nodes.find((node) => node.id === 'platform.db')?.domAttributes).not.toHaveProperty(
+      'aria-current',
+    )
+  })
+
   it('names the disclosure control after the container it opens', () => {
     expect(nodeDisclosureLabel('API Gateway', false, voice, 3)).toBe(
       'Aufklappen: API Gateway (3 Komponenten)',

--- a/frontend/src/canvas/canvasAccessibility.ts
+++ b/frontend/src/canvas/canvasAccessibility.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from 'i18next'
 
-import type { ComponentId } from '@/api/types'
+import type { ComponentId, Identifier } from '@/api/types'
 import type { CanvasKey } from '@/i18n'
 
 import { dominantOverlay, overlayLabel, type ChangeOverlay } from './changeOverlays'
@@ -391,7 +391,9 @@ export function withNodeAccessibility(
       'aria-roledescription': node.data.isCompound
         ? voice.t(CANVAS_A11Y_KEYS.containerRoleDescription)
         : voice.t(CANVAS_A11Y_KEYS.componentRoleDescription),
-      ...(node.selected === true ? { 'aria-current': true as const } : {}),
+      ...(node.selected === true || node.data.relationshipSelected === true
+        ? { 'aria-current': true as const }
+        : {}),
     },
   }))
 }
@@ -474,12 +476,19 @@ export function withEdgeAccessibility(
   edges: readonly ArchitectureEdge[],
   names: ReadonlyMap<ComponentId, string>,
   voice: CanvasVoice,
+  selectedRelationshipId: Identifier | null = null,
 ): ArchitectureEdge[] {
   return edges.map((edge) => ({
     ...edge,
     ariaLabel: edgeAccessibleName(edge, names, voice),
     domAttributes: {
       'aria-roledescription': voice.t(CANVAS_A11Y_KEYS.relationshipRoleDescription),
+      ...(selectedRelationshipId !== null &&
+      edge.data?.relationships.some(
+        (relationship) => relationship.relationshipId === selectedRelationshipId,
+      )
+        ? { 'aria-current': true as const }
+        : {}),
     },
   }))
 }

--- a/frontend/src/canvas/edgeGeometry.test.ts
+++ b/frontend/src/canvas/edgeGeometry.test.ts
@@ -7,6 +7,7 @@ import {
   fanRoute,
   pointAtRatio,
   roundedPolylinePath,
+  selfLoopRoute,
 } from './edgeGeometry'
 
 describe('edge geometry', () => {
@@ -125,5 +126,12 @@ describe('edge geometry', () => {
       const current = fanned[index] as { x: number; y: number }
       expect(previous.x === current.x || previous.y === current.y).toBe(true)
     }
+  })
+
+  it('routes a self relationship around the node for a safe label point', () => {
+    const route = selfLoopRoute({ x: 228, y: 48 }, { x: 0, y: 48 })
+    expect(route[0]).toEqual({ x: 228, y: 48 })
+    expect(route[route.length - 1]).toEqual({ x: 0, y: 48 })
+    expect(pointAtRatio(route)).toEqual({ x: 114, y: -24 })
   })
 })

--- a/frontend/src/canvas/edgeGeometry.ts
+++ b/frontend/src/canvas/edgeGeometry.ts
@@ -183,6 +183,33 @@ export function fallbackRoute(
   ]
 }
 
+/**
+ * A visible loop for a relationship whose source and target are the same node.
+ * ELK intentionally omits self references from its layout input; drawing the
+ * fallback as a straight line would put its label inside the node. The loop
+ * leaves both handles where React Flow expects them and reserves a clear label
+ * point above the box.
+ */
+export function selfLoopRoute(
+  source: LayoutPoint,
+  target: LayoutPoint,
+): LayoutPoint[] {
+  // Keep the badge's roughly 10 px height clear of a 96 px leaf box: the
+  // handle is centred at y=48, so a centre 72 px above it leaves a visible
+  // gap instead of touching the node's top border.
+  const top = Math.min(source.y, target.y) - 72
+  const right = Math.max(source.x, target.x) + 48
+  const left = Math.min(source.x, target.x) - 48
+  return [
+    source,
+    { x: right, y: source.y },
+    { x: right, y: top },
+    { x: left, y: top },
+    { x: left, y: target.y },
+    target,
+  ]
+}
+
 function round(value: number): number {
   return Math.round(value * 100) / 100
 }

--- a/frontend/src/canvas/graphProjection.ts
+++ b/frontend/src/canvas/graphProjection.ts
@@ -131,6 +131,8 @@ export interface ComponentNodeData extends Record<string, unknown> {
    * agent is doing to it.
    */
   overlayRolledUp?: boolean
+  /** `true` when this visible endpoint belongs to the selected relationship. */
+  relationshipSelected?: boolean
 }
 
 export type ArchitectureNode = Node<ComponentNodeData, ArchitectureNodeType>
@@ -158,6 +160,10 @@ export interface RelationshipEdgeData extends Record<string, unknown> {
    * the edge then falls back to a plain orthogonal connection.
    */
   route?: { x: number; y: number }[]
+  /** URL-backed selection callback injected by the canvas shell. */
+  onSelectRelationship?: (relationshipId: Identifier | null) => void
+  /** URL-backed relationship selection used for immediate rendering. */
+  selectedRelationshipId?: Identifier | null
 }
 
 export type ArchitectureEdge = Edge<RelationshipEdgeData, typeof RELATIONSHIP_EDGE_TYPE>

--- a/frontend/src/canvas/relationshipKinds.test.ts
+++ b/frontend/src/canvas/relationshipKinds.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Relationship } from '@/api/types'
+
+import {
+  MAX_CANVAS_RELATIONSHIP_ADJUNCT_LENGTH,
+  shortRelationshipDiscriminator,
+} from './relationshipKinds'
+
+const relationship = (overrides: Partial<Relationship>): Relationship => ({
+  relationshipId: 'relationship-test',
+  sourceComponentId: 'source',
+  targetComponentId: 'target',
+  kind: 'http',
+  ...overrides,
+})
+
+describe('normal relationship labels', () => {
+  it('keeps a short discriminator as a bounded adjunct', () => {
+    const value = 'GET /orders'
+    expect(shortRelationshipDiscriminator(relationship({ operation: value }))).toBe(value)
+  })
+
+  it('hides a long discriminator from the normal canvas label', () => {
+    const value = 'GET /orders/{orderId}/fulfilment/with-a-long-report-name'
+    expect(value.length).toBeGreaterThan(MAX_CANVAS_RELATIONSHIP_ADJUNCT_LENGTH)
+    expect(shortRelationshipDiscriminator(relationship({ operation: value }))).toBeNull()
+  })
+})

--- a/frontend/src/canvas/relationshipKinds.ts
+++ b/frontend/src/canvas/relationshipKinds.ts
@@ -172,3 +172,21 @@ export function relationshipDisplayName(relationship: Relationship): string {
   const discriminator = relationshipDiscriminator(relationship)
   return discriminator ? `${abbreviation} · ${discriminator}` : abbreviation
 }
+
+/** Maximum adjunct length that can sit on a route without becoming a paragraph. */
+export const MAX_CANVAS_RELATIONSHIP_ADJUNCT_LENGTH = 24
+
+/**
+ * Returns the bounded detail allowed on a normal canvas label. Long reported
+ * discriminators remain available through the label title, focus state and
+ * relationship inspector instead of colliding with nodes and other edges.
+ */
+export function shortRelationshipDiscriminator(
+  relationship: Relationship,
+): string | null {
+  const discriminator = relationshipDiscriminator(relationship)
+  return discriminator !== null &&
+    discriminator.length <= MAX_CANVAS_RELATIONSHIP_ADJUNCT_LENGTH
+    ? discriminator
+    : null
+}

--- a/frontend/src/canvas/useArchitectureGraph.ts
+++ b/frontend/src/canvas/useArchitectureGraph.ts
@@ -200,13 +200,17 @@ export function useArchitectureGraph(
   return useMemo<ArchitectureGraph>(() => {
     const isEmpty = visible.nodes.length === 0
     const isCurrent = laidOut !== null && laidOut.signature === layoutSignature
+    // Keep the last layout's positions while ELK solves the new structure, but
+    // do not keep its data. A removal can turn an applied node into a ghost
+    // without changing its id, and the overlay state must be visible in that
+    // first render (the metrics below are already derived from `visible`).
+    // `withCurrentData` intentionally matches only ids that are still drawn;
+    // genuinely new proposal nodes wait for their first valid layout.
+    const nodesWithCurrentData =
+      laidOut === null ? [] : withCurrentData(laidOut.nodes, visible.nodes)
 
     return {
-      nodes: isEmpty
-        ? []
-        : isCurrent
-          ? withCurrentData(laidOut.nodes, visible.nodes)
-          : (laidOut?.nodes ?? []),
+      nodes: isEmpty ? [] : nodesWithCurrentData,
       edges: visible.edges,
       routes: isCurrent ? laidOut.routes : {},
       diagnostics: projection.diagnostics ?? EMPTY_DIAGNOSTICS,

--- a/frontend/src/canvas/useArchitectureGraph.ts
+++ b/frontend/src/canvas/useArchitectureGraph.ts
@@ -82,6 +82,8 @@ export interface ArchitectureGraphOptions {
   revealComponentId?: ComponentId | null
   /** Direction used for handles, ports and the ELK layered layout. */
   orientation?: GraphOrientation
+  /** Components at both ends of a relationship deep link that must be visible. */
+  revealComponentIds?: readonly ComponentId[]
 }
 
 /**
@@ -109,6 +111,7 @@ export function useArchitectureGraph(
     revealComponentId,
     orientation = DEFAULT_GRAPH_ORIENTATION,
   } = options
+  const { revealComponentIds = [] } = options
   const reportedRelationshipCount = model?.relationships.length ?? 0
 
   const projection = useMemo(
@@ -125,13 +128,19 @@ export function useArchitectureGraph(
    */
   const collapsedKey = useMemo(() => {
     const base = collapsedComponentIds ?? initialCollapsedIds(projection.nodes)
-    if (!revealComponentId) return [...base].sort().join(KEY_SEPARATOR)
-    const revealed = new Set(ancestorIds(projection.nodes, revealComponentId))
+    const revealIds = [
+      ...(revealComponentId ? [revealComponentId] : []),
+      ...revealComponentIds,
+    ]
+    if (revealIds.length === 0) return [...base].sort().join(KEY_SEPARATOR)
+    const revealed = new Set(
+      revealIds.flatMap((componentId) => ancestorIds(projection.nodes, componentId)),
+    )
     return base
       .filter((componentId) => !revealed.has(componentId))
       .sort()
       .join(KEY_SEPARATOR)
-  }, [collapsedComponentIds, revealComponentId, projection.nodes])
+  }, [collapsedComponentIds, revealComponentId, revealComponentIds, projection.nodes])
 
   const visible = useMemo(
     () =>

--- a/frontend/src/components/workspace/ArchitecturePane.tsx
+++ b/frontend/src/components/workspace/ArchitecturePane.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useArchitecture } from '@/api/queries'
-import type { ComponentId, ProjectId } from '@/api/types'
+import type { ComponentId, Identifier, ProjectId } from '@/api/types'
 import {
   ArchitectureCanvas,
   type ArchitectureCanvasMetrics,
@@ -21,10 +21,14 @@ export interface ArchitecturePaneProps {
   projectId: ProjectId
   /** Selection from the URL; the canvas mirrors it, it never owns it. */
   selectedComponentId?: ComponentId | undefined
+  /** Selection from the URL for one reported relationship. */
+  selectedRelationshipId?: Identifier | null | undefined
   /** Writes the selection back into the `component` search param. */
   onSelectComponent: (componentId: ComponentId | null) => void
   orientation: GraphOrientation
   onOrientationChange: (orientation: GraphOrientation) => void
+  /** Writes a relationship selection to the `relationship` search param. */
+  onSelectRelationship: (relationshipId: Identifier | null) => void
 }
 
 /**
@@ -39,9 +43,11 @@ export interface ArchitecturePaneProps {
 export function ArchitecturePane({
   projectId,
   selectedComponentId,
+  selectedRelationshipId,
   onSelectComponent,
   orientation,
   onOrientationChange,
+  onSelectRelationship,
 }: ArchitecturePaneProps) {
   const { t } = useTranslation('canvas')
   const architecture = useArchitecture(projectId)
@@ -186,9 +192,11 @@ export function ArchitecturePane({
             projectId={projectId}
             model={model}
             selectedComponentId={selectedComponentId}
+            selectedRelationshipId={selectedRelationshipId}
             onSelectComponent={onSelectComponent}
             orientation={orientation}
             onOrientationChange={onOrientationChange}
+            onSelectRelationship={onSelectRelationship}
             onMetricsChange={onCanvasMetricsChange}
           />
         )}

--- a/frontend/src/components/workspace/InspectorPane.test.tsx
+++ b/frontend/src/components/workspace/InspectorPane.test.tsx
@@ -131,6 +131,16 @@ const APPLIED_RELATIONSHIP = appliedRelationship({
   operation: 'GET',
   label: 'Read orders',
 })
+const BUNDLED_APPLIED_RELATIONSHIP = appliedRelationship({
+  relationshipId: 'relationship-applied-sibling',
+  sourceComponentId: RELATIONSHIP_SOURCE_ID,
+  targetComponentId: RELATIONSHIP_TARGET_ID,
+  kind: 'nats_topic',
+  protocol: 'NATS',
+  operation: 'subscribe',
+  channel: 'orders.cancelled',
+  label: 'Read cancellations',
+})
 const RELATIONSHIP_ARCHITECTURE: ArchitectureResponse = {
   projectPosition: 42,
   components: [
@@ -281,6 +291,25 @@ describe('inspector — component selection', () => {
 })
 
 describe('inspector — relationship selection', () => {
+  it('shows the applied bundle members for parallel relationships', async () => {
+    const server = inspectorServer({
+      architecture: {
+        ...RELATIONSHIP_ARCHITECTURE,
+        relationships: [APPLIED_RELATIONSHIP, BUNDLED_APPLIED_RELATIONSHIP],
+      },
+    })
+    renderApp(
+      `${WORKSPACE_URL}?relationship=${APPLIED_RELATIONSHIP.relationshipId}`,
+      { fetchImpl: server.fetchImpl },
+    )
+
+    const bundle = await screen.findByTestId('inspector-relationship-bundle')
+    expect(bundle.querySelectorAll('li')).toHaveLength(2)
+    expect(bundle).toHaveTextContent('HTTP · GET')
+    expect(bundle).toHaveTextContent('NATS · orders.cancelled')
+    expect(bundle.querySelector('[data-selected="true"]')).toHaveTextContent('HTTP · GET')
+  })
+
   it('keeps applied and proposed edges separate when their endpoints match', async () => {
     const server = inspectorServer({ architecture: RELATIONSHIP_ARCHITECTURE })
     renderApp(

--- a/frontend/src/components/workspace/InspectorPane.test.tsx
+++ b/frontend/src/components/workspace/InspectorPane.test.tsx
@@ -3,9 +3,11 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 
 import type {
+  ArchitectureResponse,
   ComponentHistoryResponse,
   ComponentInspectorResponse,
   ReportedDiff,
+  Relationship,
 } from '@/api/types'
 import { applyLiveEvent } from '@/api/useLiveStream'
 import {
@@ -29,6 +31,11 @@ import {
   inspectorPage,
   reportedDiff,
 } from '@/test/inspectorFixtures'
+import {
+  activeChange,
+  appliedComponent,
+  appliedRelationship,
+} from '@/test/architectureFixtures'
 import { renderApp } from '@/test/renderApp'
 
 const WORKSPACE_URL = `/projects/${PROJECT_ID}/runs/${RUN_ID}`
@@ -48,6 +55,7 @@ const CANVAS_TIMEOUT = 15_000
 function inspectorServer(options: {
   pages?: ComponentInspectorResponse[]
   history?: ComponentHistoryResponse[]
+  architecture?: ArchitectureResponse
 } = {}) {
   const state = {
     pages: options.pages ?? [inspectorPage()],
@@ -55,7 +63,7 @@ function inspectorServer(options: {
   }
 
   const base = createFakeFetch({
-    [ARCHITECTURE_PATH]: {
+    [ARCHITECTURE_PATH]: options.architecture ?? {
       projectPosition: 42,
       components: [component({ componentId: COMPONENT_ID, name: 'Tax', kind: 'module' })],
       relationships: [],
@@ -99,6 +107,54 @@ function inspectorServer(options: {
       state.pages = pages
     },
   }
+}
+
+const RELATIONSHIP_SOURCE_ID = 'relationship-source'
+const RELATIONSHIP_TARGET_ID = 'relationship-target'
+const APPLIED_RELATIONSHIP_ID = 'relationship-applied'
+const PROPOSED_RELATIONSHIP: Relationship = {
+  relationshipId: 'relationship-proposed',
+  sourceComponentId: RELATIONSHIP_SOURCE_ID,
+  targetComponentId: RELATIONSHIP_TARGET_ID,
+  kind: 'nats_topic',
+  protocol: 'NATS',
+  operation: 'publish',
+  channel: 'orders.created',
+  label: '',
+}
+const APPLIED_RELATIONSHIP = appliedRelationship({
+  relationshipId: APPLIED_RELATIONSHIP_ID,
+  sourceComponentId: RELATIONSHIP_SOURCE_ID,
+  targetComponentId: RELATIONSHIP_TARGET_ID,
+  kind: 'http',
+  protocol: 'HTTP',
+  operation: 'GET',
+  label: 'Read orders',
+})
+const RELATIONSHIP_ARCHITECTURE: ArchitectureResponse = {
+  projectPosition: 42,
+  components: [
+    appliedComponent({
+      componentId: RELATIONSHIP_SOURCE_ID,
+      name: 'Relationship source',
+      kind: 'service',
+      parentComponentId: null,
+    }),
+    appliedComponent({
+      componentId: RELATIONSHIP_TARGET_ID,
+      name: 'Relationship target',
+      kind: 'service',
+      parentComponentId: null,
+    }),
+  ],
+  relationships: [APPLIED_RELATIONSHIP],
+  activeChanges: [
+    activeChange({
+      targetKind: 'relationship',
+      targetId: PROPOSED_RELATIONSHIP.relationshipId,
+      snapshot: PROPOSED_RELATIONSHIP as unknown as Record<string, unknown>,
+    }),
+  ],
 }
 
 function jsonResponse(body: unknown): Response {
@@ -221,6 +277,23 @@ describe('inspector — component selection', () => {
     expect(await screen.findByText('Keine Komponente ausgewählt')).toBeInTheDocument()
     expect(screen.queryByTestId('inspector-context')).not.toBeInTheDocument()
     expect(screen.queryByRole('tablist', { name: 'Belegquelle' })).not.toBeInTheDocument()
+  })
+})
+
+describe('inspector — relationship selection', () => {
+  it('keeps applied and proposed edges separate when their endpoints match', async () => {
+    const server = inspectorServer({ architecture: RELATIONSHIP_ARCHITECTURE })
+    renderApp(
+      `${WORKSPACE_URL}?relationship=${PROPOSED_RELATIONSHIP.relationshipId}`,
+      { fetchImpl: server.fetchImpl },
+    )
+
+    const context = await screen.findByTestId('inspector-relationship-context')
+    await waitFor(() => {
+      expect(context).toHaveAttribute('data-relationship-id', PROPOSED_RELATIONSHIP.relationshipId)
+      expect(context).toHaveTextContent(`NATS · ${PROPOSED_RELATIONSHIP.channel}`)
+    })
+    expect(screen.queryByTestId('inspector-relationship-bundle')).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/workspace/InspectorPane.tsx
+++ b/frontend/src/components/workspace/InspectorPane.tsx
@@ -2,11 +2,14 @@ import { Maximize2, Minimize2 } from 'lucide-react'
 import { useMemo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useComponentHistory, useComponentInspector } from '@/api/queries'
-import type { ComponentId, ProjectId, RunId } from '@/api/types'
+import { useArchitecture, useComponentHistory, useComponentInspector } from '@/api/queries'
+import type { AppliedRelationship, ComponentId, Identifier, ProjectId, Relationship, RunId } from '@/api/types'
+import { bundleEdgeId, overlayEdgeId } from '@/canvas/graphProjection'
+import { useChangeOverlays } from '@/canvas/useChangeOverlays'
 import { AsyncState, EmptyState } from '@/components/AsyncState'
 import { PaneHeader } from '@/components/workspace/PaneHeader'
 import { ComponentContextCard } from '@/components/workspace/inspector/ComponentContextCard'
+import { RelationshipContextCard } from '@/components/workspace/inspector/RelationshipContextCard'
 import { ComponentHistoryList } from '@/components/workspace/inspector/ComponentHistoryList'
 import { DiffGroupList } from '@/components/workspace/inspector/DiffGroupList'
 import { FeedbackList } from '@/components/workspace/inspector/FeedbackList'
@@ -27,6 +30,7 @@ export interface InspectorPaneProps {
   projectId: ProjectId
   runId: RunId
   componentId: ComponentId | undefined
+  relationshipId: Identifier | undefined
   focus: DeepFocusTarget | undefined
   historyMode: boolean
   onSetFocus: (target: DeepFocusTarget | undefined) => void
@@ -62,6 +66,7 @@ export function InspectorPane({
   projectId,
   runId,
   componentId,
+  relationshipId,
   focus,
   historyMode,
   onSetFocus,
@@ -70,8 +75,58 @@ export function InspectorPane({
   const { t } = useTranslation('inspector')
   const { t: tWorkspace } = useTranslation('workspace')
   const { t: tCommon } = useTranslation('common')
-  const inspector = useComponentInspector(projectId, componentId, runId)
-  const history = useComponentHistory(projectId, componentId, { enabled: historyMode })
+  const architecture = useArchitecture(projectId)
+  const overlay = useChangeOverlays(projectId, architecture.data)
+  const inspector = useComponentInspector(
+    projectId,
+    relationshipId ? undefined : componentId,
+    runId,
+  )
+  const history = useComponentHistory(projectId, relationshipId ? undefined : componentId, {
+    enabled: historyMode,
+  })
+
+  const selectedRelationship = useMemo<AppliedRelationship | Relationship | null>(() => {
+    if (!relationshipId) return null
+    const applied = architecture.data?.relationships.find(
+      (entry) => entry.relationshipId === relationshipId,
+    )
+    if (applied) return applied
+    return overlay.extraRelationships.find(
+      (entry) => entry.relationship.relationshipId === relationshipId,
+    )?.relationship ?? null
+  }, [architecture.data?.relationships, overlay.extraRelationships, relationshipId])
+  const relationshipBundle = useMemo(() => {
+    if (!selectedRelationship) return []
+    const appliedRelationshipIds = new Set(
+      architecture.data?.relationships.map((entry) => entry.relationshipId) ?? [],
+    )
+    const all = [
+      ...(architecture.data?.relationships ?? []),
+      ...overlay.extraRelationships.map((entry) => entry.relationship),
+    ]
+    const edgeIdOf = (entry: AppliedRelationship | Relationship) =>
+      appliedRelationshipIds.has(entry.relationshipId)
+        ? bundleEdgeId(entry.sourceComponentId, entry.targetComponentId)
+        : overlayEdgeId(entry.sourceComponentId, entry.targetComponentId)
+    const selectedEdgeId = edgeIdOf(selectedRelationship)
+    return all.filter(
+      (entry) => edgeIdOf(entry) === selectedEdgeId,
+    )
+  }, [architecture.data?.relationships, overlay.extraRelationships, selectedRelationship])
+  const componentNames = useMemo(
+    () =>
+      new Map([
+        ...(architecture.data?.components ?? []).map((entry) => [entry.componentId, entry.name] as const),
+        ...overlay.extraComponents.map((entry) => [entry.component.componentId, entry.component.name] as const),
+      ]),
+    [architecture.data?.components, overlay.extraComponents],
+  )
+  const selectedRelationshipOverlay = relationshipId
+    ? overlay.relationships.get(relationshipId) ??
+      overlay.extraRelationships.find((entry) => entry.relationship.relationshipId === relationshipId)
+        ?.overlay
+    : undefined
 
   const pages = useMemo(() => inspector.data?.pages ?? [], [inspector.data])
   // Every page repeats the complete, non-paged collections; only `diffs`
@@ -109,7 +164,9 @@ export function InspectorPane({
         subtitle={
           // The component's reported name — or, failing that, its reported id.
           // Only the "nothing is selected" case is the cockpit's own sentence.
-          head?.component?.name !== undefined ? (
+          relationshipId && selectedRelationship ? (
+            <ReportedText value={relationshipId} />
+          ) : head?.component?.name !== undefined ? (
             <ReportedText value={head.component.name} />
           ) : componentId !== undefined ? (
             <ReportedText value={componentId} />
@@ -142,7 +199,7 @@ export function InspectorPane({
         </div>
       )}
 
-      {componentId && (
+      {componentId && !relationshipId && (
         <div
           role="tablist"
           aria-label={t('source.label')}
@@ -174,7 +231,28 @@ export function InspectorPane({
         data-testid="inspector-scroll"
       >
         <div className="space-y-4 p-3">
-          {!componentId ? (
+          {relationshipId ? (
+            <RelationshipContextCard
+              relationshipId={relationshipId}
+              relationship={selectedRelationship}
+              sourceName={
+                selectedRelationship
+                  ? componentNames.get(selectedRelationship.sourceComponentId) ??
+                    selectedRelationship.sourceComponentId
+                  : ''
+              }
+              targetName={
+                selectedRelationship
+                  ? componentNames.get(selectedRelationship.targetComponentId) ??
+                    selectedRelationship.targetComponentId
+                  : ''
+              }
+              {...(selectedRelationshipOverlay
+                ? { overlay: selectedRelationshipOverlay }
+                : {})}
+              bundle={relationshipBundle}
+            />
+          ) : !componentId ? (
             <EmptyState title={t('empty.title')} description={t('empty.description')} />
           ) : (
             <AsyncState

--- a/frontend/src/components/workspace/inspector/RelationshipContextCard.tsx
+++ b/frontend/src/components/workspace/inspector/RelationshipContextCard.tsx
@@ -1,0 +1,157 @@
+import type { AppliedRelationship, Identifier, Relationship } from '@/api/types'
+import { Badge } from '@/components/ui/badge'
+import { ReportedText } from '@/i18n'
+import { useTranslation } from 'react-i18next'
+
+import {
+  CHANGE_OPERATION_LABEL_KEYS,
+  type ChangeOverlay,
+} from '@/canvas/changeOverlays'
+import { RELATIONSHIP_KIND_STYLE_BY_ID, relationshipDisplayName } from '@/canvas/relationshipKinds'
+import { WORK_STATE_BY_ID } from '@/state/workStates'
+
+export interface RelationshipContextCardProps {
+  relationshipId: Identifier
+  relationship: AppliedRelationship | Relationship | null
+  sourceName?: string
+  targetName?: string
+  overlay?: ChangeOverlay
+  bundle: readonly (AppliedRelationship | Relationship)[]
+}
+
+/** Full relationship context kept out of the route label. */
+export function RelationshipContextCard({
+  relationshipId,
+  relationship,
+  sourceName,
+  targetName,
+  overlay,
+  bundle,
+}: RelationshipContextCardProps) {
+  const { t } = useTranslation('inspector')
+  const { t: tCanvas } = useTranslation('canvas')
+  const style = relationship ? RELATIONSHIP_KIND_STYLE_BY_ID[relationship.kind] : null
+  const appliedByAgentId =
+    relationship && 'appliedByAgentId' in relationship
+      ? relationship.appliedByAgentId
+      : null
+
+  return (
+    <section
+      className="border-border space-y-2 rounded-md border p-2"
+      aria-label={t('relationship.label')}
+      data-testid="inspector-relationship-context"
+      data-relationship-id={relationshipId}
+    >
+      <div className="space-y-0.5">
+        <h3 className="truncate text-sm font-semibold">
+          {relationship ? (
+            <ReportedText value={relationshipDisplayName(relationship)} />
+          ) : (
+            <ReportedText value={relationshipId} />
+          )}
+        </h3>
+        <p className="text-muted-foreground truncate font-mono text-2xs">
+          <ReportedText value={relationshipId} />
+        </p>
+      </div>
+
+      {relationship ? (
+        <>
+          <div className="flex flex-wrap items-center gap-1">
+            <Badge variant="outline" className="text-2xs font-normal">
+              {style?.abbreviation ?? relationship.kind}
+            </Badge>
+            <Badge variant="secondary" className="text-2xs font-normal">
+              {style ? tCanvas(style.labelKey) : relationship.kind}
+            </Badge>
+          </div>
+
+          <dl className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs">
+            <Detail label={t('relationship.source')} value={sourceName ?? relationship.sourceComponentId} />
+            <Detail label={t('relationship.target')} value={targetName ?? relationship.targetComponentId} />
+            <Detail label={t('relationship.channel')} value={relationship.channel} />
+            <Detail label={t('relationship.operation')} value={relationship.operation} />
+            <Detail label={t('relationship.protocol')} value={relationship.protocol} />
+            <Detail label={t('relationship.reportedLabel')} value={relationship.label} />
+          </dl>
+
+          <section className="space-y-1" aria-label={t('relationship.changeLabel')}>
+            <h4 className="pane-heading">{t('relationship.changeLabel')}</h4>
+            {overlay ? (
+              <div className="space-y-1 text-xs" data-testid="relationship-change-state">
+                <div className="flex flex-wrap gap-1">
+                  <Badge variant="outline" className="text-2xs font-normal">
+                    {tCanvas(WORK_STATE_BY_ID[overlay.state].labelKey)}
+                  </Badge>
+                  {overlay.operation && (
+                    <Badge variant="secondary" className="text-2xs font-normal">
+                      {tCanvas(CHANGE_OPERATION_LABEL_KEYS[overlay.operation])}
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-muted-foreground">
+                  {t('relationship.agents', { count: overlay.agentIds.length })}
+                  {overlay.agentIds.length > 0 && (
+                    <>
+                      :{' '}
+                      {overlay.agentIds.map((agentId, index) => (
+                        <span key={agentId}>
+                          {index > 0 && ', '}
+                          <ReportedText value={agentId} />
+                        </span>
+                      ))}
+                    </>
+                  )}
+                </p>
+              </div>
+            ) : (
+              <>
+                <p className="text-muted-foreground text-xs">{t('relationship.noChange')}</p>
+                {appliedByAgentId && (
+                  <p className="text-muted-foreground text-xs" data-testid="relationship-reporting-agents">
+                    {t('relationship.reportedBy')}: <ReportedText value={appliedByAgentId} />
+                  </p>
+                )}
+              </>
+            )}
+          </section>
+
+          {bundle.length > 1 && (
+            <section className="space-y-1" aria-label={t('relationship.bundleLabel')} data-testid="inspector-relationship-bundle">
+              <h4 className="pane-heading">{t('relationship.bundleLabel')}</h4>
+              <ul className="space-y-1 text-xs">
+                {bundle.map((entry) => (
+                  <li
+                    key={entry.relationshipId}
+                    className={
+                      entry.relationshipId === relationshipId
+                        ? 'font-medium text-foreground break-words'
+                        : 'text-muted-foreground break-words'
+                    }
+                    data-selected={entry.relationshipId === relationshipId ? 'true' : 'false'}
+                  >
+                    <ReportedText value={relationshipDisplayName(entry)} />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </>
+      ) : (
+        <p className="text-muted-foreground text-xs">{t('relationship.notFound')}</p>
+      )}
+    </section>
+  )
+}
+
+function Detail({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 break-words" title={value ?? ''}>
+        {value && value.trim() !== '' ? <ReportedText value={value} /> : <span className="text-muted-foreground">—</span>}
+      </dd>
+    </>
+  )
+}

--- a/frontend/src/i18n/locales/de/canvas.json
+++ b/frontend/src/i18n/locales/de/canvas.json
@@ -61,7 +61,7 @@
     "protocol": "Protokoll: {{value}}"
   },
   "graph": {
-    "edgeInstructions": "Enter oder Leertaste wählt diese dargestellte Verbindung aus; bei einer Sammelkante klappt sie die enthaltenen gemeldeten Beziehungen auf und wieder zu. Escape hebt die Auswahl auf.",
+    "edgeInstructions": "Enter oder Leertaste öffnet eine Sammelkante oder wählt eine einzelne Beziehung und zeigt sie im Inspector; eine Sammelkante klappt nur ihre gemeldeten Beziehungen auf und wieder zu. Escape hebt die Auswahl auf.",
     "instructions": "Architekturgraph des Projekts. Mit der Tabulatortaste zwischen den Komponenten und den dargestellten Verbindungen wechseln. Enter oder Leertaste wählt die fokussierte Komponente aus und zeigt sie im Inspector; eine erneute Aktivierung hebt die Auswahl auf, Escape ebenfalls. Jede Komponente nennt ihren gemeldeten Namen, ihre Art, ob sie weitere Komponenten enthält, in welchem Container sie liegt und welchen Änderungsstatus ein Agent für sie gemeldet hat. Gemeldete Beziehungen können als eine gebündelte Verbindung dargestellt werden. Der Graph ist eine Beobachtung: das angewandte Architekturmodell lässt sich hier nicht bearbeiten.",
     "label": "Interaktiver Architekturgraph",
     "layouting": "Layout wird berechnet…",

--- a/frontend/src/i18n/locales/de/inspector.json
+++ b/frontend/src/i18n/locales/de/inspector.json
@@ -107,6 +107,21 @@
     "emptyTitle": "Keine Probleme gemeldet",
     "label": "Probleme"
   },
+  "relationship": {
+    "agents": "{{count, number}} meldende Agents",
+    "bundleLabel": "Gebündelte Beziehungen",
+    "changeLabel": "Änderungsstatus",
+    "channel": "Kanal",
+    "label": "Beziehungskontext",
+    "noChange": "Kein Änderungsstatus gemeldet.",
+    "notFound": "Diese Beziehung ist nicht im aktuellen Architektur-Snapshot enthalten.",
+    "operation": "Operation",
+    "protocol": "Protokoll",
+    "reportedBy": "Gemeldet von Agent",
+    "reportedLabel": "Gemeldetes Label",
+    "source": "Quelle",
+    "target": "Ziel"
+  },
   "risk": {
     "emptyDescription": "Für diese Komponente wurde in diesem Run kein risk.reported gemeldet.",
     "emptyTitle": "Keine Risiken gemeldet",

--- a/frontend/src/i18n/locales/en/canvas.json
+++ b/frontend/src/i18n/locales/en/canvas.json
@@ -61,7 +61,7 @@
     "protocol": "Protocol: {{value}}"
   },
   "graph": {
-    "edgeInstructions": "Enter or Space selects this rendered connection; on a bundled edge it unfolds and folds the reported relationships it contains. Escape clears the selection.",
+    "edgeInstructions": "Enter or Space opens a bundled connection or selects a single relationship and shows it in the inspector; a bundle only unfolds and folds its reported relationships. Escape clears the selection.",
     "instructions": "Architecture graph of the project. Use Tab to move between the components and the rendered connections. Enter or Space selects the focused component and shows it in the inspector; activating it again clears the selection, as does Escape. Every component names its reported name, its kind, whether it contains further components, which container it sits in, and what change status an agent reported for it. Reported relationships may be rendered as one bundled connection. The graph is an observation: the applied architecture model cannot be edited here.",
     "label": "Interactive architecture graph",
     "layouting": "Computing the layout…",

--- a/frontend/src/i18n/locales/en/inspector.json
+++ b/frontend/src/i18n/locales/en/inspector.json
@@ -107,6 +107,21 @@
     "emptyTitle": "No problems reported",
     "label": "Problems"
   },
+  "relationship": {
+    "agents": "{{count, number}} reporting agent(s)",
+    "bundleLabel": "Bundled relationships",
+    "changeLabel": "Change state",
+    "channel": "Channel",
+    "label": "Relationship context",
+    "noChange": "No change state reported.",
+    "notFound": "This relationship is not in the current architecture snapshot.",
+    "operation": "Operation",
+    "protocol": "Protocol",
+    "reportedBy": "Reported by agent",
+    "reportedLabel": "Reported label",
+    "source": "Source",
+    "target": "Target"
+  },
   "risk": {
     "emptyDescription": "For this component no risk.reported was reported in this run.",
     "emptyTitle": "No risks reported",

--- a/frontend/src/routes/pages/WorkspacePage.tsx
+++ b/frontend/src/routes/pages/WorkspacePage.tsx
@@ -37,6 +37,7 @@ export function WorkspacePage() {
   useLiveStream(projectId)
 
   const setSelectedComponentId = useUiStore((state) => state.setSelectedComponentId)
+  const setSelectedRelationshipId = useUiStore((state) => state.setSelectedRelationshipId)
   const enterDeepFocus = useUiStore((state) => state.enterDeepFocus)
   const exitDeepFocus = useUiStore((state) => state.exitDeepFocus)
 
@@ -45,6 +46,13 @@ export function WorkspacePage() {
   useEffect(() => {
     setSelectedComponentId(search.component ?? null)
   }, [search.component, setSelectedComponentId])
+
+  // Relationship selection follows the same URL -> local mirror as component
+  // selection. The URL remains authoritative, so a reload and a click expose
+  // the same inspector and canvas state.
+  useEffect(() => {
+    setSelectedRelationshipId(search.relationship ?? null)
+  }, [search.relationship, setSelectedRelationshipId])
 
   // URL -> deep-focus layout.
   useEffect(() => {
@@ -68,7 +76,25 @@ export function WorkspacePage() {
   const setSelectedComponent = useCallback(
     (componentId: string | null) => {
       void navigate({
-        search: (previous) => ({ ...previous, component: componentId ?? undefined }),
+        search: (previous) => ({
+          ...previous,
+          component: componentId ?? undefined,
+          relationship: undefined,
+        }),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
+
+  const setSelectedRelationship = useCallback(
+    (relationshipId: string | null) => {
+      void navigate({
+        search: (previous) => ({
+          ...previous,
+          relationship: relationshipId ?? undefined,
+          component: undefined,
+        }),
         replace: true,
       })
     },
@@ -114,9 +140,11 @@ export function WorkspacePage() {
           <ArchitecturePane
             projectId={projectId}
             selectedComponentId={search.component}
+            selectedRelationshipId={search.relationship}
             onSelectComponent={setSelectedComponent}
             orientation={search.layout ?? DEFAULT_GRAPH_ORIENTATION}
             onOrientationChange={setGraphOrientation}
+            onSelectRelationship={setSelectedRelationship}
           />
         }
         right={
@@ -124,6 +152,7 @@ export function WorkspacePage() {
             projectId={projectId}
             runId={runId}
             componentId={search.component}
+            relationshipId={search.relationship}
             focus={search.focus}
             historyMode={search.history === true}
             onSetFocus={setFocus}

--- a/frontend/src/routes/searchParams.test.ts
+++ b/frontend/src/routes/searchParams.test.ts
@@ -6,6 +6,7 @@ import { validateWorkspaceSearch, type WorkspaceSearch } from './searchParams'
 // `npm run typecheck` fails if either assertion stops holding.
 const validSearch: WorkspaceSearch = {
   component: 'shop-platform.orders.domain',
+  relationship: 'rel-orders-read',
   focus: 'feedback',
   history: true,
   layout: 'left-right',
@@ -48,6 +49,10 @@ describe('validateWorkspaceSearch', () => {
     // TanStack Router parses search values as JSON, so `?component=42` arrives
     // as a number even though the contract calls component ids strings.
     expect(validateWorkspaceSearch({ component: 42 })).toEqual({ component: '42' })
+  })
+
+  it('normalises a numeric relationship id back to a string', () => {
+    expect(validateWorkspaceSearch({ relationship: 42 })).toEqual({ relationship: '42' })
   })
 
   it('drops parameters the workspace does not know', () => {

--- a/frontend/src/routes/searchParams.ts
+++ b/frontend/src/routes/searchParams.ts
@@ -26,11 +26,19 @@ const componentIdSchema = z.preprocess(
   z.string().min(1).max(128),
 )
 
+/** `Identifier` per contract: max 128 characters, never empty. */
+const relationshipIdSchema = z.preprocess(
+  (value) => (typeof value === 'number' ? String(value) : value),
+  z.string().min(1).max(128),
+)
+
 export const workspaceSearchSchema = z.object({
   /** Selected component; drives the inspector. */
   component: componentIdSchema.optional().catch(undefined),
   /** Reading direction of the architecture graph. */
   layout: z.enum(GRAPH_ORIENTATIONS).optional().catch(undefined),
+  /** Selected reported relationship; drives the relationship inspector. */
+  relationship: relationshipIdSchema.optional().catch(undefined),
   /** Deep-focus target for large feedback or diff content. */
   focus: z.enum(DEEP_FOCUS_TARGETS).optional().catch(undefined),
   /** Show the component history instead of the current run. */


### PR DESCRIPTION
Closes #57

## Umgesetzt
- Beziehungslabels sind im Normalzustand begrenzt; vollständige Details stehen über Tooltip, Fokus, Auswahl und Inspector bereit.
- Relationship-Auswahl ist über ?relationship= reproduzierbar und im Inspector mit Quelle, Ziel, Metadaten, Änderungsstatus, Agents und Bundle-Inhalt sichtbar.
- Auswahl, Dimming, Bundle-Interaktion, Escape/Fokus und Screenreader-Semantik wurden ergänzt.
- Applied- und Overlay-Beziehungen bleiben auch bei gleichen Endpunkten getrennte Inspector-Bundles.

## Wichtige Entscheidung
Der Branch wurde nach dem Merge von #54 auf develop rebased; Graphausrichtung und Beziehungsselektion sind gemeinsam integriert und getestet.

## Tests
- Frontend: 486 Tests, Typecheck, Lint, Build, Contract-, Locale- und UI-String-Checks
- Integrationssuite: 58 Tests
- git diff --check und Merge-Markerprüfung

## Einschränkung
Lokale Browser-E2E wurde nicht ausgeführt, weil e2e/node_modules fehlt; die CI führt die vollständige Playwright-Suite aus.