### PR TITLE
Prepare main for v0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ In den Repository-Einstellungen werden dafür die Variable
 `DOCKERHUB_TOKEN` hinterlegt. Kein Secret wird in einen Build-Arg, ein Image
 oder ein Log geschrieben. Die beiden getrennten Docker-Hub-Repositories sind:
 
-- `${DOCKERHUB_NAMESPACE}/visualise-ai-backend`
-- `${DOCKERHUB_NAMESPACE}/visualise-ai-frontend`
+- `risqy3d/visualise-ai-backend`
+- `risqy3d/visualise-ai-frontend`
 
 Ein stabiles Tag wie `v1.2.3` erzeugt `1.2.3`, `1.2`, `1` und `latest`. Ein
 Prerelease wie `v1.2.3-rc.1` erzeugt ausschließlich `1.2.3-rc.1`; stabile Tags
@@ -78,17 +78,17 @@ und `latest` bleiben dabei unverändert.
 Ein veröffentlichtes Image kann direkt gezogen werden:
 
 ```bash
-docker pull "$DOCKERHUB_NAMESPACE/visualise-ai-backend:1.2.3"
-docker pull "$DOCKERHUB_NAMESPACE/visualise-ai-frontend:1.2.3"
+docker pull "risqy3d/visualise-ai-backend:1.2.3"
+docker pull "risqy3d/visualise-ai-frontend:1.2.3"
 ```
 
 Für einen Compose-Start mit den veröffentlichten Images statt mit lokalen
 Quell-Builds:
 
 ```bash
-DOCKERHUB_NAMESPACE=example IMAGE_TAG=1.2.3 \
+IMAGE_TAG=1.2.3 \
   docker compose -f docker-compose.yml -f docker-compose.images.yml pull
-DOCKERHUB_NAMESPACE=example IMAGE_TAG=1.2.3 \
+IMAGE_TAG=1.2.3 \
   docker compose -f docker-compose.yml -f docker-compose.images.yml up -d --no-build
 ```
 

--- a/docker-compose.images.yml
+++ b/docker-compose.images.yml
@@ -3,8 +3,8 @@
 services:
   backend:
     build: !reset null
-    image: "${DOCKERHUB_NAMESPACE:?set DOCKERHUB_NAMESPACE}/visualise-ai-backend:${IMAGE_TAG:-latest}"
+    image: "risqy3d/visualise-ai-backend:${IMAGE_TAG:-latest}"
 
   frontend:
     build: !reset null
-    image: "${DOCKERHUB_NAMESPACE:?set DOCKERHUB_NAMESPACE}/visualise-ai-frontend:${IMAGE_TAG:-latest}"
+    image: "risqy3d/visualise-ai-frontend:${IMAGE_TAG:-latest}"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -164,9 +164,9 @@ Checkout funktionieren.
 `docker-compose.yml` fest gesetzt und ist bewusst nicht in `.env.example`: der
 Container-Port ist Teil der Topologie, nicht der Konfiguration.
 
-`DOCKERHUB_NAMESPACE` und `IMAGE_TAG` werden nur vom optionalen Compose-Override
-für veröffentlichte Images verwendet; der normale lokale Start baut weiterhin
-aus `./backend` und `./frontend`.
+`IMAGE_TAG` wird nur vom optionalen Compose-Override für veröffentlichte Images
+verwendet. Der Override nutzt fest den Docker-Hub-Namespace `risqy3d`; der
+normale lokale Start baut weiterhin aus `./backend` und `./frontend`.
 
 > **`MAX_EVENT_BYTES` anzuheben genügt allein nicht.** Nginx steht davor und
 > begrenzt den Request-Body auf `MAX_REQUEST_BODY_SIZE` (Default `4m`). Ein
@@ -201,9 +201,8 @@ In den Repository-Einstellungen sind folgende Werte erforderlich:
 | Secret `DOCKERHUB_TOKEN` | Persönlicher Zugriffstoken mit Push-Rechten |
 
 Der Workflow verwendet ausschließlich diese getrennten Repositories:
-`${DOCKERHUB_NAMESPACE}/visualise-ai-backend` und
-`${DOCKERHUB_NAMESPACE}/visualise-ai-frontend`. Ein stabiles `v1.2.3` erzeugt
-die Tags `1.2.3`, `1.2`, `1` und `latest`. Ein Prerelease wie `v1.2.3-rc.1`
+`risqy3d/visualise-ai-backend` und `risqy3d/visualise-ai-frontend`. Ein stabiles
+`v1.2.3` erzeugt die Tags `1.2.3`, `1.2`, `1` und `latest`. Ein Prerelease wie `v1.2.3-rc.1`
 erzeugt nur `1.2.3-rc.1`; es überschreibt keine stabilen Versionen und nicht
 `latest`. Beide Images tragen OCI-Labels für Source, Revision, Version und
 Erstellungszeitpunkt; beim Backend wird die Version ohne führendes `v` als
@@ -212,18 +211,19 @@ Build-Argument gesetzt.
 Ein Image lässt sich direkt prüfen oder ziehen:
 
 ```bash
-docker pull "$DOCKERHUB_NAMESPACE/visualise-ai-backend:1.2.3"
-docker pull "$DOCKERHUB_NAMESPACE/visualise-ai-frontend:1.2.3"
+docker pull "risqy3d/visualise-ai-backend:1.2.3"
+docker pull "risqy3d/visualise-ai-frontend:1.2.3"
 ```
 
 Der optionale
 [`docker-compose.images.yml`](../docker-compose.images.yml)-Override nutzt
-die gezogenen Images. `IMAGE_TAG` ist standardmäßig `latest`:
+die fest unter `risqy3d` veröffentlichten Images. `IMAGE_TAG` ist standardmäßig
+`latest`:
 
 ```bash
-DOCKERHUB_NAMESPACE=example IMAGE_TAG=1.2.3 \
+IMAGE_TAG=1.2.3 \
   docker compose -f docker-compose.yml -f docker-compose.images.yml pull
-DOCKERHUB_NAMESPACE=example IMAGE_TAG=1.2.3 \
+IMAGE_TAG=1.2.3 \
   docker compose -f docker-compose.yml -f docker-compose.images.yml up -d --no-build
 ```
 


### PR DESCRIPTION
## Summary

- integrate the fixed official Docker Hub image names from `develop` into `main`
- retain the existing `main` and `develop` history as explicit merge parents
- prepare the exact source revision for release `v0.0.2`

## Validation

- resulting tree is byte-identical to `origin/develop`
- PR #73 CI gates passed
- PR #73 E2E acceptance passed on rerun with 36/36 tests
- Docker Compose resolves `risqy3d/visualise-ai-backend` and `risqy3d/visualise-ai-frontend`
