### PR TITLE
Add accessible component search and canvas focus

### DIFF
--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -426,7 +426,7 @@ test('2 · arrow navigation exposes the active result and deep links keep jump e
   const input = page.getByTestId('canvas-component-search-input')
   await input.fill('service')
   const results = page.getByTestId('canvas-component-search-result')
-  await expect(results).toHaveCount(4)
+  await expect.poll(() => results.count()).toBeGreaterThanOrEqual(2)
   const firstResultId = await results.nth(0).getAttribute('id')
   const secondResultId = await results.nth(1).getAttribute('id')
   expect(firstResultId).not.toBeNull()

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -379,6 +379,97 @@ test('2 · selecting one relationship is a reproducible URL and inspector contex
   await expect(page).not.toHaveURL(/relationship=/)
 })
 
+test('2 · component search exposes an accessible result, opens its ancestors and syncs selection', async ({
+  page,
+}) => {
+  await openWorkspace(page)
+
+  await page.getByTestId('canvas-component-search').click()
+  const input = page.getByTestId('canvas-component-search-input')
+  await input.fill('pricing')
+
+  const result = page.getByTestId('canvas-component-search-result').first()
+  const resultId = await result.getAttribute('id')
+  expect(resultId).not.toBeNull()
+  await expect(result).toContainText('Pricing')
+  await expect(result).toContainText('Modul')
+  await expect(result).toContainText('Shop Platform / Orders Service / Orders Domain Layer')
+  await expect(input).toHaveAttribute('role', 'combobox')
+  await expect(input).toHaveAttribute('aria-expanded', 'true')
+  await expect(input).toHaveAttribute('aria-activedescendant', resultId!)
+
+  await result.click()
+  await expect(page).toHaveURL(/component=shop-platform.orders.domain.pricing/)
+  await expect(page.getByTestId('inspector-context')).toHaveAttribute(
+    'data-component-id',
+    'shop-platform.orders.domain.pricing',
+  )
+  await expect(page.getByTestId('canvas-node-shop-platform.orders.domain.pricing')).toBeVisible()
+  await expect(page.getByTestId('node-disclosure-shop-platform.orders.domain')).toHaveAttribute(
+    'aria-expanded',
+    'true',
+  )
+  // Opening a search path is a disclosure change plus an explicit pan, never a
+  // second automatic fit.
+  await expect(page.getByTestId('architecture-canvas')).toHaveAttribute(
+    'data-fit-view-count',
+    '1',
+  )
+})
+
+test('2 · arrow navigation exposes the active result and deep links keep jump explicit', async ({
+  page,
+}) => {
+  await openWorkspace(page)
+
+  await page.getByTestId('canvas-component-search').click()
+  const input = page.getByTestId('canvas-component-search-input')
+  await input.fill('service')
+  const results = page.getByTestId('canvas-component-search-result')
+  await expect(results).toHaveCount(4)
+  const firstResultId = await results.nth(0).getAttribute('id')
+  const secondResultId = await results.nth(1).getAttribute('id')
+  expect(firstResultId).not.toBeNull()
+  expect(secondResultId).not.toBeNull()
+  await expect(input).toHaveAttribute('aria-activedescendant', firstResultId!)
+
+  await input.press('ArrowDown')
+  await expect(input).toHaveAttribute('aria-activedescendant', secondResultId!)
+  await expect(results.nth(1)).toHaveAttribute('aria-selected', 'true')
+  await expect(results.nth(0)).toHaveAttribute('aria-selected', 'false')
+
+  // A deep link restores selection and disclosure but leaves camera movement to
+  // the explicit jump control when the selected node is offscreen.
+  await page.goto(
+    `/projects/${MAIN_PROJECT}/runs/${MAIN_RUN}?component=${encodeURIComponent(
+      'shop-platform.orders.domain.pricing',
+    )}`,
+  )
+  const canvas = page.getByTestId('architecture-canvas')
+  await expect(canvas).toHaveAttribute('data-layouting', 'false')
+  await expect(page.getByTestId('inspector-context')).toHaveAttribute(
+    'data-component-id',
+    'shop-platform.orders.domain.pricing',
+  )
+  const fitCount = await canvas.getAttribute('data-fit-view-count')
+  const pane = page.locator('.react-flow__pane')
+  const paneBox = await pane.boundingBox()
+  expect(paneBox).not.toBeNull()
+  await page.mouse.move(paneBox!.x + paneBox!.width / 2, paneBox!.y + paneBox!.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(paneBox!.x + paneBox!.width / 2 + 700, paneBox!.y + paneBox!.height / 2)
+  await page.mouse.up()
+
+  const jump = page.getByTestId('canvas-jump-to-selection')
+  await expect(jump).toBeVisible()
+  const before = await page.locator('.react-flow__viewport').getAttribute('style')
+  await jump.click()
+  await expect(canvas).toHaveAttribute('data-fit-view-count', fitCount ?? '1')
+  await expect
+    .poll(() => page.locator('.react-flow__viewport').getAttribute('style'))
+    .not.toBe(before)
+})
+
 test('2 · the self run keeps 28 model components apart from its open proposal at initial depth', async ({
   page,
 }) => {

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -503,6 +503,8 @@ test('2 · arrow navigation exposes the active result and deep links keep jump e
   })
   expect(pan).not.toBeNull()
   const viewportBeforePan = await page.locator('.react-flow__viewport').getAttribute('style')
+  const jump = page.getByTestId('canvas-jump-to-selection')
+  await expect(jump).not.toBeVisible()
   await page.mouse.move(pan!.start.x, pan!.start.y)
   await page.mouse.down()
   await page.mouse.move(pan!.end.x, pan!.end.y, { steps: 8 })
@@ -511,7 +513,6 @@ test('2 · arrow navigation exposes the active result and deep links keep jump e
     .poll(() => page.locator('.react-flow__viewport').getAttribute('style'))
     .not.toBe(viewportBeforePan)
 
-  const jump = page.getByTestId('canvas-jump-to-selection')
   await expect(jump).toBeVisible()
   const before = await page.locator('.react-flow__viewport').getAttribute('style')
   await jump.click()

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -455,10 +455,61 @@ test('2 · arrow navigation exposes the active result and deep links keep jump e
   const pane = page.locator('.react-flow__pane')
   const paneBox = await pane.boundingBox()
   expect(paneBox).not.toBeNull()
-  await page.mouse.move(paneBox!.x + paneBox!.width / 2, paneBox!.y + paneBox!.height / 2)
+
+  // The deep link may already be visible in the initial camera. Start on an
+  // actually empty part of the React Flow pane so this is a canvas pan, not a
+  // drag of whichever node happens to be under its centre at this layout.
+  const pan = await page.evaluate(() => {
+    const pane = document.querySelector<HTMLElement>('.react-flow__pane')
+    const selected = document.querySelector<HTMLElement>(
+      '[data-testid="canvas-node-shop-platform.orders.domain.pricing"]',
+    )
+    if (pane === null || selected === null) return null
+
+    const paneRect = pane.getBoundingClientRect()
+    const selectedRect = selected.getBoundingClientRect()
+    const moveRight =
+      selectedRect.left + selectedRect.width / 2 >= paneRect.left + paneRect.width / 2
+    const startColumns = moveRight
+      ? [paneRect.left + 32, paneRect.left + 64, paneRect.left + paneRect.width * 0.25]
+      : [paneRect.right - 32, paneRect.right - 64, paneRect.left + paneRect.width * 0.75]
+    const rows = [
+      paneRect.top + 32,
+      paneRect.top + paneRect.height * 0.25,
+      paneRect.top + paneRect.height * 0.5,
+      paneRect.top + paneRect.height * 0.75,
+      paneRect.bottom - 32,
+    ]
+    const start = startColumns
+      .flatMap((x) => rows.map((y) => ({ x, y })))
+      .find(({ x, y }) => {
+        const target = document.elementFromPoint(x, y)
+        return (
+          target?.closest('.react-flow__pane') === pane &&
+          target.closest(
+            '.react-flow__node, .react-flow__panel, .react-flow__controls, .react-flow__minimap, .react-flow__attribution',
+          ) === null
+        )
+      })
+    if (start === undefined) return null
+
+    return {
+      start,
+      end: {
+        x: moveRight ? paneRect.right - 16 : paneRect.left + 16,
+        y: start.y,
+      },
+    }
+  })
+  expect(pan).not.toBeNull()
+  const viewportBeforePan = await page.locator('.react-flow__viewport').getAttribute('style')
+  await page.mouse.move(pan!.start.x, pan!.start.y)
   await page.mouse.down()
-  await page.mouse.move(paneBox!.x + paneBox!.width / 2 + 700, paneBox!.y + paneBox!.height / 2)
+  await page.mouse.move(pan!.end.x, pan!.end.y, { steps: 8 })
   await page.mouse.up()
+  await expect
+    .poll(() => page.locator('.react-flow__viewport').getAttribute('style'))
+    .not.toBe(viewportBeforePan)
 
   const jump = page.getByTestId('canvas-jump-to-selection')
   await expect(jump).toBeVisible()

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -54,11 +54,18 @@ function architectureFetch(initial: ArchitectureResponse) {
  * with "Gesamtes Modell einpassen" — a real, reachable state, and the one these
  * tests have always described.
  */
-function renderCanvas(url = WORKSPACE_URL, initial = nestedArchitectureResponse) {
+function renderCanvas(
+  url = WORKSPACE_URL,
+  initial = nestedArchitectureResponse,
+  collapsedComponentIds?: string[],
+) {
   const architecture = architectureFetch(initial)
+  if (collapsedComponentIds !== undefined) {
+    useUiStore.getState().setCollapsedComponentIds(collapsedComponentIds)
+  }
   const app = renderApp(url, {
     fetchImpl: architecture.fetchImpl,
-    expandAllComponents: true,
+    expandAllComponents: collapsedComponentIds === undefined,
   })
   return { ...app, ...architecture }
 }
@@ -508,6 +515,75 @@ describe('architecture canvas — selection', () => {
   )
 
   it(
+    'announces the active search result while navigating with the arrow keys',
+    async () => {
+      const user = userEvent.setup()
+      renderCanvas()
+      await waitForCanvas()
+
+      await user.click(screen.getByTestId('canvas-component-search'))
+      const input = screen.getByTestId('canvas-component-search-input')
+      input.focus()
+      await user.keyboard('service')
+
+      const results = screen.getAllByTestId('canvas-component-search-result')
+      expect(input).toHaveAttribute('role', 'combobox')
+      expect(input).toHaveAttribute('aria-controls', 'canvas-component-search-results')
+      expect(input).toHaveAttribute('aria-expanded', 'true')
+      expect(input).toHaveAttribute(
+        'aria-activedescendant',
+        results[0]?.getAttribute('id') ?? '',
+      )
+      expect(results[0]).toHaveAttribute('aria-selected', 'true')
+      expect(results[1]).toHaveAttribute('aria-selected', 'false')
+
+      await user.keyboard('{ArrowDown}')
+      expect(input).toHaveAttribute(
+        'aria-activedescendant',
+        results[1]?.getAttribute('id') ?? '',
+      )
+      expect(results[0]).toHaveAttribute('aria-selected', 'false')
+      expect(results[1]).toHaveAttribute('aria-selected', 'true')
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'opens only target ancestors and keeps independent nested collapse state',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCanvas(WORKSPACE_URL, nestedArchitectureResponse, [
+        'platform.api',
+        'platform.api.http',
+        'platform.core',
+      ])
+      await waitForCanvas()
+
+      await user.click(screen.getByTestId('canvas-component-search'))
+      const input = screen.getByTestId('canvas-component-search-input')
+      input.focus()
+      await user.keyboard('gRPC Layer')
+      await user.click(screen.getByTestId('canvas-component-search-result'))
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ component: 'platform.api.grpc' }),
+      )
+      await waitForCanvas()
+
+      expect(screen.getByTestId('canvas-node-platform.api.grpc')).toBeVisible()
+      expect(screen.getByTestId('node-disclosure-platform.api.http')).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
+      expect(screen.getByTestId('node-disclosure-platform.core')).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
     'writes the clicked component into the `component` search parameter',
     async () => {
       const user = userEvent.setup()
@@ -581,6 +657,55 @@ describe('architecture canvas — selection', () => {
 })
 
 describe('architecture canvas — live updates never move the camera', () => {
+  it(
+    'does not replay a completed no-relayout search focus after a live re-layout',
+    async () => {
+      const user = userEvent.setup()
+      const { queryClient, publish } = renderCanvas()
+      const canvas = await waitForCanvas()
+
+      await user.click(screen.getByTestId('canvas-component-search'))
+      const input = screen.getByTestId('canvas-component-search-input')
+      input.focus()
+      await user.keyboard('platform.db')
+      await user.click(screen.getByTestId('canvas-component-search-result'))
+      await waitFor(() => expect(canvas).toHaveAttribute('data-layouting', 'false'))
+
+      const cameraAfterSearch = useUiStore.getState().camera
+      const transformAfterSearch = viewportTransform()
+      expect(canvas).toHaveAttribute('data-fit-view-count', '1')
+
+      // An equal refetch is deliberately quiet too; the pending search ref must
+      // not turn a data refresh into a second focus request.
+      await act(async () => {
+        await queryClient.refetchQueries({ queryKey: queryKeys.architecture(PROJECT_ID) })
+      })
+      expect(viewportTransform()).toBe(transformAfterSearch)
+      expect(useUiStore.getState().camera).toEqual(cameraAfterSearch)
+
+      publish(grownArchitectureResponse)
+      await act(async () => {
+        applyLiveEvent(
+          queryClient,
+          streamedEvent('architecture.snapshot_published', {
+            snapshotId: 'snapshot-after-search',
+            components: grownArchitectureResponse.components,
+            relationships: grownArchitectureResponse.relationships,
+          }),
+        )
+      })
+      await waitFor(
+        () => expect(canvas).toHaveAttribute('data-layouting', 'false'),
+        { timeout: CANVAS_TIMEOUT },
+      )
+
+      expect(viewportTransform()).toBe(transformAfterSearch)
+      expect(useUiStore.getState().camera).toEqual(cameraAfterSearch)
+      expect(canvas).toHaveAttribute('data-fit-view-count', '1')
+    },
+    CANVAS_TIMEOUT,
+  )
+
   it(
     'keeps zoom, pan and selection when the architecture is replaced live',
     async () => {

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -452,6 +452,62 @@ describe('architecture canvas — edge bundling stays resolvable', () => {
 
 describe('architecture canvas — selection', () => {
   it(
+    'searches name, kind, technology, tags and id, then selects the result',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCanvas()
+      await waitForCanvas()
+
+      await user.click(screen.getByTestId('canvas-component-search'))
+      const input = screen.getByTestId('canvas-component-search-input')
+      expect(
+        screen.getByText('Nach Name, Art, Technologie, Tag oder Komponenten-ID suchen.'),
+      ).toBeVisible()
+
+      input.focus()
+      await user.keyboard('routing')
+      const result = screen.getByTestId('canvas-component-search-result')
+      expect(result).toHaveAttribute('data-component-id', 'platform.api.http.router')
+      expect(result).toHaveTextContent('Router')
+      expect(result).toHaveTextContent('Modul')
+      expect(result).toHaveTextContent('Shop Platform / API Gateway / HTTP Layer')
+
+      await user.click(result)
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({
+          component: 'platform.api.http.router',
+        }),
+      )
+      expect(screen.getByTestId('inspector-context')).toHaveAttribute(
+        'data-component-id',
+        'platform.api.http.router',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
+    'opens search with the command shortcut and reports an empty result state',
+    async () => {
+      const user = userEvent.setup()
+      renderCanvas()
+      await waitForCanvas()
+
+      const trigger = screen.getByTestId('canvas-component-search')
+      trigger.focus()
+      await user.keyboard('{Control>}k{/Control}')
+      const input = screen.getByTestId('canvas-component-search-input')
+      input.focus()
+      await user.keyboard('does-not-exist')
+
+      expect(screen.getByText('Keine passende Komponente gefunden.')).toBeVisible()
+      await user.keyboard('{Escape}')
+      expect(screen.queryByTestId('canvas-component-search-input')).not.toBeInTheDocument()
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
     'writes the clicked component into the `component` search parameter',
     async () => {
       const user = userEvent.setup()

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -1,11 +1,11 @@
-import { act, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 
 import { queryKeys } from '@/api/queryKeys'
 import type { ArchitectureResponse } from '@/api/types'
 import { applyLiveEvent } from '@/api/useLiveStream'
-import { DEFAULT_CAMERA, useUiStore } from '@/state/uiStore'
+import { DEFAULT_CAMERA, resetUiStore, useUiStore } from '@/state/uiStore'
 import {
   BUNDLED_TOPIC_CHANNELS,
   NESTED_COMPONENTS,
@@ -657,6 +657,60 @@ describe('architecture canvas — selection', () => {
 })
 
 describe('architecture canvas — live updates never move the camera', () => {
+  it(
+    'drops pending search focus when orientation changes during the relayout',
+    async () => {
+      const user = userEvent.setup()
+      const collapsed = ['platform.api', 'platform.api.http', 'platform.core']
+
+      // Establish the camera produced by the explicit orientation fit without
+      // any pending search action to compare against below.
+      renderCanvas(
+        `${WORKSPACE_URL}?component=platform.api.grpc`,
+        nestedArchitectureResponse,
+        collapsed,
+      )
+      await waitForCanvas()
+      await user.click(screen.getByTestId('canvas-layout-left-right'))
+      await waitFor(() =>
+        expect(screen.getByTestId('architecture-canvas')).toHaveAttribute(
+          'data-layouting',
+          'false',
+        ),
+      )
+      const cameraAfterOrientation = useUiStore.getState().camera
+
+      cleanup()
+      resetUiStore()
+
+      const rendered = renderCanvas(WORKSPACE_URL, nestedArchitectureResponse, collapsed)
+      await waitForCanvas()
+      await user.click(screen.getByTestId('canvas-component-search'))
+      const input = screen.getByTestId('canvas-component-search-input')
+      input.focus()
+      await user.keyboard('gRPC Layer')
+      await user.click(screen.getByTestId('canvas-component-search-result'))
+
+      // The search has opened a collapsed ancestor, so ELK is still solving the
+      // graph when this explicit camera action arrives.
+      expect(rendered.router.state.location.search).toEqual({
+        component: 'platform.api.grpc',
+      })
+      await user.click(screen.getByTestId('canvas-layout-left-right'))
+      await waitFor(() =>
+        expect(screen.getByTestId('architecture-canvas')).toHaveAttribute(
+          'data-layouting',
+          'false',
+        ),
+      )
+
+      // Orientation owns the resulting camera. A stale search focus would add
+      // another pan after this fit and produce a different viewport.
+      expect(useUiStore.getState().camera).toEqual(cameraAfterOrientation)
+    },
+    CANVAS_TIMEOUT,
+  )
+
   it(
     'does not replay a completed no-relayout search focus after a live re-layout',
     async () => {

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -554,8 +554,13 @@ function ArchitectureCanvasInner({
   // changes no picture and triggers no re-layout.
   useEffect(() => {
     if (collapsedComponentIds !== null || graph.nodes.length === 0) return
-    setCollapsedComponentIds(graph.collapsedIds)
-  }, [collapsedComponentIds, graph.nodes.length, graph.collapsedIds, setCollapsedComponentIds])
+    setCollapsedComponentIds(graph.requestedCollapsedIds)
+  }, [
+    collapsedComponentIds,
+    graph.nodes.length,
+    graph.requestedCollapsedIds,
+    setCollapsedComponentIds,
+  ])
 
   // Redeems a parked fit once the layout it was asked about has landed. It goes
   // through `onUserFitRequest`, so it stays an explicit movement and never
@@ -663,13 +668,27 @@ function ArchitectureCanvasInner({
   const selectSearchResult = useCallback(
     (componentId: ComponentId) => {
       const ancestors = new Set(graph.ancestorsOf(componentId))
-      const nextCollapsed = graph.collapsedIds.filter((id) => !ancestors.has(id))
+      const nextCollapsed = graph.requestedCollapsedIds.filter((id) => !ancestors.has(id))
+      // Compare the effective sets, not the requested arrays: a nested collapse
+      // below an already closed parent is still part of the full state, but it
+      // does not change the picture until that parent is opened. This also
+      // catches a deep-link reveal being closed when the search moves elsewhere.
+      const nextVisibleCollapsed = nextCollapsed.filter(
+        (id) => !graph.ancestorsOf(id).some((ancestor) => nextCollapsed.includes(ancestor)),
+      )
       const willRelayout =
-        nextCollapsed.length !== graph.collapsedIds.length ||
-        nextCollapsed.some((id, index) => id !== graph.collapsedIds[index])
+        nextVisibleCollapsed.length !== graph.collapsedIds.length ||
+        nextVisibleCollapsed.some((id, index) => id !== graph.collapsedIds[index])
 
-      pendingFocusRef.current = componentId
-      if (willRelayout) setCollapsedComponentIds(nextCollapsed)
+      if (willRelayout) {
+        pendingFocusRef.current = componentId
+        setCollapsedComponentIds(nextCollapsed)
+      } else {
+        // A no-relayout search is complete in this user action. Never leave a
+        // ref behind that a later model update could interpret as a new camera
+        // request.
+        pendingFocusRef.current = null
+      }
       // Search is an explicit selection, not the click-toggle interaction of a
       // canvas node. The URL, selected node and inspector therefore converge on
       // this exact id even when it was already selected.
@@ -1267,7 +1286,7 @@ function ArchitectureCanvasInner({
                     ref={searchInputRef}
                     id="canvas-component-search-input"
                     type="search"
-                    role="searchbox"
+                    role="combobox"
                     value={searchQuery}
                     onChange={(event) => {
                       setSearchQuery(event.target.value)
@@ -1282,6 +1301,14 @@ function ArchitectureCanvasInner({
                     onPointerDown={(event) => event.stopPropagation()}
                     placeholder={t('search.hint')}
                     aria-describedby="canvas-component-search-status"
+                    aria-controls="canvas-component-search-results"
+                    aria-expanded={searchQuery.trim() !== '' && searchResults.length > 0}
+                    aria-autocomplete="list"
+                    aria-activedescendant={
+                      searchQuery.trim() !== '' && searchResults.length > 0
+                        ? `canvas-component-search-result-${effectiveActiveSearchIndex}`
+                        : undefined
+                    }
                     className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
                     data-testid="canvas-component-search-input"
                   />
@@ -1314,6 +1341,7 @@ function ArchitectureCanvasInner({
                 {searchQuery.trim() !== '' && searchResults.length > 0 && (
                   <div
                     className="border-border max-h-72 overflow-y-auto border-t p-1"
+                    id="canvas-component-search-results"
                     role="listbox"
                     aria-label={t('search.trigger')}
                     data-testid="canvas-component-search-results"
@@ -1322,6 +1350,7 @@ function ArchitectureCanvasInner({
                       <button
                         key={entry.component.componentId}
                         type="button"
+                        id={`canvas-component-search-result-${index}`}
                         role="option"
                         aria-selected={index === effectiveActiveSearchIndex}
                         className={`hover:bg-accent focus-visible:bg-accent flex w-full min-w-0 flex-col items-start gap-0.5 rounded-sm px-2 py-1.5 text-left text-sm outline-none ${index === effectiveActiveSearchIndex ? 'bg-accent' : ''}`}

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -15,7 +15,15 @@ import {
   type OnNodeDrag,
   type Viewport,
 } from '@xyflow/react'
-import { Layers2, Map, MapPinOff, Maximize2, RotateCcw, TriangleAlert } from 'lucide-react'
+import {
+  Layers2,
+  Map,
+  MapPinOff,
+  Maximize2,
+  RotateCcw,
+  Search,
+  TriangleAlert,
+} from 'lucide-react'
 import type { TFunction } from 'i18next'
 import {
   useCallback,
@@ -35,6 +43,7 @@ import type { ComponentId, Identifier, ProjectId } from '@/api/types'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useUiStore } from '@/state/uiStore'
+import { ReportedText } from '@/i18n'
 
 import { EdgeMarkerDefs } from './RelationshipEdge'
 import {
@@ -42,6 +51,7 @@ import {
   onLayoutReady,
   onProjectChanged,
   onUserFitRequest,
+  viewportForFocus,
   viewportForBounds,
   type CameraPolicyState,
 } from './cameraPolicy'
@@ -51,6 +61,8 @@ import {
   withEdgeAccessibility,
   withNodeAccessibility,
 } from './canvasAccessibility'
+import { componentKindLabel } from './componentKinds'
+import { componentSearchEntries, searchComponentEntries } from './componentSearch'
 import {
   DETAIL_LEVEL_DESCRIPTION_KEYS,
   DETAIL_LEVEL_LABEL_KEYS,
@@ -200,6 +212,35 @@ function ArchitectureCanvasInner({
     orientation,
     revealComponentIds: relationshipRevealIds,
   })
+  const searchEntries = useMemo(
+    () =>
+      componentSearchEntries(
+        model.components,
+        model.overlay?.extraComponents.map((entry) => entry.component) ?? [],
+      ),
+    [model.components, model.overlay?.extraComponents],
+  )
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [activeSearchIndex, setActiveSearchIndex] = useState(0)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const searchTriggerRef = useRef<HTMLButtonElement | null>(null)
+  const wasSearchOpenRef = useRef(false)
+  const pendingFocusRef = useRef<ComponentId | null>(null)
+  const searchResults = useMemo(
+    () => searchComponentEntries(searchEntries, searchQuery),
+    [searchEntries, searchQuery],
+  )
+  const effectiveActiveSearchIndex =
+    searchResults.length === 0 ? 0 : Math.min(activeSearchIndex, searchResults.length - 1)
+  useEffect(() => {
+    if (searchOpen) {
+      searchInputRef.current?.focus()
+    } else if (wasSearchOpenRef.current) {
+      searchTriggerRef.current?.focus()
+    }
+    wasSearchOpenRef.current = searchOpen
+  }, [searchOpen])
   const flow = useReactFlow()
   const storeApi = useStoreApi()
 
@@ -375,6 +416,45 @@ function ArchitectureCanvasInner({
     [flow, storeApi, setCamera, publishZoom],
   )
 
+  /** Explicitly reveals one laid-out component without changing the zoom. */
+  const focusComponentInView = useCallback(
+    (componentId: ComponentId) => {
+      const { width, height, nodeLookup } = storeApi.getState()
+      const node = nodeLookup.get(componentId)
+      if (!node || width <= 0 || height <= 0) return
+      const focus = getNodesBounds([node], { nodeLookup })
+      const current = flow.getViewport()
+      const viewport = viewportForFocus(current, focus, { width, height })
+      userMovedCameraRef.current = true
+      if (viewport.x === current.x && viewport.y === current.y) return
+      void flow.setViewport(viewport)
+      setCamera(viewport)
+      setDetailLevel(detailLevelForZoom(viewport.zoom))
+      publishZoom(viewport.zoom)
+    },
+    [flow, publishZoom, setCamera, storeApi],
+  )
+
+  // React Flow's node lookup is an external mutable store. Read it during
+  // render so layout and temporary drag updates are reflected immediately;
+  // React already re-renders this component for both kinds of change.
+  const selectionFocusBounds = (() => {
+    if (!selectedComponentId) return null
+    const { nodeLookup } = storeApi.getState()
+    const node = nodeLookup.get(selectedComponentId)
+    return node ? getNodesBounds([node], { nodeLookup }) : null
+  })()
+  const selectionNeedsJump = useMemo(() => {
+    if (!selectionFocusBounds || surfaceWidth <= 0 || surfaceHeight <= 0) return false
+    const current = camera
+    const next = viewportForFocus(
+      current,
+      selectionFocusBounds,
+      { width: surfaceWidth, height: surfaceHeight },
+    )
+    return Math.abs(next.x - current.x) > 0.1 || Math.abs(next.y - current.y) > 0.1
+  }, [camera, selectionFocusBounds, surfaceHeight, surfaceWidth])
+
   /**
    * A fit the user asked for, held until the layout it is about exists.
    *
@@ -488,6 +568,16 @@ function ArchitectureCanvasInner({
     fitView(pending.mode, pending.focusComponentId)
   }, [graph.isRelayouting, graph.nodes.length, graph.signature, fitView])
 
+  // A search result may have opened one or more collapsed ancestors. Wait for
+  // that exact layout before panning; unrelated containers stay collapsed and
+  // no camera movement happens while ELK is still solving the new graph.
+  useEffect(() => {
+    const componentId = pendingFocusRef.current
+    if (componentId === null || graph.isRelayouting || graph.nodes.length === 0) return
+    pendingFocusRef.current = null
+    focusComponentInView(componentId)
+  }, [focusComponentInView, graph.isRelayouting, graph.nodes.length, graph.signature])
+
   // Endpoint names for the edge labels. Derived from the laid-out graph rather
   // than from `nodes`, so a selection — which changes nothing an edge says —
   // does not rebuild every edge. `collapse.ts` lifts a hidden endpoint onto its
@@ -536,6 +626,85 @@ function ArchitectureCanvasInner({
       onSelectComponent(node.id === selectedComponentId ? null : node.id)
     },
     [onSelectComponent, selectedComponentId],
+  )
+
+  const openSearch = useCallback(() => {
+    setSearchQuery('')
+    setActiveSearchIndex(0)
+    setSearchOpen(true)
+  }, [])
+  const closeSearch = useCallback(() => setSearchOpen(false), [])
+
+  // The command is scoped to the mounted architecture workspace, but it also
+  // works when focus is in a neighbouring pane or on the document body. The
+  // editable guard keeps `/` from stealing an input's normal text entry.
+  useEffect(() => {
+    const onWindowKeyDown = (event: KeyboardEvent) => {
+      const target = event.target
+      const editable =
+        target instanceof Element
+          ? target.closest('input, textarea, select, [contenteditable="true"]')
+          : null
+      const commandSearch =
+        (event.key === '/' && editable === null) ||
+        ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k')
+      if (!commandSearch || event.defaultPrevented) return
+      event.preventDefault()
+      openSearch()
+    }
+    window.addEventListener('keydown', onWindowKeyDown)
+    return () => window.removeEventListener('keydown', onWindowKeyDown)
+  }, [openSearch])
+
+  const onJumpToSelection = useCallback(() => {
+    if (selectedComponentId) focusComponentInView(selectedComponentId)
+  }, [focusComponentInView, selectedComponentId])
+
+  const selectSearchResult = useCallback(
+    (componentId: ComponentId) => {
+      const ancestors = new Set(graph.ancestorsOf(componentId))
+      const nextCollapsed = graph.collapsedIds.filter((id) => !ancestors.has(id))
+      const willRelayout =
+        nextCollapsed.length !== graph.collapsedIds.length ||
+        nextCollapsed.some((id, index) => id !== graph.collapsedIds[index])
+
+      pendingFocusRef.current = componentId
+      if (willRelayout) setCollapsedComponentIds(nextCollapsed)
+      // Search is an explicit selection, not the click-toggle interaction of a
+      // canvas node. The URL, selected node and inspector therefore converge on
+      // this exact id even when it was already selected.
+      onSelectComponent(componentId)
+      closeSearch()
+      if (!willRelayout) focusComponentInView(componentId)
+    },
+    [closeSearch, focusComponentInView, graph, onSelectComponent, setCollapsedComponentIds],
+  )
+
+  const onSearchKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setActiveSearchIndex((index) =>
+          searchResults.length === 0 ? 0 : (index + 1) % searchResults.length,
+        )
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setActiveSearchIndex((index) =>
+          searchResults.length === 0
+            ? 0
+            : (index - 1 + searchResults.length) % searchResults.length,
+        )
+      } else if (event.key === 'Enter') {
+        const result = searchResults[effectiveActiveSearchIndex]
+        if (!result) return
+        event.preventDefault()
+        selectSearchResult(result.component.componentId)
+      } else if (event.key === 'Escape') {
+        event.preventDefault()
+        closeSearch()
+      }
+    },
+    [closeSearch, effectiveActiveSearchIndex, searchResults, selectSearchResult],
   )
 
   /**
@@ -621,6 +790,17 @@ function ArchitectureCanvasInner({
       const target = event.target
       if (!(target instanceof Element)) return
 
+      const editable = target.closest('input, textarea, select, [contenteditable="true"]')
+      const commandSearch =
+        (event.key === '/' && editable === null) ||
+        ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k')
+      if (commandSearch) {
+        event.preventDefault()
+        event.stopPropagation()
+        openSearch()
+        return
+      }
+
       const nodeElement = target.closest('.react-flow__node')
       if (nodeElement) {
         const control = target.closest('button, a[href], input, select, textarea')
@@ -681,6 +861,7 @@ function ArchitectureCanvasInner({
       activeSelectedRelationshipId,
       onSelectRelationship,
       setStoredSelectedRelationshipId,
+      openSearch,
       toggleEdgeExpanded,
     ],
   )
@@ -867,6 +1048,41 @@ function ArchitectureCanvasInner({
                 to a few hundred pixels, and a toolbar that runs past its edge
                 takes its own controls out of reach. */}
             <div className="border-border bg-card/90 flex max-w-[min(100%,44rem)] flex-wrap items-center gap-1 rounded-md border px-1 py-1 backdrop-blur-sm">
+              <Button
+                ref={searchTriggerRef}
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                aria-haspopup="dialog"
+                aria-expanded={searchOpen}
+                aria-keyshortcuts="/ Control+K Meta+K"
+                onClick={openSearch}
+                data-testid="canvas-component-search"
+              >
+                <Search aria-hidden="true" />
+                {t('search.trigger')}
+              </Button>
+
+              {selectionNeedsJump && selectedComponentId && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1.5 px-2 text-xs"
+                      onClick={onJumpToSelection}
+                      data-testid="canvas-jump-to-selection"
+                    >
+                      <MapPinOff aria-hidden="true" />
+                      {t('search.jumpToSelection')}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-80">
+                    {t('search.jumpToSelectionHint')}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
@@ -1035,6 +1251,106 @@ function ArchitectureCanvasInner({
                 </Tooltip>
               )}
             </div>
+            {searchOpen && (
+              <div
+                className="border-border bg-card text-card-foreground nokey nopan absolute top-full left-0 z-50 mt-1 w-[min(34rem,calc(100vw-2rem))] overflow-hidden rounded-md border shadow-lg"
+                role="dialog"
+                aria-label={t('search.trigger')}
+                data-testid="canvas-component-search-dialog"
+              >
+                <div className="border-border flex items-center gap-2 border-b p-2">
+                  <Search className="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+                  <label htmlFor="canvas-component-search-input" className="sr-only">
+                    {t('search.hint')}
+                  </label>
+                  <input
+                    ref={searchInputRef}
+                    id="canvas-component-search-input"
+                    type="search"
+                    role="searchbox"
+                    value={searchQuery}
+                    onChange={(event) => {
+                      setSearchQuery(event.target.value)
+                      setActiveSearchIndex(0)
+                    }}
+                    onKeyDown={(event) => {
+                      // React Flow owns the surrounding keyboard surface; keep
+                      // ordinary text entry from reaching its pane handler.
+                      event.stopPropagation()
+                      onSearchKeyDown(event)
+                    }}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    placeholder={t('search.hint')}
+                    aria-describedby="canvas-component-search-status"
+                    className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                    data-testid="canvas-component-search-input"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label={t('search.close')}
+                    onClick={closeSearch}
+                    data-testid="canvas-component-search-close"
+                  >
+                    <span aria-hidden="true">×</span>
+                  </Button>
+                </div>
+
+                <p
+                  id="canvas-component-search-status"
+                  data-testid="canvas-component-search-status"
+                  className="text-muted-foreground px-3 py-2 text-xs"
+                  role="status"
+                  aria-live="polite"
+                >
+                  {searchQuery.trim() === ''
+                    ? t('search.empty')
+                    : searchResults.length === 0
+                      ? t('search.noResults')
+                      : t('search.resultCount', { count: searchResults.length })}
+                </p>
+
+                {searchQuery.trim() !== '' && searchResults.length > 0 && (
+                  <div
+                    className="border-border max-h-72 overflow-y-auto border-t p-1"
+                    role="listbox"
+                    aria-label={t('search.trigger')}
+                    data-testid="canvas-component-search-results"
+                  >
+                    {searchResults.map((entry, index) => (
+                      <button
+                        key={entry.component.componentId}
+                        type="button"
+                        role="option"
+                        aria-selected={index === effectiveActiveSearchIndex}
+                        className={`hover:bg-accent focus-visible:bg-accent flex w-full min-w-0 flex-col items-start gap-0.5 rounded-sm px-2 py-1.5 text-left text-sm outline-none ${index === effectiveActiveSearchIndex ? 'bg-accent' : ''}`}
+                        onMouseEnter={() => setActiveSearchIndex(index)}
+                        onClick={() => selectSearchResult(entry.component.componentId)}
+                        data-testid="canvas-component-search-result"
+                        data-component-id={entry.component.componentId}
+                      >
+                        <span className="flex w-full min-w-0 items-center gap-2">
+                          <span className="min-w-0 flex-1 truncate font-medium">
+                            <ReportedText value={entry.component.name} />
+                          </span>
+                          <span className="text-muted-foreground shrink-0 text-xs">
+                            {componentKindLabel(entry.component.kind, t)}
+                          </span>
+                        </span>
+                        <span className="text-muted-foreground w-full truncate text-xs">
+                          {entry.containerPath.length > 0 ? (
+                            <ReportedText value={entry.containerPath.join(' / ')} />
+                          ) : (
+                            t('search.root')
+                          )}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </Panel>
 
           {graph.isRelayouting && (

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -48,6 +48,7 @@ import { ReportedText } from '@/i18n'
 import { EdgeMarkerDefs } from './RelationshipEdge'
 import {
   INITIAL_CAMERA_POLICY,
+  isBoundsFullyVisible,
   onLayoutReady,
   onProjectChanged,
   onUserFitRequest,
@@ -227,6 +228,9 @@ function ArchitectureCanvasInner({
   const searchTriggerRef = useRef<HTMLButtonElement | null>(null)
   const wasSearchOpenRef = useRef(false)
   const pendingFocusRef = useRef<ComponentId | null>(null)
+  const invalidatePendingSearchFocus = useCallback(() => {
+    pendingFocusRef.current = null
+  }, [])
   const searchResults = useMemo(
     () => searchComponentEntries(searchEntries, searchQuery),
     [searchEntries, searchQuery],
@@ -419,6 +423,7 @@ function ArchitectureCanvasInner({
   /** Explicitly reveals one laid-out component without changing the zoom. */
   const focusComponentInView = useCallback(
     (componentId: ComponentId) => {
+      invalidatePendingSearchFocus()
       const { width, height, nodeLookup } = storeApi.getState()
       const node = nodeLookup.get(componentId)
       if (!node || width <= 0 || height <= 0) return
@@ -432,7 +437,7 @@ function ArchitectureCanvasInner({
       setDetailLevel(detailLevelForZoom(viewport.zoom))
       publishZoom(viewport.zoom)
     },
-    [flow, publishZoom, setCamera, storeApi],
+    [flow, invalidatePendingSearchFocus, publishZoom, setCamera, storeApi],
   )
 
   // React Flow's node lookup is an external mutable store. Read it during
@@ -446,13 +451,11 @@ function ArchitectureCanvasInner({
   })()
   const selectionNeedsJump = useMemo(() => {
     if (!selectionFocusBounds || surfaceWidth <= 0 || surfaceHeight <= 0) return false
-    const current = camera
-    const next = viewportForFocus(
-      current,
+    return !isBoundsFullyVisible(
+      camera,
       selectionFocusBounds,
       { width: surfaceWidth, height: surfaceHeight },
     )
-    return Math.abs(next.x - current.x) > 0.1 || Math.abs(next.y - current.y) > 0.1
   }, [camera, selectionFocusBounds, surfaceHeight, surfaceWidth])
 
   /**
@@ -474,16 +477,18 @@ function ArchitectureCanvasInner({
     // not a second explicit camera movement.
     if (previous === null || previous === orientation) return
 
+    invalidatePendingSearchFocus()
     // Positions are meaningful only in the coordinate system that produced
     // them. Resetting them here keeps one transient set instead of persisting
     // two direction-specific sets, while selection and disclosure stay intact.
     clearNodePositions()
     pendingFitRef.current = { mode: 'user', focusComponentId: null }
-  }, [clearNodePositions, orientation])
+  }, [clearNodePositions, invalidatePendingSearchFocus, orientation])
 
   /** Fits now if the graph is already the right one, otherwise after re-layout. */
   const requestFit = useCallback(
     (mode: FitMode, afterRelayout: boolean) => {
+      invalidatePendingSearchFocus()
       // "Systemebene" reproduces the entry picture, and the entry picture keeps
       // the selected component on screen. The whole-model overview does not: it
       // is about the model, not about one component of it.
@@ -496,7 +501,7 @@ function ArchitectureCanvasInner({
       policyRef.current = onUserFitRequest(policyRef.current).state
       fitView(mode, focusComponentId)
     },
-    [fitView, selectedComponentId],
+    [fitView, invalidatePendingSearchFocus, selectedComponentId],
   )
 
   // Switching projects makes the next model an initial one again — including
@@ -763,24 +768,29 @@ function ArchitectureCanvasInner({
   // React Flow passes `null` for a programmatic move and the real input event
   // for a user one — which is exactly the distinction the camera policy needs.
   const onMoveStart = useCallback((event: unknown) => {
-    if (event !== null && event !== undefined) userMovedCameraRef.current = true
-  }, [])
+    if (event !== null && event !== undefined) {
+      userMovedCameraRef.current = true
+      invalidatePendingSearchFocus()
+    }
+  }, [invalidatePendingSearchFocus])
 
   const onMove = useCallback(
-    (_event: unknown, viewport: Viewport) => {
+    (event: unknown, viewport: Viewport) => {
+      if (event !== null && event !== undefined) invalidatePendingSearchFocus()
       setDetailLevel(detailLevelForZoom(viewport.zoom))
       publishZoom(viewport.zoom)
     },
-    [publishZoom],
+    [invalidatePendingSearchFocus, publishZoom],
   )
 
   const onMoveEnd = useCallback(
-    (_event: unknown, viewport: Viewport) => {
+    (event: unknown, viewport: Viewport) => {
+      if (event !== null && event !== undefined) invalidatePendingSearchFocus()
       setCamera(viewport)
       setDetailLevel(detailLevelForZoom(viewport.zoom))
       publishZoom(viewport.zoom)
     },
-    [setCamera, publishZoom],
+    [invalidatePendingSearchFocus, setCamera, publishZoom],
   )
 
   /**

--- a/frontend/src/canvas/cameraPolicy.test.ts
+++ b/frontend/src/canvas/cameraPolicy.test.ts
@@ -4,6 +4,7 @@ import {
   FIT_VIEW_PADDING,
   INITIAL_CAMERA_POLICY,
   MIN_FIT_VIEWPORT,
+  isBoundsFullyVisible,
   onLayoutReady,
   onProjectChanged,
   onUserFitRequest,
@@ -258,6 +259,15 @@ describe('where the camera goes', () => {
     expect(repeated.zoom).toBe(focused.zoom)
     expect(repeated.x).toBeCloseTo(focused.x, 10)
     expect(repeated.y).toBeCloseTo(focused.y, 10)
+  })
+
+  it('only marks a selection for jumping when it crosses the real viewport edge', () => {
+    const current = { x: 0, y: 0, zoom: 1 }
+    const nearRightEdge = { x: 800, y: 100, width: 228, height: 96 }
+    const justOffscreen = { x: 809, y: 100, width: 228, height: 96 }
+
+    expect(isBoundsFullyVisible(current, nearRightEdge, SURFACE)).toBe(true)
+    expect(isBoundsFullyVisible(current, justOffscreen, SURFACE)).toBe(false)
   })
 
   it('shows where an oversized focus begins rather than where it ends', () => {

--- a/frontend/src/canvas/cameraPolicy.test.ts
+++ b/frontend/src/canvas/cameraPolicy.test.ts
@@ -8,6 +8,7 @@ import {
   onProjectChanged,
   onUserFitRequest,
   viewportForBounds,
+  viewportForFocus,
   type CameraPolicyInput,
 } from './cameraPolicy'
 import { MIN_LEGIBLE_FONT_SIZE_PX, MIN_READABLE_ZOOM } from './detailLevel'
@@ -234,6 +235,29 @@ describe('where the camera goes', () => {
       focus: { x: 40, y: 40, width: 228, height: 96 },
     })
     expect(withFocus).toEqual(without)
+  })
+
+  it('moves an explicit focus by the minimum pan and preserves zoom', () => {
+    const current = { x: 0, y: 0, zoom: 0.77 }
+    const focused = viewportForFocus(
+      current,
+      { x: 1500, y: 100, width: 228, height: 96 },
+      SURFACE,
+    )
+
+    expect(focused.zoom).toBe(current.zoom)
+    expect(focused.x).toBeLessThan(current.x)
+    expect(focused.y).toBe(current.y)
+
+    // Once visible, the same explicit action is a no-op rather than a recenter.
+    const repeated = viewportForFocus(
+      focused,
+      { x: 1500, y: 100, width: 228, height: 96 },
+      SURFACE,
+    )
+    expect(repeated.zoom).toBe(focused.zoom)
+    expect(repeated.x).toBeCloseTo(focused.x, 10)
+    expect(repeated.y).toBeCloseTo(focused.y, 10)
   })
 
   it('shows where an oversized focus begins rather than where it ends', () => {

--- a/frontend/src/canvas/cameraPolicy.ts
+++ b/frontend/src/canvas/cameraPolicy.ts
@@ -240,6 +240,26 @@ export function viewportForFocus(
   }
 }
 
+/**
+ * Whether a layout box is fully inside the actual visible surface.
+ *
+ * This deliberately has no comfort padding. The caller can still use
+ * `viewportForFocus` to make a visible component more comfortably placed, but
+ * a jump affordance must only appear when part of the component is truly off
+ * the viewport.
+ */
+export function isBoundsFullyVisible(
+  viewport: CameraViewport,
+  focus: LayoutBounds,
+  surface: ViewportSize,
+): boolean {
+  const left = focus.x * viewport.zoom + viewport.x
+  const top = focus.y * viewport.zoom + viewport.y
+  const right = left + focus.width * viewport.zoom
+  const bottom = top + focus.height * viewport.zoom
+  return left >= 0 && top >= 0 && right <= surface.width && bottom <= surface.height
+}
+
 function axisOffset(
   surfaceSize: number,
   boundsStart: number,

--- a/frontend/src/canvas/cameraPolicy.ts
+++ b/frontend/src/canvas/cameraPolicy.ts
@@ -220,6 +220,26 @@ export function viewportForBounds(
   }
 }
 
+/**
+ * Keeps the current zoom and moves only as far as needed to reveal one box.
+ *
+ * This is the explicit counterpart to the initial fit: search and "jump to
+ * selection" are user requests, so they may pan the camera, but they must not
+ * zoom or recenter a component that is already visible.
+ */
+export function viewportForFocus(
+  viewport: CameraViewport,
+  focus: LayoutBounds,
+  surface: ViewportSize,
+  padding = FIT_VIEW_PADDING,
+): CameraViewport {
+  return {
+    zoom: viewport.zoom,
+    x: panIntoView(viewport.x, focus.x, focus.width, surface.width, viewport.zoom, padding),
+    y: panIntoView(viewport.y, focus.y, focus.height, surface.height, viewport.zoom, padding),
+  }
+}
+
 function axisOffset(
   surfaceSize: number,
   boundsStart: number,

--- a/frontend/src/canvas/componentKinds.ts
+++ b/frontend/src/canvas/componentKinds.ts
@@ -15,6 +15,7 @@ import type { TFunction } from 'i18next'
 
 import type { Component, ComponentKind, Technology } from '@/api/types'
 import type { CanvasKey } from '@/i18n'
+import { resources } from '@/i18n/resources'
 
 import { reported } from './relationshipKinds'
 
@@ -37,6 +38,8 @@ export interface ComponentKindStyle {
   icon: LucideIcon
 }
 
+type ComponentKindCatalogueKey = keyof typeof resources.de.canvas.componentKind
+
 export const COMPONENT_KIND_STYLES: Record<ComponentKind, ComponentKindStyle> = {
   system: { id: 'system', labelKey: 'componentKind.system', icon: Boxes },
   service: { id: 'service', labelKey: 'componentKind.service', icon: Server },
@@ -57,6 +60,21 @@ export function componentKindStyle(kind: ComponentKind): ComponentKindStyle {
 export function componentKindLabel(kind: ComponentKind, t: TFunction<'canvas'>): string {
   const key = componentKindStyle(kind).labelKey
   return key === null ? kind : t(key)
+}
+
+/**
+ * The visible kind labels are searchable in both supported languages. Keeping
+ * these values sourced from the catalogues means a localized badge and its
+ * command-search index cannot drift apart.
+ */
+export function componentKindSearchLabels(kind: ComponentKind): string[] {
+  const key = componentKindStyle(kind).labelKey
+  if (key === null || !key.startsWith('componentKind.')) return []
+  const catalogueKey = key.slice('componentKind.'.length) as ComponentKindCatalogueKey
+  return [
+    resources.de.canvas.componentKind[catalogueKey],
+    resources.en.canvas.componentKind[catalogueKey],
+  ].filter((label, index, labels): label is string => labels.indexOf(label) === index)
 }
 
 /**

--- a/frontend/src/canvas/componentSearch.test.ts
+++ b/frontend/src/canvas/componentSearch.test.ts
@@ -43,6 +43,21 @@ describe('component search inventory', () => {
     expect(searchComponentEntries(entries, 'service')).toHaveLength(2)
   })
 
+  it('searches the localized component kind labels', () => {
+    const entries = componentSearchEntries([
+      { ...components[0]!, kind: 'module' },
+      { ...components[1]!, kind: 'datastore' },
+    ])
+
+    expect(searchComponentEntries(entries, 'Modul').map((entry) => entry.component.kind)).toEqual([
+      'module',
+    ])
+    expect(
+      searchComponentEntries(entries, 'Datenspeicher').map((entry) => entry.component.kind),
+    ).toEqual(['datastore'])
+    expect(searchComponentEntries(entries, 'Data store')).toHaveLength(1)
+  })
+
   it('includes overlay-only components while preferring applied rows for duplicate ids', () => {
     const entries = componentSearchEntries(components.slice(0, 1), [
       components[1]!,

--- a/frontend/src/canvas/componentSearch.test.ts
+++ b/frontend/src/canvas/componentSearch.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Component } from '@/api/types'
+
+import { componentSearchEntries, searchComponentEntries } from './componentSearch'
+
+const components: Component[] = [
+  {
+    componentId: 'platform',
+    name: 'Platform',
+    kind: 'system' as const,
+    parentComponentId: null,
+    technology: { framework: 'React' },
+    tags: ['core'],
+  },
+  {
+    componentId: 'platform.orders',
+    name: 'Orders',
+    kind: 'service' as const,
+    parentComponentId: 'platform',
+    technology: { language: 'TypeScript', runtime: 'Node.js' },
+    tags: ['checkout'],
+  },
+  {
+    componentId: 'platform.billing',
+    name: 'Orders',
+    kind: 'service' as const,
+    parentComponentId: 'platform',
+    technology: { framework: 'chi' },
+    tags: ['payments'],
+  },
+]
+
+describe('component search inventory', () => {
+  it('keeps container paths and searches every reported field', () => {
+    const entries = componentSearchEntries(components)
+    const orders = entries.find((entry) => entry.component.componentId === 'platform.orders')
+
+    expect(orders?.containerPath).toEqual(['Platform'])
+    expect(searchComponentEntries(entries, 'TypeScript')).toHaveLength(1)
+    expect(searchComponentEntries(entries, 'checkout')).toHaveLength(1)
+    expect(searchComponentEntries(entries, 'platform.orders')).toHaveLength(1)
+    expect(searchComponentEntries(entries, 'service')).toHaveLength(2)
+  })
+
+  it('includes overlay-only components while preferring applied rows for duplicate ids', () => {
+    const entries = componentSearchEntries(components.slice(0, 1), [
+      components[1]!,
+      { ...components[0]!, name: 'Overlay copy' },
+    ])
+
+    expect(entries.map((entry) => entry.component.componentId)).toEqual([
+      'platform',
+      'platform.orders',
+    ])
+    expect(entries[0]?.component.name).toBe('Platform')
+  })
+
+  it('does not loop when a malformed hierarchy contains a cycle', () => {
+    const cyclic = [
+      { ...components[0]!, parentComponentId: 'platform.orders' },
+      components[1]!,
+    ]
+    const entries = componentSearchEntries(cyclic)
+
+    expect(entries[0]?.containerPath).toEqual(['Orders'])
+    expect(entries[1]?.containerPath).toEqual(['Platform'])
+  })
+})

--- a/frontend/src/canvas/componentSearch.ts
+++ b/frontend/src/canvas/componentSearch.ts
@@ -1,5 +1,7 @@
 import type { Component, ComponentId } from '@/api/types'
 
+import { componentKindSearchLabels } from './componentKinds'
+
 /** One component that can be found from the canvas command search. */
 export interface ComponentSearchEntry {
   component: Component
@@ -40,6 +42,7 @@ export function componentSearchEntries(
         component.componentId,
         component.name,
         component.kind,
+        ...componentKindSearchLabels(component.kind),
         ...technology,
         ...tags,
         ...containerPath,

--- a/frontend/src/canvas/componentSearch.ts
+++ b/frontend/src/canvas/componentSearch.ts
@@ -1,0 +1,93 @@
+import type { Component, ComponentId } from '@/api/types'
+
+/** One component that can be found from the canvas command search. */
+export interface ComponentSearchEntry {
+  component: Component
+  /** Container names from the root to the immediate parent. */
+  containerPath: string[]
+  /** Normalised fields used by the query matcher. */
+  searchValues: string[]
+}
+
+/**
+ * Builds the search inventory from both the applied model and overlay-only
+ * components. Applied rows win when an overlay repeats their id, exactly like
+ * the graph projection does. The result is canonical by component id so live
+ * refetches cannot make the command list jump around.
+ */
+export function componentSearchEntries(
+  components: readonly Component[],
+  overlayComponents: readonly Component[] = [],
+): ComponentSearchEntry[] {
+  const byId = new Map<ComponentId, Component>()
+  for (const component of [...components, ...overlayComponents]) {
+    if (!byId.has(component.componentId)) byId.set(component.componentId, component)
+  }
+
+  const ordered = [...byId.values()].sort((left, right) =>
+    left.componentId < right.componentId ? -1 : left.componentId > right.componentId ? 1 : 0,
+  )
+  const nameById = new Map(ordered.map((component) => [component.componentId, component.name]))
+
+  return ordered.map((component) => {
+    const containerPath = pathOf(component, byId, nameById)
+    const technology = Object.values(component.technology ?? {})
+    const tags = component.tags ?? []
+    return {
+      component,
+      containerPath,
+      searchValues: normaliseValues([
+        component.componentId,
+        component.name,
+        component.kind,
+        ...technology,
+        ...tags,
+        ...containerPath,
+      ]),
+    }
+  })
+}
+
+/**
+ * Matches every query token against at least one reported field. This keeps a
+ * query such as "orders service" useful without inventing a global search
+ * index or changing the read contract.
+ */
+export function searchComponentEntries(
+  entries: readonly ComponentSearchEntry[],
+  query: string,
+): ComponentSearchEntry[] {
+  const terms = normalise(query)
+    .split(/\s+/)
+    .filter(Boolean)
+  if (terms.length === 0) return [...entries]
+  return entries.filter((entry) =>
+    terms.every((term) => entry.searchValues.some((value) => value.includes(term))),
+  )
+}
+
+function pathOf(
+  component: Component,
+  byId: ReadonlyMap<ComponentId, Component>,
+  nameById: ReadonlyMap<ComponentId, string>,
+): string[] {
+  const path: string[] = []
+  const seen = new Set<ComponentId>([component.componentId])
+  let parentId = component.parentComponentId ?? null
+  while (parentId !== null && !seen.has(parentId)) {
+    seen.add(parentId)
+    const parent = byId.get(parentId)
+    if (!parent) break
+    path.unshift(nameById.get(parentId) ?? parent.name)
+    parentId = parent.parentComponentId ?? null
+  }
+  return path
+}
+
+function normaliseValues(values: readonly unknown[]): string[] {
+  return values.map((value) => normalise(String(value)))
+}
+
+function normalise(value: string): string {
+  return value.trim().toLocaleLowerCase()
+}

--- a/frontend/src/canvas/useArchitectureGraph.ts
+++ b/frontend/src/canvas/useArchitectureGraph.ts
@@ -46,6 +46,12 @@ export interface ArchitectureGraph {
   /** Containers that are currently collapsed, in canonical order. */
   collapsedIds: ComponentId[]
   /**
+   * The complete collapse state requested by the user, including containers
+   * below a currently collapsed parent. `collapsedIds` cannot carry those IDs
+   * because they are not visible until that parent is opened.
+   */
+  requestedCollapsedIds: ComponentId[]
+  /**
    * The collapsed set this model opens with. Kept here rather than recomputed
    * by the canvas because it needs the *full* hierarchy, which only the
    * projection still has once containers are closed.
@@ -126,8 +132,14 @@ export function useArchitectureGraph(
    * what keeps a re-render that produced an equal set from re-running ELK — the
    * same reason `projectionSignature` exists.
    */
+  const requestedCollapsedIds = useMemo(
+    () =>
+      [...(collapsedComponentIds ?? initialCollapsedIds(projection.nodes))].sort(),
+    [collapsedComponentIds, projection.nodes],
+  )
+
   const collapsedKey = useMemo(() => {
-    const base = collapsedComponentIds ?? initialCollapsedIds(projection.nodes)
+    const base = requestedCollapsedIds
     const revealIds = [
       ...(revealComponentId ? [revealComponentId] : []),
       ...revealComponentIds,
@@ -140,7 +152,7 @@ export function useArchitectureGraph(
       .filter((componentId) => !revealed.has(componentId))
       .sort()
       .join(KEY_SEPARATOR)
-  }, [collapsedComponentIds, revealComponentId, revealComponentIds, projection.nodes])
+  }, [requestedCollapsedIds, revealComponentId, revealComponentIds, projection.nodes])
 
   const visible = useMemo(
     () =>
@@ -226,6 +238,7 @@ export function useArchitectureGraph(
       appliedEdgeCount: projection.appliedEdgeCount,
       overlayEdgeCount: projection.overlayEdgeCount,
       collapsedIds: [...visible.collapsedComponentIds].sort(),
+      requestedCollapsedIds,
       initialCollapsedIds: initialCollapsedIds(projection.nodes),
       hiddenComponentIds: visible.hiddenComponentIds,
       visibleNodeCount: visible.nodes.length,
@@ -233,7 +246,7 @@ export function useArchitectureGraph(
       reportedRelationshipCount,
       ancestorsOf: (componentId) => ancestorIds(projection.nodes, componentId),
     }
-  }, [laidOut, projection, visible, layoutSignature, error, reportedRelationshipCount])
+  }, [laidOut, projection, visible, layoutSignature, error, reportedRelationshipCount, requestedCollapsedIds])
 }
 
 /**

--- a/frontend/src/i18n/locales/de/canvas.json
+++ b/frontend/src/i18n/locales/de/canvas.json
@@ -114,6 +114,18 @@
     "renderedConnections_other": "{{count, number}} Verbindungen dargestellt",
     "title": "Architektur"
   },
+  "search": {
+    "close": "Komponentensuche schließen",
+    "empty": "Nach Name, Art, Technologie, Tag oder Komponenten-ID suchen.",
+    "hint": "Name, Art, Technologie, Tags oder Komponenten-ID suchen",
+    "noResults": "Keine passende Komponente gefunden.",
+    "resultCount_one": "{{count, number}} Komponente gefunden",
+    "resultCount_other": "{{count, number}} Komponenten gefunden",
+    "root": "Wurzelebene",
+    "trigger": "Komponenten suchen",
+    "jumpToSelection": "Zur Auswahl springen",
+    "jumpToSelectionHint": "Die Kamera schwenkt nur so weit, bis die ausgewählte Komponente sichtbar ist."
+  },
   "relationshipKind": {
     "async": {
       "description": "Asynchroner Nachrichtenfluss ohne unmittelbare Antwort.",

--- a/frontend/src/i18n/locales/en/canvas.json
+++ b/frontend/src/i18n/locales/en/canvas.json
@@ -114,6 +114,18 @@
     "renderedConnections_other": "{{count, number}} connections rendered",
     "title": "Architecture"
   },
+  "search": {
+    "close": "Close component search",
+    "empty": "Type a name, kind, technology, tag or component id to search.",
+    "hint": "Search name, kind, technology, tags or component id",
+    "noResults": "No components match this search.",
+    "resultCount_one": "{{count, number}} component found",
+    "resultCount_other": "{{count, number}} components found",
+    "root": "Root level",
+    "trigger": "Search components",
+    "jumpToSelection": "Jump to selection",
+    "jumpToSelectionHint": "Pan only as far as needed to show the selected component."
+  },
   "relationshipKind": {
     "async": {
       "description": "Asynchronous message flow without an immediate reply.",


### PR DESCRIPTION
Closes #55

## Umgesetzt
- Zugängliche Canvas-Suche über Name, Art, Technologie, Tags und ID mit DE/EN-Texten.
- Tastaturzugriff über / und Ctrl/Cmd+K; Ergebnisliste als Combobox mit Screenreader-Semantik.
- Suchauswahl synchronisiert URL, Auswahl und Inspector, öffnet nur notwendige Vorfahren und fokussiert explizit ohne unnötigen Zoom.
- Sichtbare Aktion zum gezielten Sprung auf eine tatsächlich nicht sichtbare Auswahl; keine automatische Kamera bei Live-Updates, Refetches oder Inspector-Interaktionen.
- Playwright- und Frontend-Regressionstests für Suche, Deep Links, Collapse, Offscreen-Fokus und A11y ergänzt.

## Entscheidungen
- Kein optionaler Breadcrumb: nicht für Akzeptanzkriterien erforderlich.
- Suchfokus wird nach einer nachfolgenden Nutzer-Kameraaktion verworfen.

## Tests
- Frontend: 500 Tests, Lint, Typecheck, Build, Contract-, Locale- und UI-String-Checks.
- git diff --check.

## Einschränkungen
- Lokale Playwright-Ausführung war nicht möglich, weil e2e/node_modules fehlt; die CI führt die vollständige E2E-Suite aus.