### PR TITLE
Improve readable semantic architecture zoom

### DIFF
--- a/docs/decisions/0017-readable-entry-zoom-and-progressive-disclosure.md
+++ b/docs/decisions/0017-readable-entry-zoom-and-progressive-disclosure.md
@@ -1,5 +1,10 @@
 # 17. A readable entry picture: a floor under the automatic zoom and a hierarchy that opens on demand
 
+> **Threshold note:** Issue #56 / [ADR 0024](./0024-readable-semantic-zoom-levels.md)
+> supersedes this record's former 10 px-derived `0.77` floor with separate
+> effective floors for primary (12 px) and secondary (10 px) text. The hierarchy
+> disclosure and camera ownership decisions below remain in force.
+
 - **Status:** accepted
 - **Date:** 2026-08-04
 - **Context issue:** #34 (part of the v0 epic #1)

--- a/docs/decisions/0024-readable-semantic-zoom-levels.md
+++ b/docs/decisions/0024-readable-semantic-zoom-levels.md
@@ -1,0 +1,66 @@
+# 24. Readable semantic zoom levels for the architecture canvas
+
+- **Status:** accepted
+- **Date:** 2026-08-17
+- **Context issue:** #56
+- **Supersedes:** the readability floor and detail thresholds in [0017 — Readable entry zoom and progressive disclosure](./0017-readable-entry-zoom-and-progressive-disclosure.md)
+
+## Decision
+
+The canvas is rendered inside a CSS transform, so a font declared as 10 px is
+not a 10 px label on screen. The product documents two effective text floors:
+
+| text class | declared size at zoom 1 | effective minimum | derived threshold |
+| --- | ---: | ---: | ---: |
+| primary (component names) | 13 px | 12 px | `ceil(12 / 13, 2) = 0.93` |
+| secondary (kind, technology, badges, tags, relationship adjuncts) | 10 px | 10 px | `10 / 10 = 1.00` |
+
+The automatic camera uses `MIN_READABLE_ZOOM = 0.93`. It may never choose a
+zoom below the primary floor at either supported desktop viewport. A user may
+still request the spatial whole-model map, which can zoom farther out because
+its purpose is orientation rather than reading.
+
+Detail is a pure presentation decision. Node sizes, ELK input, positions,
+selection, search and inspector state do not depend on it:
+
+| semantic stage | zoom | visible canvas content | hidden detail remains available through |
+| --- | ---: | --- | --- |
+| **Map / Karte** | `< 0.93` | node shape/icon and relationship lines | node/edge selection, tooltip/title, inspector |
+| **Readable overview / Lesbare Übersicht** | `0.93–<1.00` | primary names; 11 px state/count summaries | selection, inspector, container disclosure |
+| **Standard / Standard** | `1.00–<1.15` | names, kind, technology and short relationship adjuncts | title/tooltip and inspector for full reported values |
+| **Full / Vollständig** | `≥ 1.15` | tags and individually fanned relationship labels | inspector and relationship selection |
+
+Long relationship discriminators are never required for the normal canvas
+label. They remain verbatim in the title/tooltip and relationship inspector.
+At the map stage all text labels are removed, while the relationship path and
+accessible edge name remain interactive.
+
+The toolbar names the two camera intents explicitly:
+
+- **Lesbare Systemübersicht / Readable system overview** restores the entry
+  picture and its readable camera floor.
+- **Gesamtkarte / Whole-model map** expands every container and fits the full
+  model as a spatial orientation map. It explains why labels can become hidden
+  and does not change the model or disable search/selection.
+
+The current semantic stage is always shown in the toolbar and the exact zoom is
+published as `data-canvas-zoom` on the canvas for diagnostics and acceptance
+checks. Detail changes do not relayout or move nodes. Existing transitions
+respect `prefers-reduced-motion: reduce`.
+
+## Acceptance matrix (working note)
+
+| criterion | 1280 × 720 | 1920 × 1080 | verification |
+| --- | --- | --- | --- |
+| Automatic camera | zoom ≥ 0.93; primary ≥ 12 px | zoom ≥ 0.93; primary ≥ 12 px | `ArchitectureZoom.test.tsx`, Playwright canvas check |
+| No undersized secondary text | at 0.93: no 10 px rows/badges; metadata starts at 1.00 | same | `detailLevel.test.ts`, stage-content E2E |
+| Spatial whole-model map | may be below 0.93; label explains orientation purpose | may be below 0.93; label explains orientation purpose | camera/toolbar tests |
+| Reachability | search, selection, path click and inspector remain available | same | architecture canvas + Playwright |
+| Stable layout | stage changes only content; no ELK rerun or position shift | same | box-size invariant/unit tests |
+| Motion preference | transition durations collapse to a near-zero duration | same | reduced-motion CSS rule |
+| Language parity | German keys and labels present | English keys and labels present | `check:locales`, `check:ui-strings` |
+
+Local Compose E2E is intentionally not run as part of this change: it mutates
+the shared simulator/database state and is outside a safe unit/Playwright
+verification run. The repository's existing CI Compose job remains the place
+for that destructive integration check.

--- a/e2e/src/canvas.ts
+++ b/e2e/src/canvas.ts
@@ -5,8 +5,8 @@ import { expect, type Page } from '@playwright/test'
  *
  * A project opens on its system and container level with deeper containers
  * collapsed, so that a model of thirty-odd components is readable at the
