### PR TITLE
Add tag-gated Docker Hub image releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to validate when called by a release workflow'
+        required: false
+        type: string
+
+permissions:
+  contents: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -38,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
@@ -54,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -96,6 +111,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-node@v5
         with:
           node-version: 24

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,15 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to validate when called by a release workflow'
+        required: false
+        type: string
+
+permissions:
+  contents: read
 
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.ref }}
@@ -33,6 +42,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/release-dockerhub.yml
+++ b/.github/workflows/release-dockerhub.yml
@@ -1,0 +1,253 @@
+name: Release Docker Hub images
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+# A release tag must never have two concurrent publishers. A failed run is
+# intentionally not cancelled: it must finish with a clear status for the tag.
+concurrency:
+  group: dockerhub-release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.semver.outputs.tag }}
+      version: ${{ steps.semver.outputs.version }}
+      prerelease: ${{ steps.semver.outputs.prerelease }}
+      ref: ${{ steps.semver.outputs.ref }}
+    steps:
+      - id: semver
+        name: Validate SemVer tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|([0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))(\.((0|[1-9][0-9]*)|([0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)))*)?$'
+          if [[ ! "${RELEASE_TAG}" =~ ${semver_re} ]]; then
+            echo "::error::Release ref '${RELEASE_TAG}' is not a supported SemVer tag. Expected v<major>.<minor>.<patch> with an optional prerelease suffix."
+            exit 1
+          fi
+
+          version="${RELEASE_TAG#v}"
+          prerelease=false
+          if [[ "${version}" == *-* ]]; then
+            prerelease=true
+          fi
+
+          echo "tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "prerelease=${prerelease}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${GITHUB_REF}" >> "${GITHUB_OUTPUT}"
+
+  dockerhub-config:
+    name: validate Docker Hub configuration
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required repository configuration
+        env:
+          DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -n "${DOCKERHUB_NAMESPACE}" ]] || missing+=(DOCKERHUB_NAMESPACE)
+          [[ -n "${DOCKERHUB_USERNAME}" ]] || missing+=(DOCKERHUB_USERNAME)
+          [[ -n "${DOCKERHUB_TOKEN}" ]] || missing+=(DOCKERHUB_TOKEN)
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing required Docker Hub repository configuration: ${missing[*]}"
+            exit 1
+          fi
+
+  ci:
+    name: CI gates
+    needs: [validate, dockerhub-config]
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ needs.validate.outputs.ref }}
+    permissions:
+      contents: read
+
+  e2e:
+    name: E2E gate
+    needs: [validate, dockerhub-config]
+    uses: ./.github/workflows/e2e.yml
+    with:
+      ref: ${{ needs.validate.outputs.ref }}
+    permissions:
+      contents: read
+
+  image-build:
+    name: build release images (no push)
+    needs: [validate, dockerhub-config, ci, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.ref }}
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Prepare backend image metadata
+        id: backend-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: example.invalid/visualise-ai-backend
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.validate.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.validate.outputs.tag }},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=semver,pattern={{major}},value=${{ needs.validate.outputs.tag }},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ needs.validate.outputs.prerelease == 'false' }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+            org.opencontainers.image.created=${{ github.run_started_at }}
+
+      - name: Prepare frontend image metadata
+        id: frontend-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: example.invalid/visualise-ai-frontend
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.validate.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.validate.outputs.tag }},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=semver,pattern={{major}},value=${{ needs.validate.outputs.tag }},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ needs.validate.outputs.prerelease == 'false' }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+            org.opencontainers.image.created=${{ github.run_started_at }}
+
+      - name: Build backend image for both release platforms
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ steps.backend-meta.outputs.tags }}
+          labels: ${{ steps.backend-meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ needs.validate.outputs.version }}
+          cache-from: type=gha,scope=release-backend
+          cache-to: type=gha,mode=max,scope=release-backend
+
+      - name: Build frontend image for both release platforms
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ steps.frontend-meta.outputs.tags }}
+          labels: ${{ steps.frontend-meta.outputs.labels }}
+          cache-from: type=gha,scope=release-frontend
+          cache-to: type=gha,mode=max,scope=release-frontend
+
+  publish:
+    name: publish release images
+    needs: [validate, dockerhub-config, ci, e2e, image-build]
+    runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.ref }}
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Prepare backend image metadata
+        id: backend-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_NAMESPACE }}/visualise-ai-backend
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.validate.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.validate.outputs.tag }},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=semver,pattern={{major}},value=${{ needs.validate.outputs.tag }},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ needs.validate.outputs.prerelease == 'false' }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+            org.opencontainers.image.created=${{ github.run_started_at }}
+
+      - name: Prepare frontend image metadata
+        id: frontend-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_NAMESPACE }}/visualise-ai-frontend
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.validate.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.validate.outputs.tag }},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=semver,pattern={{major}},value=${{ needs.validate.outputs.tag }},enable=${{ needs.validate.outputs.prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ needs.validate.outputs.prerelease == 'false' }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+            org.opencontainers.image.created=${{ github.run_started_at }}
+
+      - name: Publish backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.backend-meta.outputs.tags }}
+          labels: ${{ steps.backend-meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ needs.validate.outputs.version }}
+          cache-from: type=gha,scope=release-backend
+          cache-to: type=gha,mode=max,scope=release-backend
+
+      - name: Publish frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.frontend-meta.outputs.tags }}
+          labels: ${{ steps.frontend-meta.outputs.labels }}
+          cache-from: type=gha,scope=release-frontend
+          cache-to: type=gha,mode=max,scope=release-frontend
+
+      - name: Verify backend manifest
+        run: docker buildx imagetools inspect "${DOCKERHUB_NAMESPACE}/visualise-ai-backend:${{ needs.validate.outputs.version }}"
+
+      - name: Verify frontend manifest
+        run: docker buildx imagetools inspect "${DOCKERHUB_NAMESPACE}/visualise-ai-frontend:${{ needs.validate.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,48 @@ Danach zeigt <http://localhost:8080/projects/visualise-ai> den vollständigen
 Demo-Run. Details:
 [Demo ausführen](docs/operations.md#demo-ausfuehren).
 
+## Veröffentlichte Docker-Hub-Images
+
+Der Workflow
+[`release-dockerhub.yml`](.github/workflows/release-dockerhub.yml) veröffentlicht
+beide Anwendungsimages ausschließlich bei gültigen Release-Tags im Format
+`v<major>.<minor>.<patch>`; ein optionaler Prerelease-Suffix ist erlaubt, zum
+Beispiel `v1.2.3-rc.1`. Vor dem Push müssen die Vertrags-, Backend-, Frontend-,
+Simulator- und E2E-Prüfungen sowie der Compose-Build erfolgreich sein.
+
+In den Repository-Einstellungen werden dafür die Variable
+`DOCKERHUB_NAMESPACE` und die Secrets `DOCKERHUB_USERNAME` und
+`DOCKERHUB_TOKEN` hinterlegt. Kein Secret wird in einen Build-Arg, ein Image
+oder ein Log geschrieben. Die beiden getrennten Docker-Hub-Repositories sind:
+
+- `${DOCKERHUB_NAMESPACE}/visualise-ai-backend`
+- `${DOCKERHUB_NAMESPACE}/visualise-ai-frontend`
+
+Ein stabiles Tag wie `v1.2.3` erzeugt `1.2.3`, `1.2`, `1` und `latest`. Ein
+Prerelease wie `v1.2.3-rc.1` erzeugt ausschließlich `1.2.3-rc.1`; stabile Tags
+und `latest` bleiben dabei unverändert.
+
+Ein veröffentlichtes Image kann direkt gezogen werden:
+
+```bash
+docker pull "$DOCKERHUB_NAMESPACE/visualise-ai-backend:1.2.3"
+docker pull "$DOCKERHUB_NAMESPACE/visualise-ai-frontend:1.2.3"
+```
+
+Für einen Compose-Start mit den veröffentlichten Images statt mit lokalen
+Quell-Builds:
+
+```bash
+DOCKERHUB_NAMESPACE=example IMAGE_TAG=1.2.3 \
+  docker compose -f docker-compose.yml -f docker-compose.images.yml pull
+DOCKERHUB_NAMESPACE=example IMAGE_TAG=1.2.3 \
+  docker compose -f docker-compose.yml -f docker-compose.images.yml up -d --no-build
+```
+
+Das Release veröffentlicht nur Backend und Frontend. PostgreSQL bleibt der
+interne, unveränderte `postgres:17-alpine`-Service aus der Compose-Datei und
+wird nicht als Visualise-AI-Image veröffentlicht.
+
 ## Repository-Struktur
 
 | Pfad | Inhalt |
@@ -65,6 +107,7 @@ Demo-Run. Details:
 | `simulator/` | Node/TypeScript-Eventsimulator — der deterministische Demo-Client |
 | `e2e/` | Playwright-Abnahmetest gegen das echte Compose-System |
 | `docker-compose.yml` | Die Services `frontend`, `backend` und `postgres` |
+| `docker-compose.images.yml` | Optionaler Compose-Override für veröffentlichte Images |
 | `docs/` | Betriebs- und Integrationsdokumentation, Decision Records |
 
 ## Netzwerktopologie

--- a/docker-compose.images.yml
+++ b/docker-compose.images.yml
@@ -1,0 +1,10 @@
+# Optional override for running the images published by the release workflow.
+# The base compose file remains the source-build path for local development.
+services:
+  backend:
+    build: !reset null
+    image: "${DOCKERHUB_NAMESPACE:?set DOCKERHUB_NAMESPACE}/visualise-ai-backend:${IMAGE_TAG:-latest}"
+
+  frontend:
+    build: !reset null
+    image: "${DOCKERHUB_NAMESPACE:?set DOCKERHUB_NAMESPACE}/visualise-ai-frontend:${IMAGE_TAG:-latest}"

--- a/docs/decisions/0028-dockerhub-release-workflow.md
+++ b/docs/decisions/0028-dockerhub-release-workflow.md
@@ -1,0 +1,22 @@
+# ADR 0028: Tag-gated Docker-Hub image releases
+
+## Entscheidung
+
+Release images are published only from SemVer Git tags (`v1.2.3` or a
+prerelease such as `v1.2.3-rc.1`). The release workflow calls the existing CI
+and E2E workflows as reusable gates, then publishes the backend and frontend
+images in one multi-architecture job to separate Docker-Hub repositories. GHA
+cache scopes are separate per image, and a Compose override provides an
+explicit image-only path for operators.
+
+Stable tags receive `1.2.3`, `1.2`, `1` and `latest`; prereleases receive only
+their complete version tag. PostgreSQL remains the internal Compose service
+and is not part of the project image release.
+
+## Begründung und Trade-offs
+
+Reusing the existing workflows keeps the release gate aligned with pull-request
+and main-branch validation without copying a growing test matrix. A single
+publish job makes the ordering and shared Docker login obvious, although an
+external registry can still fail after one image has already been accepted;
+the validation gate prevents any image push when application checks fail.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -164,6 +164,10 @@ Checkout funktionieren.
 `docker-compose.yml` fest gesetzt und ist bewusst nicht in `.env.example`: der
 Container-Port ist Teil der Topologie, nicht der Konfiguration.
 
+`DOCKERHUB_NAMESPACE` und `IMAGE_TAG` werden nur vom optionalen Compose-Override
+für veröffentlichte Images verwendet; der normale lokale Start baut weiterhin
+aus `./backend` und `./frontend`.
+
 > **`MAX_EVENT_BYTES` anzuheben genügt allein nicht.** Nginx steht davor und
 > begrenzt den Request-Body auf `MAX_REQUEST_BODY_SIZE` (Default `4m`). Ein
 > Event darüber wird schon am Einstiegspunkt abgelehnt und erreicht das Backend
@@ -173,6 +177,58 @@ Container-Port ist Teil der Topologie, nicht der Konfiguration.
 > Nginx antwortet in diesem Fall ebenfalls mit `application/problem+json` und
 > `code: event_too_large`, damit ein Agent die Ablehnung genauso auswerten kann
 > wie die des Backends.
+
+## Veröffentlichte Docker-Hub-Images
+
+Der Release-Workflow
+([`.github/workflows/release-dockerhub.yml`](../.github/workflows/release-dockerhub.yml))
+reagiert ausschließlich auf Tags der Form `v<major>.<minor>.<patch>` mit
+optionalem Prerelease, beispielsweise `v1.2.3` oder `v1.2.3-rc.1`. Branch- und
+Pull-Request-Ereignisse veröffentlichen nichts.
+
+Vor der Veröffentlichung laufen die bestehenden CI- und E2E-Workflows als
+gemeinsames Gate: API-Vertrag, Backend-Build/Vet/Tests, Frontend-Locale-Checks,
+Lint, Typecheck, Tests und Build, Simulator-Checks, Playwright-E2E sowie der
+Build beider Dockerfiles müssen erfolgreich sein. Fehlt die Konfiguration,
+bricht der Workflow mit den fehlenden Namen ab, ohne Secret-Werte auszugeben.
+
+In den Repository-Einstellungen sind folgende Werte erforderlich:
+
+| Einstellung | Inhalt |
+| --- | --- |
+| Variable `DOCKERHUB_NAMESPACE` | Docker-Hub-Namespace, ohne Image-Namen |
+| Secret `DOCKERHUB_USERNAME` | Docker-Hub-Benutzername oder Maschinenkonto |
+| Secret `DOCKERHUB_TOKEN` | Persönlicher Zugriffstoken mit Push-Rechten |
+
+Der Workflow verwendet ausschließlich diese getrennten Repositories:
+`${DOCKERHUB_NAMESPACE}/visualise-ai-backend` und
+`${DOCKERHUB_NAMESPACE}/visualise-ai-frontend`. Ein stabiles `v1.2.3` erzeugt
+die Tags `1.2.3`, `1.2`, `1` und `latest`. Ein Prerelease wie `v1.2.3-rc.1`
+erzeugt nur `1.2.3-rc.1`; es überschreibt keine stabilen Versionen und nicht
+`latest`. Beide Images tragen OCI-Labels für Source, Revision, Version und
+Erstellungszeitpunkt; beim Backend wird die Version ohne führendes `v` als
+Build-Argument gesetzt.
+
+Ein Image lässt sich direkt prüfen oder ziehen:
+
+```bash
+docker pull "$DOCKERHUB_NAMESPACE/visualise-ai-backend:1.2.3"
+docker pull "$DOCKERHUB_NAMESPACE/visualise-ai-frontend:1.2.3"
+```
+
+Der optionale
+[`docker-compose.images.yml`](../docker-compose.images.yml)-Override nutzt
+die gezogenen Images. `IMAGE_TAG` ist standardmäßig `latest`:
+
+```bash
+DOCKERHUB_NAMESPACE=example IMAGE_TAG=1.2.3 \
+  docker compose -f docker-compose.yml -f docker-compose.images.yml pull
+DOCKERHUB_NAMESPACE=example IMAGE_TAG=1.2.3 \
+  docker compose -f docker-compose.yml -f docker-compose.images.yml up -d --no-build
+```
+
+Der Override ersetzt nur Backend und Frontend. PostgreSQL bleibt der interne
+`postgres:17-alpine`-Service; dafür wird kein Visualise-AI-Image veröffentlicht.
 
 Alle Werte werden beim Start geprüft. Ein nicht parsbarer oder nicht positiver
 Wert lässt das Backend scheitern, statt still auf den Default zurückzufallen —


### PR DESCRIPTION
## Summary

- Add a SemVer-tagged Docker Hub release workflow for the backend and frontend images.
- Reuse the existing CI and Playwright acceptance workflows as release gates through `workflow_call`.
- Build both images for `linux/amd64` and `linux/arm64`, attach OCI metadata, use separate GitHub Actions cache scopes, and verify both pushed manifests.
- Add an image-only Compose override and document the required `DOCKERHUB_NAMESPACE` variable plus `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets.
- Keep PostgreSQL on the upstream `postgres:17-alpine` image; it is not published by this workflow.

Stable tags such as `v1.2.3` publish `1.2.3`, `1.2`, `1`, and `latest`. Prereleases such as `v1.2.3-rc.1` publish only the complete prerelease tag.

## Verification

- `git diff --cached --check`
- `docker compose -f docker-compose.yml -f docker-compose.images.yml config` with `DOCKERHUB_NAMESPACE=example` and `IMAGE_TAG=1.2.3`
- Strict SemVer acceptance/rejection check for stable, prerelease, leading-zero, incomplete, and build-metadata examples
- Full CI and E2E gates run by GitHub Actions on this pull request

The release workflow itself runs only for `v*` tag pushes, validates the tag before any build, checks the required repository configuration before the expensive gates, and never receives Docker Hub credentials from pull-request runs. No tags or secrets were created.

Closes #53