- * resolution this suite accepts at (issue #34, ADR 0017). "Gesamtes Modell
- * einpassen" is the explicit overview action that undoes it — the same button a
+ * resolution this suite accepts at (issue #34, ADR 0017). "Gesamtkarte" is the
+ * explicit spatial action that undoes it — the same button a
  * user presses — so assertions about components three and four levels down go
  * through it rather than around it.
  *

--- a/e2e/tests/03-architecture.spec.ts
+++ b/e2e/tests/03-architecture.spec.ts
@@ -169,6 +169,42 @@ async function zoomToFullDetail(page: Page): Promise<void> {
   await expect(canvas).toHaveAttribute('data-detail-level', 'full')
 }
 
+test('2 · readable semantic stages expose only content that fits at both desktop sizes', async ({
+  page,
+}) => {
+  for (const viewport of [
+    { width: 1280, height: 720 },
+    { width: 1920, height: 1080 },
+  ] as const) {
+    await page.setViewportSize(viewport)
+    await openWorkspace(page)
+
+    const canvas = page.getByTestId('architecture-canvas')
+    await expect(canvas).toHaveAttribute('data-fit-view-count', '1')
+    const zoom = Number(await canvas.getAttribute('data-canvas-zoom'))
+    expect(zoom).toBeGreaterThanOrEqual(0.93)
+    const initialLevel = await canvas.getAttribute('data-detail-level')
+    expect(['overview', 'standard']).toContain(initialLevel)
+
+    // The readable entry picture keeps primary names but does not paint the
+    // 10 px technology rows/badges below their effective 10 px floor.
+    await expect(page.locator('[data-testid="node-name"]').first()).toBeVisible()
+    if (initialLevel === 'overview') {
+      await expect(page.locator('[data-testid="node-technology"]')).toHaveCount(0)
+    }
+
+    const zoomIn = page.locator('.react-flow__controls-zoomin')
+    if (initialLevel === 'overview') {
+      await zoomIn.click()
+      await expect(canvas).toHaveAttribute('data-detail-level', 'standard')
+    }
+    await expect(page.locator('[data-testid="node-technology"]').first()).toBeVisible()
+
+    await zoomToFullDetail(page)
+    await expect(canvas).toHaveAttribute('data-detail-level', 'full')
+  }
+})
+
 test.describe.configure({ mode: 'serial' })
 
 test('2 · the canvas draws the reported hierarchy across four nesting levels', async ({

--- a/frontend/src/canvas/ArchitectureAccessibility.test.tsx
+++ b/frontend/src/canvas/ArchitectureAccessibility.test.tsx
@@ -548,7 +548,7 @@ describe('accessible architecture graph — the state a screen reader hears is t
  *
  * A **pan** is a different matter. React Flow's `autoPanOnNodeFocus` brings a
  * node that lies outside the viewport into view at the same zoom, and it is
- * deliberately left on (ADR 0018): since ADR 0017 the entry zoom is 0.77 rather
+ * deliberately left on (ADR 0018): since ADR 0024 the entry zoom is 0.93 rather
  * than 0.20, so a large model no longer fits on screen and a focus ring on an
  * off-screen node would be a ring nobody can see. That pan is requested by the
  * user's own Tab press — never by arriving data.

--- a/frontend/src/canvas/ArchitectureAccessibility.test.tsx
+++ b/frontend/src/canvas/ArchitectureAccessibility.test.tsx
@@ -247,6 +247,35 @@ describe('accessible architecture graph — every node arrives named', () => {
 
 describe('accessible architecture graph — selection by keyboard alone', () => {
   it(
+    'selects the first relationship of a bundled edge with Enter at map level',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderGraph()
+      const canvas = await waitForCanvas()
+
+      await user.click(screen.getByTestId('canvas-fit-view'))
+      await waitFor(() => expect(canvas).toHaveAttribute('data-detail-level', 'minimal'))
+
+      const edge = document.querySelector<HTMLElement>(
+        '.react-flow__edge[data-id="rel:platform.core.orders~>platform.bus"]',
+      )
+      expect(edge).not.toBeNull()
+      edge?.focus()
+      await user.keyboard('{Enter}')
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ relationship: 'r-05' }),
+      )
+      expect(await screen.findByTestId('inspector-relationship-context')).toHaveAttribute(
+        'data-relationship-id',
+        'r-05',
+      )
+      expect(document.activeElement).toBe(edge)
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
     'selects a single relationship with Enter and preserves edge focus',
     async () => {
       const user = userEvent.setup()

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -366,6 +366,29 @@ describe('architecture canvas — edge bundling stays resolvable', () => {
   )
 
   it(
+    'selects the first bundle member from the map control when another member is selected',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCanvas(`${WORKSPACE_URL}?relationship=r-06`)
+      const canvas = await waitForCanvas()
+
+      await user.click(screen.getByTestId('canvas-fit-view'))
+      await waitFor(() => expect(canvas).toHaveAttribute('data-detail-level', 'minimal'))
+
+      await user.click(await screen.findByTestId(`edge-bundle-${BUNDLE_EDGE_ID}`))
+
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ relationship: 'r-05' }),
+      )
+      expect(await screen.findByTestId('inspector-relationship-context')).toHaveAttribute(
+        'data-relationship-id',
+        'r-05',
+      )
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
     'selecting one topic of an unfolded bundle marks exactly that relationship',
     async () => {
       const user = userEvent.setup()

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -332,6 +332,40 @@ describe('architecture canvas — edge bundling stays resolvable', () => {
   )
 
   it(
+    'keeps a bundled relationship inspectable from the icon-only map control',
+    async () => {
+      const user = userEvent.setup()
+      const { router } = renderCanvas()
+      const canvas = await waitForCanvas()
+
+      await user.click(screen.getByTestId('canvas-fit-view'))
+      await waitFor(() => expect(canvas).toHaveAttribute('data-detail-level', 'minimal'))
+
+      const bundle = await screen.findByTestId(`edge-bundle-${BUNDLE_EDGE_ID}`)
+      expect(bundle).toHaveAttribute('title', expect.stringContaining('Inspector'))
+      expect(bundle).toHaveAttribute('aria-label', expect.stringContaining('Inspector'))
+      expect(bundle.querySelector('svg')).toBeInTheDocument()
+      expect(bundle.textContent).not.toContain('NATS')
+
+      // Map-level activation selects a real member, so the inspector can show
+      // the selected relationship and the complete bundle without tiny labels.
+      await user.click(bundle)
+      await waitFor(() =>
+        expect(router.state.location.search).toEqual({ relationship: 'r-05' }),
+      )
+      expect(await screen.findByTestId('inspector-relationship-context')).toHaveAttribute(
+        'data-relationship-id',
+        'r-05',
+      )
+      expect(screen.getByTestId('inspector-relationship-bundle')).toHaveTextContent(
+        'NATS · orders.created',
+      )
+      expect(screen.queryByTestId('edge-label-r-05')).not.toBeInTheDocument()
+    },
+    CANVAS_TIMEOUT,
+  )
+
+  it(
     'selecting one topic of an unfolded bundle marks exactly that relationship',
     async () => {
       const user = userEvent.setup()

--- a/frontend/src/canvas/ArchitectureCanvas.test.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.test.tsx
@@ -51,7 +51,7 @@ function architectureFetch(initial: ArchitectureResponse) {
  * ADR 0017), which is what `ArchitectureZoom.test.tsx` covers. The assertions
  * in this file are about bundling, selection and the camera on components that
  * sit three and four levels down, so they start from the state the user reaches
- * with "Gesamtes Modell einpassen" — a real, reachable state, and the one these
+ * with "Gesamtkarte" — a real, reachable state, and the one these
  * tests have always described.
  */
 function renderCanvas(
@@ -262,7 +262,7 @@ describe('architecture canvas — edge bundling stays resolvable', () => {
       // The initial fit intentionally stays readable. Explicitly fitting the
       // whole model gives this test the actual overview interaction state.
       await user.click(screen.getByTestId('canvas-fit-view'))
-      await waitFor(() => expect(canvas).toHaveAttribute('data-detail-level', 'overview'))
+      await waitFor(() => expect(canvas).toHaveAttribute('data-detail-level', 'minimal'))
 
       // Individual labels stay hidden at overview so the graph does not become
       // a wall of long reported values. The line itself remains the hit target.

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -732,14 +732,26 @@ function ArchitectureCanvasInner({
   )
 
   /**
-   * The path is the hit target in overview, where an individual relationship
-   * deliberately has no label. Bundles remain a disclosure action: the path
-   * opens them, while their expanded labels select one member at a time.
+   * The path is the hit target when labels are hidden. At readable levels a
+   * bundle remains a disclosure action: the path opens it, while its expanded
+   * labels select one member at a time. At map level the path selects the first
+   * member in the inspector, because expanding labels would violate the text
+   * floor.
    */
   const onEdgeClick = useCallback<EdgeMouseHandler<ArchitectureEdge>>(
     (_event, edge) => {
       const relationships = edge.data?.relationships ?? []
       if (relationships.length > 1) {
+        if (detailLevel === 'minimal') {
+          const first = relationships[0]
+          if (!first) return
+          ;(onSelectRelationship ?? setStoredSelectedRelationshipId)(
+            first.relationshipId === visualSelectedRelationshipId
+              ? null
+              : first.relationshipId,
+          )
+          return
+        }
         toggleEdgeExpanded(edge.id)
         return
       }
@@ -753,6 +765,7 @@ function ArchitectureCanvasInner({
       onSelectRelationship,
       setStoredSelectedRelationshipId,
       toggleEdgeExpanded,
+      detailLevel,
       visualSelectedRelationshipId,
     ],
   )
@@ -807,7 +820,9 @@ function ArchitectureCanvasInner({
    * writes the `component` search parameter, which is the same path a click
    * takes, so the URL, the selection and the inspector cannot drift apart.
    * Activating an edge unfolds a bundle or selects the single relationship —
-   * the same two actions its badges offer to the mouse.
+   * the same two actions its badges offer to the mouse. At map level the
+   * bundle control is icon-only, so activation selects its first relationship
+   * for the inspector instead of exposing text below the readability floor.
    *
    * A real control *inside* a node — the disclosure toggle of a container — is
    * left alone: it is its own tab stop with its own action, and a container
@@ -874,6 +889,16 @@ function ArchitectureCanvasInner({
       const edge = edges.find((candidate) => candidate.id === edgeId)
       const relationships = edge?.data?.relationships ?? []
       if (relationships.length > 1) {
+        if (detailLevel === 'minimal') {
+          const first = relationships[0]
+          if (!first) return
+          ;(onSelectRelationship ?? setStoredSelectedRelationshipId)(
+            first.relationshipId === activeSelectedRelationshipId
+              ? null
+              : first.relationshipId,
+          )
+          return
+        }
         toggleEdgeExpanded(edgeId)
         return
       }
@@ -890,6 +915,7 @@ function ArchitectureCanvasInner({
       activeSelectedRelationshipId,
       onSelectRelationship,
       setStoredSelectedRelationshipId,
+      detailLevel,
       openSearch,
       toggleEdgeExpanded,
     ],

--- a/frontend/src/canvas/ArchitectureCanvas.tsx
+++ b/frontend/src/canvas/ArchitectureCanvas.tsx
@@ -106,8 +106,8 @@ import { useCanvasVoice } from './useCanvasVoice'
  *    project and on an explicit click, never because data arrived.
  * 4. **The first picture is readable.** The automatic camera never goes below
  *    `MIN_READABLE_ZOOM`, and a project opens on its top levels with deeper
- *    containers collapsed (`collapse.ts`). Both are undone by an explicit
- *    "Gesamtes Modell einpassen", never by anything the data does.
+ *    containers collapsed (`collapse.ts`). Both are undone by the explicit
+ *    spatial "Gesamtkarte", never by anything the data does.
  *
  * The accessible surface — names, roles and states of the nodes and edges —
  * lives in `./canvasAccessibility`; this component only wires it up, owns the
@@ -489,7 +489,7 @@ function ArchitectureCanvasInner({
   const requestFit = useCallback(
     (mode: FitMode, afterRelayout: boolean) => {
       invalidatePendingSearchFocus()
-      // "Systemebene" reproduces the entry picture, and the entry picture keeps
+      // "Lesbare Systemübersicht" reproduces the entry picture, and the entry picture keeps
       // the selected component on screen. The whole-model overview does not: it
       // is about the model, not about one component of it.
       const focusComponentId =
@@ -924,7 +924,7 @@ function ArchitectureCanvasInner({
     [onToggleCollapsed],
   )
 
-  /** "Gesamtes Modell einpassen": everything open, everything on screen. */
+  /** "Gesamtkarte": everything open, everything on screen for orientation. */
   const onShowWholeModel = useCallback(() => {
     const willRelayout = graph.collapsedIds.length > 0
     if (willRelayout) setCollapsedComponentIds([])

--- a/frontend/src/canvas/ArchitectureZoom.test.tsx
+++ b/frontend/src/canvas/ArchitectureZoom.test.tsx
@@ -17,7 +17,7 @@ import { PROJECT_ID, RUN_ID, createFakeFetch, streamedEvent } from '@/test/fixtu
 import { renderApp } from '@/test/renderApp'
 
 import {
-  MIN_LEGIBLE_FONT_SIZE_PX,
+  MIN_PRIMARY_TEXT_SIZE_PX,
   MIN_READABLE_ZOOM,
   NODE_LABEL_FONT_SIZE_PX,
 } from './detailLevel'
@@ -156,15 +156,14 @@ describe('architecture canvas — a large model opens readable', () => {
 
       const { zoom } = useUiStore.getState().camera
 
-      // The acceptance criterion, as a measurement: the name of a visible
-      // component is at least as large as the smallest type the product
-      // renders anywhere else.
+      // The acceptance criterion, as a measurement: primary text is at least
+      // 12 effective px in the automatic picture.
       expect(zoom).toBeGreaterThanOrEqual(MIN_READABLE_ZOOM)
       expect(NODE_LABEL_FONT_SIZE_PX * zoom).toBeGreaterThanOrEqual(
-        MIN_LEGIBLE_FONT_SIZE_PX,
+        MIN_PRIMARY_TEXT_SIZE_PX,
       )
-      expect(LEAF_NODE_SIZE.width * zoom).toBeGreaterThanOrEqual(175)
-      expect(LEAF_NODE_SIZE.height * zoom).toBeGreaterThanOrEqual(73)
+      expect(LEAF_NODE_SIZE.width * zoom).toBeGreaterThanOrEqual(210)
+      expect(LEAF_NODE_SIZE.height * zoom).toBeGreaterThanOrEqual(89)
 
       // Still exactly one automatic camera movement.
       expect(canvas.getAttribute('data-fit-view-count')).toBe('1')

--- a/frontend/src/canvas/ChangeOverlayMark.tsx
+++ b/frontend/src/canvas/ChangeOverlayMark.tsx
@@ -13,9 +13,11 @@ import { overlayLabel, overlayTitle, type ChangeOverlay } from './changeOverlays
  * always renders
  *
  * 1. the state's **icon** (a distinct glyph per state),
- * 2. the state's **label as text** — `geplant`, `aktiv`, `kürzlich angewandt`,
- *    `entfernt` — extended by the operation, so `geplant · entfernen` and
- *    `geplant · hinzufügen` are told apart by words rather than by hue, and
+ * 2. the state's **label as text** at readable levels — `geplant`, `aktiv`,
+ *    `kürzlich angewandt`, `entfernt` — extended by the operation, so
+ *    `geplant · entfernen` and `geplant · hinzufügen` are told apart by words
+ *    rather than by hue; the compact map form keeps that label screen-reader
+ *    only, and
  * 3. a border in the state's **line style** (dashed, double, solid, dotted),
  *
  * with the colour on top of all three. A greyscale screenshot of the canvas
@@ -23,9 +25,9 @@ import { overlayLabel, overlayTitle, type ChangeOverlay } from './changeOverlays
  * `data-operation` make that testable without looking at a single colour.
  *
  * When more than one agent reported for the same element, the count is shown
- * next to the label and every single contribution is listed in the `title`.
- * Nothing is merged away: two agents working on one component must be visible
- * as two.
+ * next to the label at readable zoom and every single contribution is listed
+ * in the `title`. The compact map mark keeps only the state icon; its title
+ * still exposes the complete context without rendering text below 10 px.
  */
 export interface ChangeOverlayMarkProps {
   overlay: ChangeOverlay
@@ -49,8 +51,8 @@ export function ChangeOverlayMark({
     <span
       className={cn(
         // Overlay labels are secondary text. At zoom 0.93 they therefore use
-        // 11 px (10.2 effective px); the compact form keeps only the icon when
-        // even primary text is below its floor.
+        // The compact form keeps only the icon when the map is below the
+        // secondary-text floor; the title remains the detailed fallback.
         'inline-flex max-w-full shrink-0 items-center gap-1 rounded-sm border px-1 py-px text-[11px] leading-tight',
         'bg-card/90',
         className,
@@ -76,7 +78,7 @@ export function ChangeOverlayMark({
       ) : (
         <span className="truncate">{label}</span>
       )}
-      {agentCount > 1 && (
+      {!compact && agentCount > 1 && (
         <span className="inline-flex shrink-0 items-center gap-0.5 font-medium">
           <Users className="size-3" aria-hidden="true" />
           {agentCount}

--- a/frontend/src/canvas/ChangeOverlayMark.tsx
+++ b/frontend/src/canvas/ChangeOverlayMark.tsx
@@ -48,7 +48,10 @@ export function ChangeOverlayMark({
   return (
     <span
       className={cn(
-        'inline-flex max-w-full shrink-0 items-center gap-1 rounded-sm border px-1 py-px text-[10px] leading-tight',
+        // Overlay labels are secondary text. At zoom 0.93 they therefore use
+        // 11 px (10.2 effective px); the compact form keeps only the icon when
+        // even primary text is below its floor.
+        'inline-flex max-w-full shrink-0 items-center gap-1 rounded-sm border px-1 py-px text-[11px] leading-tight',
         'bg-card/90',
         className,
       )}

--- a/frontend/src/canvas/ChangeOverlays.test.tsx
+++ b/frontend/src/canvas/ChangeOverlays.test.tsx
@@ -1,8 +1,9 @@
-import { act, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import type { ArchitectureResponse, Component, Relationship } from '@/api/types'
 import { applyLiveEvent } from '@/api/useLiveStream'
+import { EMPTY_LEDGER } from '@/state/changeLedger'
 import { DEFAULT_CAMERA, useUiStore } from '@/state/uiStore'
 import { WORK_STATES } from '@/state/workStates'
 import { translateWith } from '@/test/translate'
@@ -19,6 +20,8 @@ import {
 import { PROJECT_ID, RUN_ID, createFakeFetch, streamedEvent } from '@/test/fixtures'
 import { renderApp } from '@/test/renderApp'
 
+import { ChangeOverlayMark } from './ChangeOverlayMark'
+import { buildChangeOverlays } from './changeOverlays'
 /**
  * The live change overlays end to end: a committed event goes through the real
  * SSE apply path, the read model refetches, and the canvas shows the reported
@@ -476,6 +479,38 @@ describe('live change overlays — concurrent agents', () => {
     },
     CANVAS_TIMEOUT,
   )
+
+  it('keeps the compact mark icon-only while its title retains agent context', () => {
+    const overlay = buildChangeOverlays({
+      components: NESTED_COMPONENTS,
+      relationships: NESTED_RELATIONSHIPS,
+      activeChanges: [
+        activeChange({
+          changeId: 'change-a',
+          targetId: 'platform.core.orders',
+          operation: 'modify',
+          agentId: 'subagent-implementer',
+          position: 50,
+        }),
+        activeChange({
+          changeId: 'change-b',
+          targetId: 'platform.core.orders',
+          operation: 'modify',
+          agentId: 'subagent-reviewer',
+          position: 51,
+        }),
+      ],
+      ledger: { ...EMPTY_LEDGER },
+    }).components.get('platform.core.orders')
+
+    expect(overlay).toBeDefined()
+    render(<ChangeOverlayMark overlay={overlay!} compact />)
+
+    const mark = screen.getByTestId('overlay-mark-component-platform.core.orders')
+    expect(mark).not.toHaveTextContent('2')
+    expect(mark).toHaveAttribute('title', expect.stringContaining('2 Agents'))
+    expect(mark.querySelector('.lucide-users')).toBeNull()
+  })
 })
 
 describe('live change overlays — retraction', () => {

--- a/frontend/src/canvas/ComponentNode.tsx
+++ b/frontend/src/canvas/ComponentNode.tsx
@@ -18,7 +18,13 @@ import {
   componentTags,
   technologyParts,
 } from './componentKinds'
-import { DISCLOSURE_LABEL_KEYS, showsTags, showsTechnology } from './detailLevel'
+import {
+  DISCLOSURE_LABEL_KEYS,
+  showsKind,
+  showsPrimaryText,
+  showsTags,
+  showsTechnology,
+} from './detailLevel'
 import { HANDLE_IDS, type ArchitectureNode } from './graphProjection'
 import type { GraphOrientation } from './graphOrientation'
 import { CanvasNodeActionsContext } from './nodeActions'
@@ -247,18 +253,26 @@ export const ComponentNode = memo(function ComponentNode({
     >
       <div className="flex items-start gap-1.5">
         <Icon className="text-muted-foreground mt-px size-3.5 shrink-0" aria-hidden="true" />
-        <span
-          className="text-foreground min-w-0 flex-1 truncate text-[13px] leading-tight font-medium"
-          title={component.name}
-          data-testid="node-name"
-        >
-          {/* The component's reported name. Not ours, so never translated. */}
-          <ReportedText value={component.name} />
-        </span>
-        <KindBadge label={componentKindLabel(component.kind, t)} />
+        {showsPrimaryText(level) && (
+          <span
+            className="text-foreground min-w-0 flex-1 truncate text-[13px] leading-tight font-medium"
+            title={component.name}
+            data-testid="node-name"
+          >
+            {/* The component's reported name. Not ours, so never translated. */}
+            <ReportedText value={component.name} />
+          </span>
+        )}
+        {showsKind(level) && <KindBadge label={componentKindLabel(component.kind, t)} />}
       </div>
 
-      {overlay && <ChangeOverlayMark overlay={overlay} className="self-start" />}
+      {overlay && (
+        <ChangeOverlayMark
+          overlay={overlay}
+          compact={!showsPrimaryText(level)}
+          className="self-start"
+        />
+      )}
       {showsTechnology(level) && <TechnologyRow parts={technology} />}
       {showsTags(level) && <TagRow tags={tags} />}
 
@@ -334,13 +348,15 @@ export const CompoundNode = memo(function CompoundNode({
           hiddenCount={collapsed ? hiddenCount : childCount}
         />
         <Icon className="text-muted-foreground size-3.5 shrink-0" aria-hidden="true" />
-        <span
-          className="text-foreground min-w-0 flex-1 truncate text-[13px] leading-tight font-medium"
-          title={component.name}
-          data-testid="node-name"
-        >
-          <ReportedText value={component.name} />
-        </span>
+        {showsPrimaryText(level) && (
+          <span
+            className="text-foreground min-w-0 flex-1 truncate text-[13px] leading-tight font-medium"
+            title={component.name}
+            data-testid="node-name"
+          >
+            <ReportedText value={component.name} />
+          </span>
+        )}
         {/* A closed container is only as wide as a leaf, so the metadata moves
             out of the header — squeezed between a technology string and two
             badges, the name is the first thing to lose its space, and the name
@@ -353,25 +369,27 @@ export const CompoundNode = memo(function CompoundNode({
             <ReportedText value={technology.join(' · ')} />
           </span>
         )}
-        {overlay && <ChangeOverlayMark overlay={overlay} />}
-        {!collapsed && (
-          <span className="text-muted-foreground shrink-0 text-[10px]">
+        {overlay && <ChangeOverlayMark overlay={overlay} compact={!showsPrimaryText(level)} />}
+        {!collapsed && showsPrimaryText(level) && (
+          <span className="text-muted-foreground shrink-0 text-[11px]">
             {tCommon('count.child', { count: childCount })}
           </span>
         )}
-        <KindBadge label={componentKindLabel(component.kind, t)} />
+        {showsKind(level) && <KindBadge label={componentKindLabel(component.kind, t)} />}
       </div>
 
       {collapsed && (
         <div className="flex flex-col gap-1 px-2.5 pt-1.5">
-          <p
-            className="text-muted-foreground text-[10px] leading-tight"
-            data-testid="node-hidden-count"
-          >
-            {t('node.collapsed', {
-              components: tCommon('count.component', { count: hiddenCount }),
-            })}
-          </p>
+          {showsPrimaryText(level) && (
+            <p
+              className="text-muted-foreground text-[11px] leading-tight"
+              data-testid="node-hidden-count"
+            >
+              {t('node.collapsed', {
+                components: tCommon('count.component', { count: hiddenCount }),
+              })}
+            </p>
+          )}
           {showsTechnology(level) && <TechnologyRow parts={technology} />}
         </div>
       )}

--- a/frontend/src/canvas/RelationshipEdge.tsx
+++ b/frontend/src/canvas/RelationshipEdge.tsx
@@ -1,5 +1,6 @@
 import { EdgeLabelRenderer, useStore, type EdgeProps } from '@xyflow/react'
 import type { TFunction } from 'i18next'
+import { Layers2 } from 'lucide-react'
 import { memo, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -38,8 +39,10 @@ import { useDetailLevel } from './useDetailLevel'
  * rendering decision that depends on the zoom level and on what the user asked
  * for — it is never a change to the model:
  *
- * * folded (low zoom, default): one line plus a badge with the count, and the
+ * * folded (readable overview): one line plus a badge with the count, and the
  *   kinds it contains,
+ * * map level: one line plus an icon-only control that selects a member in the
+ *   inspector without putting secondary text below its effective-size floor,
  * * unfolded (high zoom, or after a click on the badge): one line per
  *   relationship, each labelled with a bounded identifier — the topic name for
  *   a NATS topic, the operation for a call. Full reported text stays on the
@@ -148,8 +151,10 @@ function EdgeBadge({
   zIndex,
   onClick,
   title,
+  ariaLabel,
   testId,
   emphasised,
+  iconOnly = false,
   detail,
   shortDetail,
   dimmed = false,
@@ -161,8 +166,11 @@ function EdgeBadge({
   zIndex: number
   onClick?: () => void
   title?: string
+  ariaLabel?: string | undefined
   testId?: string
   emphasised?: boolean
+  /** Render an icon-only action when the camera is below the text floor. */
+  iconOnly?: boolean
   /** Full reported discriminator, shown on focus and selection. */
   detail?: string | null
   /** Bounded discriminator shown in the normal canvas state. */
@@ -177,6 +185,7 @@ function EdgeBadge({
     // Relationship badges are secondary text. An 11 px base keeps their
     // effective size above 10 px in the readable overview (zoom 0.93).
     'pointer-events-auto rounded-sm border px-1 py-px font-mono text-[11px] leading-tight whitespace-nowrap',
+    iconOnly && 'size-7 justify-center p-1',
     emphasised
       ? 'border-ring/70 bg-popover text-foreground'
       : 'border-border bg-popover/95 text-muted-foreground',
@@ -211,11 +220,12 @@ function EdgeBadge({
         title={title}
         aria-current={emphasised ? 'true' : undefined}
         aria-label={
-          detail
+          ariaLabel ??
+          (detail
             ? `${children} · ${detail}`
             : typeof children === 'string'
               ? children
-              : undefined
+              : undefined)
         }
         data-testid={testId}
       >
@@ -399,21 +409,46 @@ export const RelationshipEdge = memo(function RelationshipEdge({
               compact={level === 'minimal'}
             />
           )}
-          {bundled && level !== 'minimal' ? (
+          {bundled ? (
             <EdgeBadge
               point={badgePoint}
               zIndex={edgeLabelZIndex}
-              onClick={() => toggleEdgeExpanded(id)}
+              onClick={() => {
+                if (level === 'minimal') {
+                  const first = resolved[0]
+                  if (!first) return
+                  selectRelationship(
+                    emphasised ? null : first.relationship.relationshipId,
+                  )
+                  return
+                }
+                toggleEdgeExpanded(id)
+              }}
               // The display names are built from reported values; they are
               // interpolated into our sentence, never rewritten.
-              title={t('edge.bundleExpand', {
-                relationships: resolved.map((entry) => entry.displayName).join(', '),
-              })}
+              title={t(
+                level === 'minimal' ? 'edge.bundleSelect' : 'edge.bundleExpand',
+                { relationships: resolved.map((entry) => entry.displayName).join(', ') },
+              )}
+              ariaLabel={
+                level === 'minimal'
+                  ? t('edge.bundleSelect', {
+                      relationships: resolved
+                        .map((entry) => entry.displayName)
+                        .join(', '),
+                    })
+                  : undefined
+              }
               testId={`edge-bundle-${id}`}
+              iconOnly={level === 'minimal'}
               dimmed={dimmed}
               {...(hasSelection ? { onEscape: () => selectRelationship(null) } : {})}
             >
-              {badgeLabel} ▸
+              {level === 'minimal' ? (
+                <Layers2 className="size-4" aria-hidden="true" />
+              ) : (
+                `${badgeLabel} ▸`
+              )}
             </EdgeBadge>
           ) : (
             (level === 'standard' || level === 'full') &&

--- a/frontend/src/canvas/RelationshipEdge.tsx
+++ b/frontend/src/canvas/RelationshipEdge.tsx
@@ -418,7 +418,9 @@ export const RelationshipEdge = memo(function RelationshipEdge({
                   const first = resolved[0]
                   if (!first) return
                   selectRelationship(
-                    emphasised ? null : first.relationship.relationshipId,
+                    first.relationship.relationshipId === selectedRelationshipId
+                      ? null
+                      : first.relationship.relationshipId,
                   )
                   return
                 }

--- a/frontend/src/canvas/RelationshipEdge.tsx
+++ b/frontend/src/canvas/RelationshipEdge.tsx
@@ -174,7 +174,9 @@ function EdgeBadge({
 }) {
   const [focused, setFocused] = useState(false)
   const className = cn(
-    'pointer-events-auto rounded-sm border px-1 py-px font-mono text-[10px] leading-tight whitespace-nowrap',
+    // Relationship badges are secondary text. An 11 px base keeps their
+    // effective size above 10 px in the readable overview (zoom 0.93).
+    'pointer-events-auto rounded-sm border px-1 py-px font-mono text-[11px] leading-tight whitespace-nowrap',
     emphasised
       ? 'border-ring/70 bg-popover text-foreground'
       : 'border-border bg-popover/95 text-muted-foreground',
@@ -242,12 +244,14 @@ function EdgeOverlayMark({
   overlay,
   zIndex,
   dimmed = false,
+  compact = false,
 }: {
   point: LayoutPoint
   overlay: ChangeOverlay
   /** Keep the visual mark above its edge without intercepting edge input. */
   zIndex: number
   dimmed?: boolean
+  compact?: boolean
 }) {
   return (
     <span
@@ -258,7 +262,7 @@ function EdgeOverlayMark({
       }}
       className={cn('pointer-events-none', dimmed && 'opacity-25')}
     >
-      <ChangeOverlayMark overlay={overlay} />
+      <ChangeOverlayMark overlay={overlay} compact={compact} />
     </span>
   )
 }
@@ -337,7 +341,10 @@ export const RelationshipEdge = memo(function RelationshipEdge({
 
   const overlays = data.overlays ?? {}
   const bundled = resolved.length > 1
-  const unfolded = bundled && (unfoldsBundles(level) || expandedEdgeIds.includes(id))
+  const unfolded =
+    bundled &&
+    level !== 'minimal' &&
+    (unfoldsBundles(level) || expandedEdgeIds.includes(id))
   const selectedEntry = resolved.find(
     (entry) => entry.relationship.relationshipId === selectedRelationshipId,
   )
@@ -389,9 +396,10 @@ export const RelationshipEdge = memo(function RelationshipEdge({
               overlay={edgeOverlay}
               zIndex={edgeLabelZIndex}
               dimmed={dimmed}
+              compact={level === 'minimal'}
             />
           )}
-          {bundled ? (
+          {bundled && level !== 'minimal' ? (
             <EdgeBadge
               point={badgePoint}
               zIndex={edgeLabelZIndex}
@@ -408,7 +416,7 @@ export const RelationshipEdge = memo(function RelationshipEdge({
               {badgeLabel} ▸
             </EdgeBadge>
           ) : (
-            level !== 'overview' &&
+            (level === 'standard' || level === 'full') &&
             single && (
               <EdgeBadge
                 point={badgePoint}

--- a/frontend/src/canvas/cameraPolicy.test.ts
+++ b/frontend/src/canvas/cameraPolicy.test.ts
@@ -12,7 +12,7 @@ import {
   viewportForFocus,
   type CameraPolicyInput,
 } from './cameraPolicy'
-import { MIN_LEGIBLE_FONT_SIZE_PX, MIN_READABLE_ZOOM } from './detailLevel'
+import { MIN_PRIMARY_TEXT_SIZE_PX, MIN_READABLE_ZOOM } from './detailLevel'
 import { LEAF_NODE_SIZE } from './graphProjection'
 
 /** A settled 1920 × 1080 workspace: the centre pane is ~1036 × 933. */
@@ -153,7 +153,7 @@ describe('where the camera goes', () => {
     // Fitting all of it would need 0.48; the floor wins.
     expect(automatic.zoom).toBe(MIN_READABLE_ZOOM)
     expect(LEAF_NODE_SIZE.width * automatic.zoom).toBeGreaterThan(170)
-    expect(13 * automatic.zoom).toBeGreaterThanOrEqual(MIN_LEGIBLE_FONT_SIZE_PX)
+    expect(13 * automatic.zoom).toBeGreaterThanOrEqual(MIN_PRIMARY_TEXT_SIZE_PX)
   })
 
   it('holds the floor however many components there are', () => {

--- a/frontend/src/canvas/detailLevel.test.ts
+++ b/frontend/src/canvas/detailLevel.test.ts
@@ -7,11 +7,16 @@ import {
   DETAIL_LEVEL_THRESHOLDS,
   INITIAL_EXPANDED_DEPTH,
   MIN_LEGIBLE_FONT_SIZE_PX,
+  MIN_PRIMARY_TEXT_SIZE_PX,
+  MIN_SECONDARY_TEXT_SIZE_PX,
   MIN_READABLE_ZOOM,
   NODE_LABEL_FONT_SIZE_PX,
   detailLevelForZoom,
   effectiveLabelSize,
+  effectiveSecondaryTextSize,
   isReadableZoom,
+  isSecondaryTextReadable,
+  showsKind,
   showsTags,
   showsTechnology,
   unfoldsBundles,
@@ -19,9 +24,10 @@ import {
 import { LEAF_NODE_SIZE } from './graphProjection'
 
 describe('progressive detail levels', () => {
-  it('shows only name and kind when zoomed out', () => {
-    const level = detailLevelForZoom(0.3)
+  it('shows only the primary name in the readable overview', () => {
+    const level = detailLevelForZoom(0.94)
     expect(level).toBe('overview')
+    expect(showsKind(level)).toBe(false)
     expect(showsTechnology(level)).toBe(false)
     expect(showsTags(level)).toBe(false)
     expect(unfoldsBundles(level)).toBe(false)
@@ -41,7 +47,7 @@ describe('progressive detail levels', () => {
   })
 
   it('is monotonic and total', () => {
-    const order = { overview: 0, standard: 1, full: 2 }
+    const order = { minimal: 0, overview: 1, standard: 2, full: 3 }
     let previous = -1
     for (let zoom = 0.05; zoom <= 3; zoom += 0.05) {
       const current = order[detailLevelForZoom(zoom)]
@@ -49,11 +55,11 @@ describe('progressive detail levels', () => {
       previous = current
     }
     // A broken zoom value must not produce an undefined level.
-    expect(detailLevelForZoom(Number.NaN)).toBe('standard')
+    expect(detailLevelForZoom(Number.NaN)).toBe('minimal')
     // …and the level it produces still resolves to a real word, not a bare key.
     const t = translateWith('canvas')
     expect(t(DETAIL_LEVEL_LABEL_KEYS[detailLevelForZoom(Number.POSITIVE_INFINITY)])).toBe(
-      'Standard',
+      'Karte',
     )
   })
 
@@ -66,23 +72,28 @@ describe('progressive detail levels', () => {
 
 describe('the readable zoom', () => {
   it('is the zoom at which the node name reaches the smallest type of the design system', () => {
-    // Not a chosen number: the node name is 13 px and the product's own floor
-    // for legible type is 10 px, so the canvas may not scale a name below
-    // 10 / 13 ≈ 0.769. Rounded up, never down.
+    // Not a chosen number: the node name is 13 px and the documented primary
+    // text floor is 12 px, so the canvas may not scale it below 12 / 13 ≈
+    // 0.923. Rounded up, never down.
     expect(NODE_LABEL_FONT_SIZE_PX).toBe(13)
-    expect(MIN_LEGIBLE_FONT_SIZE_PX).toBe(10)
-    expect(MIN_READABLE_ZOOM).toBe(0.77)
+    expect(MIN_PRIMARY_TEXT_SIZE_PX).toBe(12)
+    expect(MIN_SECONDARY_TEXT_SIZE_PX).toBe(10)
+    expect(MIN_LEGIBLE_FONT_SIZE_PX).toBe(MIN_PRIMARY_TEXT_SIZE_PX)
+    expect(MIN_READABLE_ZOOM).toBe(0.93)
     expect(MIN_READABLE_ZOOM).toBeGreaterThanOrEqual(
-      MIN_LEGIBLE_FONT_SIZE_PX / NODE_LABEL_FONT_SIZE_PX,
+      MIN_PRIMARY_TEXT_SIZE_PX / NODE_LABEL_FONT_SIZE_PX,
     )
   })
 
   it('measures readability as an effective size, not as a zoom level', () => {
     expect(effectiveLabelSize(MIN_READABLE_ZOOM)).toBeGreaterThanOrEqual(
-      MIN_LEGIBLE_FONT_SIZE_PX,
+      MIN_PRIMARY_TEXT_SIZE_PX,
     )
     expect(isReadableZoom(MIN_READABLE_ZOOM)).toBe(true)
     // The zoom a 28-component model used to be fitted to: a 2.6 px name.
+    expect(isSecondaryTextReadable(1)).toBe(true)
+    expect(isSecondaryTextReadable(0.99)).toBe(false)
+    expect(effectiveSecondaryTextSize(0.77)).toBeCloseTo(7.7, 5)
     expect(isReadableZoom(0.2)).toBe(false)
     expect(effectiveLabelSize(0.2)).toBeCloseTo(2.6, 5)
   })
@@ -90,15 +101,16 @@ describe('the readable zoom', () => {
   it('turns the leaf box into something with room for a name', () => {
     const width = LEAF_NODE_SIZE.width * MIN_READABLE_ZOOM
     const height = LEAF_NODE_SIZE.height * MIN_READABLE_ZOOM
-    expect(Math.round(width)).toBe(176)
-    expect(Math.round(height)).toBe(74)
+    expect(Math.round(width)).toBe(212)
+    expect(Math.round(height)).toBe(89)
     // Against 46 × 20 at the old fitted zoom.
     expect(Math.round(LEAF_NODE_SIZE.width * 0.2)).toBe(46)
   })
 
   it('is a readable level, not the lowest detail level', () => {
-    // A model opened at the readable zoom shows technology as well as names.
-    expect(detailLevelForZoom(MIN_READABLE_ZOOM)).toBe('standard')
+    // A model opened at the readable zoom shows primary names only. 10 px
+    // metadata waits for zoom 1, where it is still 10 px effective.
+    expect(detailLevelForZoom(MIN_READABLE_ZOOM)).toBe('overview')
   })
 
   it('opens on the system and container levels', () => {

--- a/frontend/src/canvas/detailLevel.ts
+++ b/frontend/src/canvas/detailLevel.ts
@@ -10,7 +10,7 @@ import type { CanvasKey } from '@/i18n'
  *
  * | level      | nodes                        | edges                                  |
  * | ---------- | ---------------------------- | -------------------------------------- |
- * | `minimal`  | shape and icon only         | line only                              |
+ * | `minimal`  | shape and icon only         | line and icon-only inspector action    |
  * | `overview` | primary name                | bundled, count badge only              |
  * | `standard` | + kind and technology       | bundled, kind badge + count            |
  * | `full`     | + tags                       | bundles fanned out, one label per edge |

--- a/frontend/src/canvas/detailLevel.ts
+++ b/frontend/src/canvas/detailLevel.ts
@@ -10,8 +10,9 @@ import type { CanvasKey } from '@/i18n'
  *
  * | level      | nodes                        | edges                                  |
  * | ---------- | ---------------------------- | -------------------------------------- |
- * | `overview` | name + kind                  | bundled, count badge only              |
- * | `standard` | + technology                 | bundled, kind badge + count            |
+ * | `minimal`  | shape and icon only         | line only                              |
+ * | `overview` | primary name                | bundled, count badge only              |
+ * | `standard` | + kind and technology       | bundled, kind badge + count            |
  * | `full`     | + tags                       | bundles fanned out, one label per edge |
  *
  * Two rules keep this from becoming a source of surprise:
@@ -23,25 +24,31 @@ import type { CanvasKey } from '@/i18n'
  *    remains reachable by interaction at that same zoom level: a bundle can be
  *    unfolded by clicking it, and the inspector always has the full detail.
  */
-export type DetailLevel = 'overview' | 'standard' | 'full'
+export type DetailLevel = 'minimal' | 'overview' | 'standard' | 'full'
 
 /**
- * Zoom thresholds. Chosen so that the default `fitView` of a mid-sized model at
- * 1920 × 1080 lands in `standard`, a fitted large model in `overview`, and
- * reading a single component in `full`.
+ * Zoom thresholds derived from the type sizes rendered inside a transformed
+ * node. Primary text is 13 px at zoom 1 and must stay at least 12 px; secondary
+ * text is 10 px and must stay at least 10 px. The first readable picture is
+ * therefore `overview` (name only) and metadata starts at zoom 1. A model that
+ * is explicitly fitted below the primary floor becomes a `minimal` map rather
+ * than showing text that has become too small to read.
  */
 export const DETAIL_LEVEL_THRESHOLDS = {
-  /** At or above this zoom the technology metadata appears. */
-  standard: 0.62,
+  /** At or above this zoom the primary component name is readable. */
+  overview: 0.93,
+  /** At or above this zoom secondary 10 px metadata is readable. */
+  standard: 1,
   /** At or above this zoom tags appear and edge bundles fan out. */
   full: 1.15,
 } as const
 
 export function detailLevelForZoom(zoom: number): DetailLevel {
-  if (!Number.isFinite(zoom)) return 'standard'
+  if (!Number.isFinite(zoom)) return 'minimal'
   if (zoom >= DETAIL_LEVEL_THRESHOLDS.full) return 'full'
   if (zoom >= DETAIL_LEVEL_THRESHOLDS.standard) return 'standard'
-  return 'overview'
+  if (zoom >= DETAIL_LEVEL_THRESHOLDS.overview) return 'overview'
+  return 'minimal'
 }
 
 // ---------------------------------------------------------------------------
@@ -58,6 +65,9 @@ export function detailLevelForZoom(zoom: number): DetailLevel {
  */
 export const NODE_LABEL_FONT_SIZE_PX = 13
 
+/** Minimum effective size for primary text, such as a component name. */
+export const MIN_PRIMARY_TEXT_SIZE_PX = 12
+
 /**
  * The smallest type the design system renders at zoom 1: `text-[10px]`, used
  * for the kind badge, the technology row, the tags and the legends.
@@ -66,7 +76,13 @@ export const NODE_LABEL_FONT_SIZE_PX = 13
  * this rule — it is the size the cockpit already considers readable everywhere
  * that is *not* under a zoom transform.
  */
-export const MIN_LEGIBLE_FONT_SIZE_PX = 10
+export const SECONDARY_TEXT_FONT_SIZE_PX = 10
+
+/** Minimum effective size for visible secondary text and metadata. */
+export const MIN_SECONDARY_TEXT_SIZE_PX = 10
+
+/** Compatibility name for the former automatic-camera legibility floor. */
+export const MIN_LEGIBLE_FONT_SIZE_PX = MIN_PRIMARY_TEXT_SIZE_PX
 
 /**
  * Smallest zoom at which a node is still readable.
@@ -74,33 +90,43 @@ export const MIN_LEGIBLE_FONT_SIZE_PX = 10
  * The canvas draws its nodes inside a CSS transform, so every glyph on them is
  * scaled by the zoom: the effective size of the component name is
  * `NODE_LABEL_FONT_SIZE_PX × zoom`. Requiring that product to stay at or above
- * the product's own legibility floor gives
+ * the documented primary text floor gives
  *
  * ```
- * 13 px × zoom ≥ 10 px   ⇒   zoom ≥ 10 / 13 ≈ 0.7692
+ * 13 px × zoom ≥ 12 px   ⇒   zoom ≥ 12 / 13 ≈ 0.9231
  * ```
  *
- * rounded *up* to 0.77, so the floor is never undercut by the rounding. At that
- * zoom a leaf node measures 228 × 96 × 0.77 ≈ 176 × 74 CSS px and its name
- * renders at 10.0 px — against 46 × 20 px and 2.6 px at the zoom a 28-component
- * model used to be fitted to.
+ * rounded *up* to 0.93, so the floor is never undercut by the rounding. At that
+ * zoom a leaf node measures 228 × 96 × 0.93 ≈ 212 × 89 CSS px and its name
+ * renders at 12.1 px. Secondary 10 px text starts at zoom 1, so metadata never
+ * appears at a size below 10 px.
  *
  * The floor applies to the **automatic** camera only: the first picture of a
- * project, which the user did not ask for. An explicit "Gesamtes Modell
- * einpassen" still zooms out as far as the model needs, because the user asked
+ * project, which the user did not ask for. An explicit "Gesamtkarte" action
+ * still zooms out as far as the model needs, because the user asked
  * for the overview and knows what they traded for it.
  */
 export const MIN_READABLE_ZOOM =
-  Math.ceil((MIN_LEGIBLE_FONT_SIZE_PX / NODE_LABEL_FONT_SIZE_PX) * 100) / 100
+  Math.ceil((MIN_PRIMARY_TEXT_SIZE_PX / NODE_LABEL_FONT_SIZE_PX) * 100) / 100
 
 /** Effective size of the node label on screen at a given zoom, in CSS px. */
 export function effectiveLabelSize(zoom: number): number {
   return NODE_LABEL_FONT_SIZE_PX * zoom
 }
 
-/** `true` when a node's name is at or above the legibility floor at this zoom. */
+/** Effective size of 10 px secondary text on screen at a given zoom. */
+export function effectiveSecondaryTextSize(zoom: number): number {
+  return SECONDARY_TEXT_FONT_SIZE_PX * zoom
+}
+
+/** `true` when primary text is at or above its documented floor. */
 export function isReadableZoom(zoom: number): boolean {
-  return effectiveLabelSize(zoom) >= MIN_LEGIBLE_FONT_SIZE_PX
+  return effectiveLabelSize(zoom) >= MIN_PRIMARY_TEXT_SIZE_PX
+}
+
+/** `true` when secondary text is at or above its documented floor. */
+export function isSecondaryTextReadable(zoom: number): boolean {
+  return effectiveSecondaryTextSize(zoom) >= MIN_SECONDARY_TEXT_SIZE_PX
 }
 
 // ---------------------------------------------------------------------------
@@ -150,20 +176,32 @@ export const DISCLOSURE_LABEL_KEYS = {
 } as const satisfies Record<string, CanvasKey>
 
 export const DETAIL_LEVEL_LABEL_KEYS: Record<DetailLevel, CanvasKey> = {
+  minimal: 'detail.minimalLabel',
   overview: 'detail.overviewLabel',
   standard: 'detail.standardLabel',
   full: 'detail.fullLabel',
 }
 
 export const DETAIL_LEVEL_DESCRIPTION_KEYS: Record<DetailLevel, CanvasKey> = {
+  minimal: 'detail.minimalDescription',
   overview: 'detail.overviewDescription',
   standard: 'detail.standardDescription',
   full: 'detail.fullDescription',
 }
 
+/** `true` once the level is detailed enough to show the primary name. */
+export function showsPrimaryText(level: DetailLevel): boolean {
+  return level !== 'minimal'
+}
+
+/** `true` once the level is detailed enough to show a secondary kind label. */
+export function showsKind(level: DetailLevel): boolean {
+  return level === 'standard' || level === 'full'
+}
+
 /** `true` once the level is detailed enough to show technology metadata. */
 export function showsTechnology(level: DetailLevel): boolean {
-  return level !== 'overview'
+  return level === 'standard' || level === 'full'
 }
 
 /** `true` once the level is detailed enough to show tags. */

--- a/frontend/src/i18n/locales/de/canvas.json
+++ b/frontend/src/i18n/locales/de/canvas.json
@@ -39,10 +39,12 @@
   "detail": {
     "fullDescription": "Zusätzlich Tags. Gebündelte Beziehungen sind einzeln aufgefächert.",
     "fullLabel": "Vollständig",
-    "indicator": "Detailstufe: {{level}}",
-    "overviewDescription": "Nur Name und Art. Parallele Beziehungen sind gebündelt.",
-    "overviewLabel": "Übersicht",
-    "standardDescription": "Zusätzlich die gemeldete Technologie. Parallele Beziehungen sind gebündelt.",
+    "indicator": "Darstellungsstufe: {{level}}",
+    "minimalDescription": "Nur Form und Symbol. Texte werden ausgeblendet, bleiben aber über Auswahl und Inspector erreichbar.",
+    "minimalLabel": "Karte",
+    "overviewDescription": "Lesbare Übersicht mit primären Namen. Sekundärtexte erscheinen erst ab ausreichendem Zoom.",
+    "overviewLabel": "Lesbare Übersicht",
+    "standardDescription": "Zusätzlich Art und gemeldete Technologie. Sekundärtexte bleiben mindestens 10 px groß.",
     "standardLabel": "Standard"
   },
   "diagnostics": {
@@ -153,13 +155,13 @@
     }
   },
   "tool": {
-    "backToOverview": "Systemebene",
-    "backToOverviewHint": "Zurück auf System- und Container-Ebene: tiefere Komponenten werden wieder eingeklappt und die Ansicht in lesbarer Größe eingepasst.",
+    "backToOverview": "Lesbare Systemübersicht",
+    "backToOverviewHint": "Zur lesbaren Systemübersicht: tiefere Komponenten werden wieder eingeklappt und die Ansicht wird mit mindestens 12 px Primärtext eingepasst.",
     "collapse": "Einklappen",
     "expand": "Aufklappen",
     "expandHidden": "Aufklappen ({{hidden}})",
-    "fitWholeModel": "Gesamtes Modell einpassen",
-    "fitWholeModelHint": "Klappt alle Container auf und passt das vollständige Modell in die Fläche ein. Bei vielen Komponenten wird die Darstellung dabei bewusst klein — das ist die Übersichtsaktion. Die Kamera bewegt sich sonst nur beim ersten Laden — nie durch eintreffende Ereignisse.",
+    "fitWholeModel": "Gesamtkarte (gesamtes Modell)",
+    "fitWholeModelHint": "Öffnet alle Container und zeigt das vollständige Modell als räumliche Gesamtkarte. Bei vielen Komponenten wird die Darstellung bewusst klein; sie dient der Orientierung, nicht dem Lesen. Suche, Auswahl und Inspector bleiben verfügbar. Die Kamera bewegt sich sonst nur beim ersten Laden — nie durch eintreffende Ereignisse.",
     "hideMinimap": "Übersichtskarte ausblenden",
     "layoutLeftRight": "Links nach rechts",
     "layoutOrientation": "Graphausrichtung",
@@ -169,7 +171,7 @@
     "showMinimap": "Übersichtskarte einblenden"
   },
   "visibility": {
-    "hint": "Tiefere Komponenten werden hinter ihrem Container eingeklappt, damit die oberen Ebenen lesbar bleiben. Verbindungen zu eingeklappten Komponenten werden auf den sichtbaren Container angehoben. Beziehungen innerhalb desselben eingeklappten Containers werden absichtlich nicht gezeichnet. Parallele gemeldete Beziehungen können als eine Sammelverbindung gebündelt werden. Aufklappen über das Dreieck am Container, über einen Deep Link oder über „Gesamtes Modell einpassen\".",
+    "hint": "Tiefere Komponenten werden hinter ihrem Container eingeklappt, damit die oberen Ebenen lesbar bleiben. Verbindungen zu eingeklappten Komponenten werden auf den sichtbaren Container angehoben. Beziehungen innerhalb desselben eingeklappten Containers werden absichtlich nicht gezeichnet. Parallele gemeldete Beziehungen können als eine Sammelverbindung gebündelt werden. Aufklappen über das Dreieck am Container, über einen Deep Link oder über die räumliche Gesamtkarte.",
     "summary_one": "{{visible, number}} von {{total, number}} Element sichtbar",
     "summary_other": "{{visible, number}} von {{total, number}} Elementen sichtbar"
   },

--- a/frontend/src/i18n/locales/de/canvas.json
+++ b/frontend/src/i18n/locales/de/canvas.json
@@ -58,6 +58,7 @@
   "edge": {
     "bundleCollapse": "Sammelkante wieder zusammenklappen",
     "bundleExpand": "Sammelkante aufklappen: {{relationships}}",
+    "bundleSelect": "Eine Beziehung dieser Sammelkante im Inspector anzeigen: {{relationships}}",
     "channel": "Kanal: {{value}}",
     "operation": "Operation: {{value}}",
     "protocol": "Protokoll: {{value}}"

--- a/frontend/src/i18n/locales/en/canvas.json
+++ b/frontend/src/i18n/locales/en/canvas.json
@@ -58,6 +58,7 @@
   "edge": {
     "bundleCollapse": "Fold the bundled edge back together",
     "bundleExpand": "Unfold the bundled edge: {{relationships}}",
+    "bundleSelect": "Inspect a relationship in this bundle: {{relationships}}",
     "channel": "Channel: {{value}}",
     "operation": "Operation: {{value}}",
     "protocol": "Protocol: {{value}}"

--- a/frontend/src/i18n/locales/en/canvas.json
+++ b/frontend/src/i18n/locales/en/canvas.json
@@ -39,10 +39,12 @@
   "detail": {
     "fullDescription": "Tags in addition. Bundled relationships are fanned out one by one.",
     "fullLabel": "Full",
-    "indicator": "Detail level: {{level}}",
-    "overviewDescription": "Name and kind only. Parallel relationships are bundled.",
-    "overviewLabel": "Overview",
-    "standardDescription": "The reported technology in addition. Parallel relationships are bundled.",
+    "indicator": "Display level: {{level}}",
+    "minimalDescription": "Shape and icon only. Text stays available through selection and the inspector.",
+    "minimalLabel": "Map",
+    "overviewDescription": "Readable overview with primary names. Secondary text appears only once the zoom is high enough.",
+    "overviewLabel": "Readable overview",
+    "standardDescription": "Kind and reported technology in addition. Secondary text stays at least 10 px effective size.",
     "standardLabel": "Standard"
   },
   "diagnostics": {
@@ -153,13 +155,13 @@
     }
   },
   "tool": {
-    "backToOverview": "System level",
-    "backToOverviewHint": "Back to system and container level: deeper components are collapsed again and the view is fitted at a readable size.",
+    "backToOverview": "Readable system overview",
+    "backToOverviewHint": "Back to a readable system overview: deeper components are collapsed again and the view is fitted with at least 12 px effective primary text.",
     "collapse": "Collapse",
     "expand": "Expand",
     "expandHidden": "Expand ({{hidden}})",
-    "fitWholeModel": "Fit the whole model",
-    "fitWholeModelHint": "Expands every container and fits the complete model into the surface. With many components the picture deliberately becomes small — this is the overview action. Otherwise the camera only moves on the first load — never because events arrive.",
+    "fitWholeModel": "Whole-model map",
+    "fitWholeModelHint": "Expands every container and shows the complete model as a spatial map. With many components the picture deliberately becomes small; it is for orientation, not reading. Search, selection and the inspector remain available. Otherwise the camera only moves on the first load — never because events arrive.",
     "hideMinimap": "Hide the overview map",
     "layoutLeftRight": "Left to right",
     "layoutOrientation": "Graph orientation",
@@ -169,7 +171,7 @@
     "showMinimap": "Show the overview map"
   },
   "visibility": {
-    "hint": "Deeper components are collapsed behind their container so the upper levels stay readable. Connections to collapsed components are lifted to the visible container. Relationships whose two ends are inside the same collapsed container are intentionally not drawn. Parallel reported relationships may be bundled into one connection. Expand them through the triangle on the container, through a deep link or through “Fit the whole model”.",
+    "hint": "Deeper components are collapsed behind their container so the upper levels stay readable. Connections to collapsed components are lifted to the visible container. Relationships whose two ends are inside the same collapsed container are intentionally not drawn. Parallel reported relationships may be bundled into one connection. Expand them through the triangle on the container, through a deep link or through the spatial whole-model map.",
     "summary_one": "{{visible, number}} of {{total, number}} element visible",
     "summary_other": "{{visible, number}} of {{total, number}} elements visible"
   },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -186,6 +186,21 @@
   border-radius: calc(var(--radius) - 2px);
 }
 
+/* Semantic detail changes are content changes, not motion. Respect the
+   platform preference when a node state or relationship highlight transitions
+   between them, and when React Flow animates a camera operation. */
+@media (prefers-reduced-motion: reduce) {
+  .react-flow,
+  .react-flow *,
+  .react-flow *::before,
+  .react-flow *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 @layer components {
   /* Shared surface for the three panes. */
   .pane-surface {

--- a/frontend/src/test/renderApp.tsx
+++ b/frontend/src/test/renderApp.tsx
@@ -20,7 +20,7 @@ export interface RenderAppOptions {
   i18n?: I18n
   /**
    * Starts with every architecture container open, i.e. in the state the user
-   * reaches with "Gesamtes Modell einpassen".
+   * reaches with the "Gesamtkarte" action.
    *
    * A project otherwise opens on its top levels with deeper containers
    * collapsed (ADR 0017), which is the right default but the wrong starting


### PR DESCRIPTION
Closes #56

## Umgesetzt
- Semantische Zoomstufen mit dokumentierten effektiven Textgrößen für lesbare Übersicht und räumliche Gesamtkarte.
- Vereinfachte Nodes, Overlays und Relationship-Details bei kleinen Zoomstufen, ohne Layout- oder Nodegrößenänderung.
- Gesamtkarte klar benannt; Suche, Auswahl, Tooltip und Inspector bleiben erreichbar.
- Zugängliche iconbasierte Bundle-Interaktion in der Kartenstufe sowie Reduced-Motion-Verhalten ergänzt.
- DE/EN-Texte, ADR und Unit-/Viewport-E2E-Abdeckung ergänzt.

## Tests
- Frontend: 503 Tests, Lint, Typecheck, Build, Contract-, Locale- und UI-String-Checks.
- E2E-Typecheck und git diff --check.

## Einschränkungen
- Lokale Compose/Playwright-Abnahme wurde nicht ausgeführt, da sie den gemeinsamen Simulator- und Datenbankzustand zurücksetzt; die CI führt sie vollständig aus.